### PR TITLE
feat(ssr): route /r/*, /browse, /sitemap.xml to Flask (TAS-2718)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -74,6 +74,14 @@ let server: Server | null = null;
     res.sendFile(path.join(publicPath, 'privacy-policy.html'));
   });
 
+  // Flask SSR routes — individual public recipes, the browse index, and the
+  // sitemap must be proxied to Flask BEFORE the Angular catch-all so the HTML
+  // the crawler receives is server-rendered (not the empty SPA shell).
+  const ssrProxy = createFlaskProxy('SSR');
+  app.get('/r/*splat', staticPageLimiter, ssrProxy);
+  app.get('/browse', staticPageLimiter, ssrProxy);
+  app.get('/sitemap.xml', staticPageLimiter, ssrProxy);
+
   app.get('{*path}', staticPageLimiter, (_req, res) => {
     res.sendFile(path.join(distPath, 'index.html'));
   });


### PR DESCRIPTION
## Summary
- Mounts SSR proxy routes in Express (`/r/*splat`, `/browse`, `/sitemap.xml`) **before** the Angular `{*path}` catch-all so crawler traffic reaches Flask and receives server-rendered HTML instead of the empty SPA shell.
- Bumps the Backend submodule to [`adamtasteslikegood/tasteslikegood.com#114`](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/114) which implements the `public_bp` SSR blueprint, opens public recipe images to anonymous fetches, and adds 8 pytest cases (pagination, N+1 guard, public/private visibility).

## Test plan
- [x] Express: `type-check`, `eslint`, `prettier --check`, `vitest` (35 tests)
- [x] Flask: `pytest` (109 tests, including 8 new SSR tests)
- [ ] Manual: `npm run dev` + `python Backend/app.py`, verify `curl -i http://localhost:3000/r/<public-slug>` returns SSR HTML and `/browse` lists public recipes only
- [ ] Manual: confirm anonymous `GET /api/recipes/<public-id>/image` returns image bytes while private remains 404

Depends on: https://github.com/adamtasteslikegood/tasteslikegood.com/pull/114 (merge first; this PR pins that commit via the Backend submodule)