### PR TITLE
docs: require branching off dev for all changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Two Cloud Run services in `us-central1`:
 - **Rate limiter** uses Valkey for distributed state across Express replicas; `server/valkey.ts` has open GH issues (#163, #162) for edge cases under broken connections — see KAN-16, KAN-17
 - **AI model names** include `models/` prefix (e.g., `models/gemini-3.1-pro-preview`); filter by `generateContent` in `supported_generation_methods`
 - **Backend submodule** — `Backend/` is a git submodule; always `git pull` inside it separately or use `git submodule update --remote`
+- **Branching** — ALWAYS create a new branch off `dev` before making any changes. Do not commit directly to `dev` or `main`.
 - **CI auto-formats** — Prettier runs as a CI job and commits fixes on push; don't be alarmed by bot commits
 - **TypeScript 6.x is blocked** — `package.json` pins `typescript >= 5.9 < 7`; Dependabot is configured to skip TS major bumps
 

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -9,6 +9,7 @@ Keep suggestions aligned with the repo's deployment targets (Cloud Run) and mini
 
 ## Constraints
 
+- ALWAYS create a new branch off `dev` before making any changes. Do not commit directly to `dev` or `main`.
 - Use `VITE_`-prefixed environment variables for client-visible config.
 - Avoid adding server-side runtime dependencies unless explicitly requested.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,7 +36,7 @@ This project is a full-stack application featuring an Angular/React frontend and
 
 ## Development Conventions
 
-- **Version Control:** Follow guidelines in `BRANCHING_STRATEGY.md` and `CONTRIBUTING.md`.
+- **Version Control:** Follow guidelines in `BRANCHING_STRATEGY.md` and `CONTRIBUTING.md`. ALWAYS create a new branch off `dev` before making any changes — do not commit directly to `dev` or `main`.
 - **CI/CD:** PRs and commits are checked via GitHub Actions and Qodana. Ensure all tests pass before submitting a PR.
 - **Code Style:** Enforced by ESLint (frontend), Flake8 (backend - `.flake8`), and Prettier.
 - **Documentation:** Review `START_HERE.md` and `API.md` (in Backend) for detailed onboarding.


### PR DESCRIPTION
## Summary
- Adds an explicit "always branch off `dev`" rule to `CLAUDE.md`, `COPILOT.md`, and `GEMINI.md`
- 3 files, 3 lines added, 1 line modified — pure documentation

## Why
Captures the useful content from the stale `security/oauth-fixes` branch (commit `9f4a499`) without landing that branch's regressions:
- Older `Backend` submodule pointer (`c9bf4322` → `b647a417` would roll backwards)
- Deleted junie workflows (`.github/workflows/junie-*.yml`)
- Removed `.junie/mcp/mcp.json`
- `GEMINI.md` formatting regression (deleted blank lines)
- Other cherry-pick of unrelated drift

The 3-line guidance is the only piece worth keeping. `security/oauth-fixes` will be deleted after this lands.

## Test plan
- [ ] Prettier CI passes (the only relevant check for doc-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)