### PR TITLE
fix(valkey): catch quit failures before reinitializing client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Catch `shutdownValkey()` failures inside `createValkeyClient()` so a broken `quit()` cannot prevent reinitialization or fallback to in-memory rate limiting ([TAS-48](https://linear.app/tasteslikegood/issue/TAS-48/catch-quit-failures-before-reinitializing-valkey-client))
+
 ### Changed
 
 - Mark all `inject()` service references as `readonly` across Angular components and services ([TAS-2707](https://linear.app/tasteslikegood/issue/TAS-2707/find-a-small-improvement-copy))

--- a/server/valkey.ts
+++ b/server/valkey.ts
@@ -74,7 +74,11 @@ export async function createValkeyClient(): Promise<Redis | null> {
     // removed, tear it down to avoid leaking handles (e.g. in tests / dev).
     if (client) {
       console.warn('[Valkey] VALKEY_HOST removed — shutting down existing client');
-      await shutdownValkey();
+      try {
+        await shutdownValkey();
+      } catch (err) {
+        console.error('[Valkey] Shutdown failed during cleanup:', (err as Error).message);
+      }
     }
     console.log('[Valkey] VALKEY_HOST not set — using in-memory rate limiting');
     return null;
@@ -86,9 +90,14 @@ export async function createValkeyClient(): Promise<Redis | null> {
       await client.ping();
       return client;
     } catch {
-      // Existing client is unhealthy — tear it down before reinitializing
+      // Existing client is unhealthy — tear it down before reinitializing.
+      // Catch shutdown errors so a broken quit() cannot prevent reinitialization.
       console.warn('[Valkey] Existing client unhealthy, reinitializing...');
-      await shutdownValkey();
+      try {
+        await shutdownValkey();
+      } catch (err) {
+        console.error('[Valkey] Shutdown failed during reinit:', (err as Error).message);
+      }
     }
   }
 
@@ -149,7 +158,11 @@ export async function createValkeyClient(): Promise<Redis | null> {
     return client;
   } catch (err) {
     console.error('[Valkey] Connection failed, falling back to in-memory rate limiting:', err);
-    await shutdownValkey();
+    try {
+      await shutdownValkey();
+    } catch (shutdownErr) {
+      console.error('[Valkey] Shutdown failed during fallback:', (shutdownErr as Error).message);
+    }
     return null;
   }
 }


### PR DESCRIPTION
Assignee: @adamtasteslikegood ([adamschoen3](https://linear.app/tasteslikegood/profiles/adamschoen3))

## Summary

- Wraps all three `shutdownValkey()` call sites inside `createValkeyClient()` with try/catch blocks so that a rejected `quit()` (common when the TCP socket is already broken) is logged and swallowed instead of escaping the function
- This ensures the reinitialization path and the in-memory fallback path always execute, even when shutdown itself fails
- No behavioral change when shutdown succeeds — only the error path is guarded

## Test plan

- [x] All 34 existing Vitest tests pass
- [x] ESLint clean (zero warnings)
- [x] TypeScript type-check passes (both tsconfigs)
- [x] Prettier formatting verified
- [ ] Manual verification: with `VALKEY_HOST` set to an unreachable host, confirm the Express server starts and falls back to in-memory rate limiting without throwing

Resolves [TAS-48](https://linear.app/tasteslikegood/issue/TAS-48/catch-quit-failures-before-reinitializing-valkey-client)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->