### PR TITLE
refactor: readonly inject(), Number.parseInt(), and error context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Mark all `inject()` service references as `readonly` across Angular components and services ([TAS-2707](https://linear.app/tasteslikegood/issue/TAS-2707/find-a-small-improvement-copy))
+- Use `Number.parseInt()` instead of global `parseInt()` in `server/valkey.ts` for consistency with the rest of the codebase
+- Add descriptive context to bare `console.error()` in recipe import error handler
+
 ## [0.1.0] - 2026-04-13
 
 ### Added

--- a/server/valkey.ts
+++ b/server/valkey.ts
@@ -92,7 +92,7 @@ export async function createValkeyClient(): Promise<Redis | null> {
     }
   }
 
-  const port = parseInt(process.env.VALKEY_PORT || '6379', 10);
+  const port = Number.parseInt(process.env.VALKEY_PORT || '6379', 10);
   const authMode = process.env.VALKEY_AUTH_MODE;
 
   try {

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -14,9 +14,9 @@ import { Ingredient, IngredientGroup, Recipe } from './recipe.types';
   styleUrls: [],
 })
 export class AppComponent {
-  private geminiService = inject(GeminiService);
-  private persistenceService = inject(PersistenceService);
-  authService = inject(AuthService);
+  private readonly geminiService = inject(GeminiService);
+  private readonly persistenceService = inject(PersistenceService);
+  readonly authService = inject(AuthService);
 
   // Navigation
   activeView = signal<'generator' | 'kitchen'>('generator');
@@ -392,7 +392,7 @@ export class AppComponent {
           alert(`Successfully imported ${count} recipes!`);
         }
       } catch (err) {
-        console.error(err);
+        console.error('Failed to parse recipe import file:', err);
         alert('Failed to parse recipe file. Please ensure it is valid JSON.');
       }
     };

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -20,7 +20,7 @@ import { Cookbook } from '../auth.types';
 export class PersistenceService {
   /** Prevents duplicate API loads for the same session. */
   private _apiSynced = false;
-  private auth = inject(AuthService);
+  private readonly auth = inject(AuthService);
 
   constructor() {
     // Auto-load from API when a logged-in user's session is confirmed.


### PR DESCRIPTION
Assignee: @adamtasteslikegood ([adamschoen3](https://linear.app/tasteslikegood/profiles/adamschoen3))

## Summary

Small code quality improvements across the Angular frontend and Express server:

- **`readonly` on `inject()` calls** — All service injections in `AppComponent` and `PersistenceService` are now marked `readonly`, preventing accidental reassignment (Angular best practice)
- **`Number.parseInt()` consistency** — `server/valkey.ts` used the global `parseInt()` while the rest of the codebase (`server/index.ts`) uses `Number.parseInt()`. Now consistent
- **Error context** — The recipe import catch block had a bare `console.error(err)` with no label, making production logs harder to triage. Added a descriptive prefix

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run format:check` passes
- [x] `npm test` — all 34 tests pass

Closes [TAS-2707](https://linear.app/tasteslikegood/issue/TAS-2707/find-a-small-improvement-copy)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->