### PR TITLE
fix(a11y): replace bare label with aria-labelledby switch button

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -361,8 +361,16 @@
                 <!-- v0.2 Anti-Recipe Distribution Controls -->
                 <div class="flex items-center gap-2 ml-2 pl-4 border-l border-stone-200">
                   <div class="flex items-center gap-2">
-                    <label class="text-[10px] font-bold uppercase text-stone-400">Public</label>
+                    <span
+                      id="public-toggle-label"
+                      class="text-[10px] font-bold uppercase text-stone-400"
+                      >Public</span
+                    >
                     <button
+                      type="button"
+                      role="switch"
+                      [attr.aria-checked]="r.is_public"
+                      aria-labelledby="public-toggle-label"
                       (click)="togglePublic(r)"
                       class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                       [class.bg-green-600]="r.is_public"


### PR DESCRIPTION
## Summary
Resolves the failing **Lint** CI job on dev (and downstream PRs like #2888 that inherit it).

The `<label>` at `src/app.component.html:364` was used as plain text without `for=` or a wrapped form control, failing `@angular-eslint/template/label-has-associated-control`. Replaced with `<span id="public-toggle-label">` and gave the existing toggle `<button>` proper `role="switch"`, `aria-checked`, and `aria-labelledby` so screen readers announce it as a switch named "Public".

## Test plan
- [x] `npm run lint` exits 0 locally (was failing on `src/app.component.html:364:21`)
- [x] No behavior change — same toggle, same handler, same Tailwind classes
- [ ] CI Lint job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)