### PR TITLE
feat(pubsub): wire push endpoints + OIDC + gcloud setup (release-prep for #2891)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -111,7 +111,12 @@ steps:
       # KAN-29: FLASK_ENV=production activates production-only guards:
       #   - OAUTHLIB_INSECURE_TRANSPORT guard (CRITICAL-2)
       #   - FLASK_SECRET_KEY fail-fast at startup (CRITICAL-4)
-      - --set-env-vars=FLASK_ENV=production,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images
+      # GCP_PROJECT_ID + PUBSUB_INVOKER_SA wire the Pub/Sub push handlers
+       # (Backend/blueprints/worker_api_bp.py). PUBSUB_INVOKER_SA is the email
+      # of the SA Pub/Sub uses to OIDC-sign push requests; created by
+      # scripts/gcloud/setup_pubsub.sh. Both must be set or worker_api_bp
+      # fails closed with 503.
+      - --set-env-vars=FLASK_ENV=production,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
       - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest
       - --no-allow-unauthenticated
       - --quiet

--- a/scripts/gcloud/setup_pubsub.sh
+++ b/scripts/gcloud/setup_pubsub.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Idempotent setup for Pub/Sub topics, push subscriptions, IAM, and the
+# pubsub-pusher service account that signs OIDC tokens for push delivery.
+#
+# Run BEFORE the first deploy of the push-based Pub/Sub workers (KAN-?).
+# Safe to re-run; existing resources are left in place.
+#
+# Required env vars (with sensible defaults):
+#   PROJECT_ID       — GCP project (default: comdottasteslikegood)
+#   REGION           — Cloud Run region (default: us-central1)
+#   FLASK_SERVICE    — Cloud Run service name (default: flask-backend)
+#
+# Usage:
+#   ./scripts/gcloud/setup_pubsub.sh
+#   PROJECT_ID=staging-tlg ./scripts/gcloud/setup_pubsub.sh
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-comdottasteslikegood}"
+REGION="${REGION:-us-central1}"
+FLASK_SERVICE="${FLASK_SERVICE:-flask-backend}"
+
+PUSH_SA_NAME="pubsub-pusher"
+PUSH_SA="${PUSH_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Topic → subscription → push endpoint mapping.
+# Format: topic:endpoint_path
+PAIRS=(
+  "recipe-generation:recipe"
+  "image-generation:image"
+)
+
+DLQ_TOPIC="generation-dlq"
+DLQ_SUB="generation-dlq-sub"
+
+log() { printf '\033[36m[setup-pubsub]\033[0m %s\n' "$*"; }
+warn() { printf '\033[33m[setup-pubsub] WARN:\033[0m %s\n' "$*" >&2; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found in PATH"; exit 1; }
+}
+
+require gcloud
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+# ── 1. Push service account ─────────────────────────────────────────────────
+log "Ensuring service account ${PUSH_SA}"
+if ! gcloud iam service-accounts describe "$PUSH_SA" >/dev/null 2>&1; then
+  gcloud iam service-accounts create "$PUSH_SA_NAME" \
+    --display-name="Pub/Sub push invoker" \
+    --description="Identity Pub/Sub uses to OIDC-sign push requests to /api/worker/*"
+else
+  log "  already exists"
+fi
+
+# ── 2. Topics + DLQ ─────────────────────────────────────────────────────────
+ALL_TOPICS=("$DLQ_TOPIC")
+for pair in "${PAIRS[@]}"; do
+  ALL_TOPICS+=("${pair%%:*}")
+done
+
+for topic in "${ALL_TOPICS[@]}"; do
+  log "Ensuring topic ${topic}"
+  if ! gcloud pubsub topics describe "$topic" >/dev/null 2>&1; then
+    gcloud pubsub topics create "$topic"
+  else
+    log "  already exists"
+  fi
+done
+
+# ── 3. Dead-letter subscription so DLQ is actually drainable ───────────────
+log "Ensuring DLQ subscription ${DLQ_SUB}"
+if ! gcloud pubsub subscriptions describe "$DLQ_SUB" >/dev/null 2>&1; then
+  gcloud pubsub subscriptions create "$DLQ_SUB" \
+    --topic="$DLQ_TOPIC" \
+    --message-retention-duration=7d \
+    --ack-deadline=60
+else
+  log "  already exists"
+fi
+
+# ── 4. Resolve Flask URL for push endpoints ────────────────────────────────
+FLASK_URL="$(gcloud run services describe "$FLASK_SERVICE" \
+  --region="$REGION" --format='value(status.url)' 2>/dev/null || true)"
+
+if [[ -z "$FLASK_URL" ]]; then
+  warn "Cloud Run service '${FLASK_SERVICE}' not found yet."
+  warn "Push subscriptions will be CREATED with a placeholder URL and must be"
+  warn "updated post-deploy via: ./scripts/gcloud/update_push_endpoints.sh"
+  FLASK_URL="https://placeholder.invalid"
+fi
+log "Flask URL: ${FLASK_URL}"
+
+# ── 5. Push subscriptions ──────────────────────────────────────────────────
+for pair in "${PAIRS[@]}"; do
+  TOPIC="${pair%%:*}"
+  ENDPOINT_PATH="${pair##*:}"
+  SUB="${TOPIC}-push-sub"
+  PUSH_URL="${FLASK_URL}/api/worker/${ENDPOINT_PATH}"
+
+  log "Ensuring push subscription ${SUB} → ${PUSH_URL}"
+  if ! gcloud pubsub subscriptions describe "$SUB" >/dev/null 2>&1; then
+    gcloud pubsub subscriptions create "$SUB" \
+      --topic="$TOPIC" \
+      --push-endpoint="$PUSH_URL" \
+      --push-auth-service-account="$PUSH_SA" \
+      --ack-deadline=600 \
+      --message-retention-duration=7d \
+      --min-retry-delay=10s \
+      --max-retry-delay=600s \
+      --dead-letter-topic="$DLQ_TOPIC" \
+      --max-delivery-attempts=5
+  else
+    log "  already exists (run update_push_endpoints.sh if Flask URL changed)"
+  fi
+done
+
+# ── 6. IAM ─────────────────────────────────────────────────────────────────
+FLASK_SA="$(gcloud run services describe "$FLASK_SERVICE" \
+  --region="$REGION" \
+  --format='value(spec.template.spec.serviceAccountName)' 2>/dev/null \
+  || echo "")"
+if [[ -z "$FLASK_SA" ]]; then
+  PROJECT_NUM="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+  FLASK_SA="${PROJECT_NUM}-compute@developer.gserviceaccount.com"
+  warn "Falling back to default compute SA for publisher role: ${FLASK_SA}"
+fi
+
+log "Granting roles/pubsub.publisher to ${FLASK_SA}"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${FLASK_SA}" \
+  --role="roles/pubsub.publisher" \
+  --condition=None \
+  --quiet >/dev/null
+
+log "Granting roles/run.invoker on ${FLASK_SERVICE} to ${PUSH_SA}"
+gcloud run services add-iam-policy-binding "$FLASK_SERVICE" \
+  --region="$REGION" \
+  --member="serviceAccount:${PUSH_SA}" \
+  --role="roles/run.invoker" \
+  --quiet >/dev/null
+
+PROJECT_NUM="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+PUBSUB_AGENT="service-${PROJECT_NUM}@gcp-sa-pubsub.iam.gserviceaccount.com"
+log "Granting Pub/Sub agent (${PUBSUB_AGENT}) tokenCreator on ${PUSH_SA}"
+gcloud iam service-accounts add-iam-policy-binding "$PUSH_SA" \
+  --member="serviceAccount:${PUBSUB_AGENT}" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --quiet >/dev/null
+
+log "✅ Done."
+log ""
+log "Set on flask-backend Cloud Run env vars:"
+log "  PUBSUB_INVOKER_SA=${PUSH_SA}"
+log "  GCP_PROJECT_ID=${PROJECT_ID}"
+log ""
+log "Verify with:"
+log "  gcloud pubsub subscriptions list --filter='name:push-sub'"
+log "  gcloud pubsub topics list"

--- a/scripts/gcloud/update_push_endpoints.sh
+++ b/scripts/gcloud/update_push_endpoints.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Repoint existing Pub/Sub push subscriptions at the current Flask Cloud Run URL.
+# Run after any deploy that changes the flask-backend service URL (region change,
+# rename, etc.). Normal redeploys keep the same URL so this is rarely needed,
+# but the first deploy after setup_pubsub.sh ran without a live service does
+# require it.
+#
+# Usage:
+#   ./scripts/gcloud/update_push_endpoints.sh
+#   PROJECT_ID=staging-tlg ./scripts/gcloud/update_push_endpoints.sh
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-comdottasteslikegood}"
+REGION="${REGION:-us-central1}"
+FLASK_SERVICE="${FLASK_SERVICE:-flask-backend}"
+
+PAIRS=(
+  "recipe-generation:recipe"
+  "image-generation:image"
+)
+
+log() { printf '\033[36m[update-push]\033[0m %s\n' "$*"; }
+
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+FLASK_URL="$(gcloud run services describe "$FLASK_SERVICE" \
+  --region="$REGION" --format='value(status.url)')"
+
+if [[ -z "$FLASK_URL" ]]; then
+  echo "ERROR: Cloud Run service '${FLASK_SERVICE}' not found in ${REGION}" >&2
+  exit 1
+fi
+
+log "Flask URL: ${FLASK_URL}"
+
+for pair in "${PAIRS[@]}"; do
+  TOPIC="${pair%%:*}"
+  ENDPOINT_PATH="${pair##*:}"
+  SUB="${TOPIC}-push-sub"
+  PUSH_URL="${FLASK_URL}/api/worker/${ENDPOINT_PATH}"
+
+  log "Updating ${SUB} → ${PUSH_URL}"
+  gcloud pubsub subscriptions update "$SUB" \
+    --push-endpoint="$PUSH_URL" \
+    --quiet
+done
+
+log "✅ Done."


### PR DESCRIPTION
## Summary

Closes the gap between the two Phase 4 PRs already merged on dev: **publishers were live but no consumer existed**. Without this PR, promoting dev → main (#2891) would leave \`recipe-generation\` and \`image-generation\` Pub/Sub messages with no drain — recipes would return 202 forever.

## What this PR does

### Backend submodule bump → \`release/pubsub-push-hardened\` (\`ecbe5da\`)
1. **Adds the missing import.** \`Backend/app.py\` registered \`worker_api_bp\` but never imported it. The container would crash on startup with \`NameError\`. One line fix.
2. **Adds OIDC verification** to \`/api/worker/recipe\` and \`/api/worker/image\`. Without this, anyone with the public Cloud Run URL could POST and trigger free Gemini/Imagen calls or push fake recipes into Cloud SQL. Verifies the JWT Pub/Sub signs each push with and confirms the email claim matches \`PUBSUB_INVOKER_SA\`.
3. \`PUBSUB_AUTH_OPTIONAL=1\` env escape hatch for local dev only.

### \`cloudbuild.yaml\`
Adds \`GCP_PROJECT_ID\` and \`PUBSUB_INVOKER_SA\` env vars on \`flask-backend\` so the push handler knows which OIDC issuer to trust. Worker fails closed (503) if either is missing.

### \`scripts/gcloud/setup_pubsub.sh\` (new)
Idempotent one-time setup. Creates:
- \`pubsub-pusher\` service account (the OIDC signer)
- Topics: \`recipe-generation\`, \`image-generation\`, \`generation-dlq\`
- Push subscriptions with **600s ack-deadline** (Imagen takes 30-90s), DLQ after 5 failed deliveries, exponential retry backoff
- IAM: \`pubsub.publisher\` to flask SA, \`run.invoker\` to push SA, \`tokenCreator\` to Pub/Sub service agent

### \`scripts/gcloud/update_push_endpoints.sh\` (new)
Repoints push subscriptions at the live Flask Cloud Run URL. Needed after the first deploy (setup runs before flask-backend exists, so subscriptions get a placeholder URL).

## Deploy timeline (the goal: ONE deploy to main, not three)

1. Merge this PR → dev
2. Run \`./scripts/gcloud/setup_pubsub.sh\` (one-time, before deploy)
3. Merge dev → main (#2891)
4. Cloud Build deploys both services
5. Run \`./scripts/gcloud/update_push_endpoints.sh\` (repoint subs at live URL)
6. Smoke test: \`POST /api/generate\` → 202 → \`GET /api/recipes/<id>\` shows \`status=ready\` within ~30s

## Test plan
- [x] \`python3 -c \"import ast; ast.parse('worker_api_bp.py')\"\` — syntax OK
- [x] \`bash -n setup_pubsub.sh && bash -n update_push_endpoints.sh\` — syntax OK
- [x] \`yaml.safe_load(cloudbuild.yaml)\` — YAML valid
- [ ] CI passes
- [ ] Manual: run \`setup_pubsub.sh\` in staging if available before merging
- [ ] Post-deploy: smoke test recipe generation end-to-end

## Risks
- **OIDC verification is strict.** If \`PUBSUB_INVOKER_SA\` env var is wrong or unset, all push deliveries 503 and messages retry into the DLQ. Mitigation: env var is in \`cloudbuild.yaml\`, will deploy correctly.
- **First deploy gap.** Between the deploy completing and \`update_push_endpoints.sh\` running, push subs point at \`https://placeholder.invalid\`. Messages queue but don't deliver. Window is ~1 min; acceptable for first cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)