### PR TITLE
fix(deploy): add Cloud Run migrate Job; document FINAL release flow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "Backend"]
 	path = Backend
 	url = https://github.com/adamtasteslikegood/tasteslikegood.com.git
-	branch = dev/backend_sub222
+	branch = dev
 
 [submodule "alirez-claude-skills"]
 	path = alirez-claude-skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,20 +110,58 @@ Modular blueprint architecture (the `Backend/CLAUDE.md` is **outdated** — igno
 
 In production all secrets come from Google Secret Manager, injected at Cloud Run runtime.
 
+## Branching strategy (FINAL)
+
+Both this repo and the `Backend/` submodule follow the same model:
+
+- **`main`** — release branch. Stable. Only the bot's release commit and merges from `dev` land here. Tags fire from `main`.
+- **`dev`** — integration branch. All feature work merges here first.
+- **`feat/*`, `fix/*`, `chore/*`** — short-lived branches off `dev`. PR back into `dev`.
+
+Never commit directly to `main` or `dev`. Always branch off `dev`.
+
+The `.gitmodules` `Backend` entry tracks `dev`, so `git submodule update --remote Backend` fast-forwards to the Backend integration tip. To ship a Backend change:
+
+1. PR into Backend `dev` (in `Backend/` submodule).
+2. After it lands, in this repo: `git submodule update --remote Backend`, commit the new pointer in a cookbook PR off `dev`, merge to `main`, release.
+
+There is no path that ships Backend code without a corresponding cookbook PR — production deploys whatever SHA the cookbook submodule pins at the moment of the release tag.
+
+## Database migrations
+
+Backend migrations live in `Backend/migrations/versions/` (Alembic via Flask-Migrate). They are applied in production by a Cloud Run **Job** named `flask-backend-migrate`, wired into `cloudbuild.yaml` between "Push Flask Backend Version Tag" and "Deploy Flask Backend". The job:
+
+- Reuses the just-pushed `flask-backend:$SHORT_SHA` image
+- Overrides the container command to `flask db upgrade`
+- Mirrors the Flask service's env + secrets (`DATABASE_URL`, `FLASK_SECRET_KEY`, `FLASK_ENV=production`, etc.)
+- Runs in the same VPC/subnet so it can reach Cloud SQL via private IP
+- Runs to completion with `--wait`; a failure aborts the build and the old Flask revision keeps serving traffic
+
+When two PRs both add migrations off the same parent revision, Alembic ends up with branched heads and `flask db upgrade` refuses to run. Detect with `cd Backend && uv run flask db heads` (must be one line). To unify, generate a merge migration:
+
+```bash
+cd Backend && uv run flask db merge -m "merge <topic-a> and <topic-b> heads" <revA> <revB>
+```
+
+Commit the resulting `*_merge_*.py` file with the PR. The merge migration's `upgrade()`/`downgrade()` are typically empty — it exists only to unify the DAG. Recipe of last resort if production is already broken: run the Cloud Run job manually with `gcloud run jobs execute flask-backend-migrate --region=us-central1 --wait`.
+
 ## Deployment
 
-Two Cloud Run services in `us-central1`:
+Two Cloud Run services in `us-central1`, plus one Cloud Run Job:
 
-- `express-frontend` — Node.js, port 8080, public
-- `flask-backend` — Python (gunicorn), port 5000, no public auth
+- `express-frontend` — Node.js service, port 8080, public
+- `flask-backend` — Python (gunicorn) service, port 5000, no public auth
+- `flask-backend-migrate` — Cloud Run **Job** that runs `flask db upgrade` before each Flask service deploy (see "Database migrations" above)
 
-`cloudbuild.yaml` builds both Docker images and deploys them in sequence. Express Dockerfile is at root; Flask Dockerfile is at `Backend/Dockerfile`.
+`cloudbuild.yaml` builds both Docker images, runs the migrate Job, then deploys both services in sequence. Express Dockerfile is at root; Flask Dockerfile is at `Backend/Dockerfile`.
 
 ### Release flow
 
-1. PR merges to `main` (only path that ships).
-2. `.github/workflows/release.yml` extracts `version` from `package.json`, creates the git tag `vX.Y.Z`, pushes the tag, and publishes a GitHub Release with the matching CHANGELOG section. Idempotent — re-running on an existing tag is a no-op.
-3. The tag push hits a **Cloud Build trigger configured on the GCP side** (not in this repo). The trigger watches for tag pushes matching the regex below and runs `cloudbuild.yaml` with `_VERSION=vX.Y.Z`.
+1. Feature work on a `feat/*` / `fix/*` / `chore/*` branch off `dev`. PR into `dev`.
+2. When ready to ship: PR `dev` → `main`, bumping `package.json` version + CHANGELOG. Merge.
+3. `.github/workflows/release.yml` extracts `version` from `package.json`, creates the git tag `vX.Y.Z`, pushes the tag, and publishes a GitHub Release with the matching CHANGELOG section. Idempotent — re-running on an existing tag is a no-op.
+4. The tag push hits a **Cloud Build trigger configured on the GCP side** (not in this repo). The trigger watches for tag pushes matching the regex below and runs `cloudbuild.yaml` with `_VERSION=vX.Y.Z`.
+5. `cloudbuild.yaml` builds both images, runs the `flask-backend-migrate` Job (blocking), then deploys Flask service, then Express service.
 
 ### Cloud Build tag-push trigger (production deploy)
 
@@ -166,11 +204,12 @@ To verify the daemon is running during a session: `ps -ef | grep pm_daemon | gre
 
 - **Rate limiter** uses Valkey for distributed state across Express replicas; `server/valkey.ts` has open GH issues (#163, #162) for edge cases under broken connections — see KAN-16, KAN-17
 - **AI model names** include `models/` prefix (e.g., `models/gemini-3.1-pro-preview`); filter by `generateContent` in `supported_generation_methods`
-- **Backend submodule** — `Backend/` is a git submodule (remote: `adamtasteslikegood/tasteslikegood.com`, branch `dev/backend_sub222`) and accounts for roughly half of the project. Before starting any backend work or shipping a release, ALWAYS check the Backend repo for open PRs and recent commits that may not yet be reflected in the parent's submodule pointer. Quick checks:
+- **Backend submodule** — `Backend/` is a git submodule (remote: `adamtasteslikegood/tasteslikegood.com`, tracked branch `dev`) and accounts for roughly half of the project. Before starting any backend work or shipping a release, ALWAYS check the Backend repo for open PRs and recent commits that may not yet be reflected in the parent's submodule pointer. Quick checks:
   - `gh pr list -R adamtasteslikegood/tasteslikegood.com --state open` — open Backend PRs
-  - `git -C Backend fetch && git -C Backend log --oneline HEAD..origin/dev/backend_sub222` — commits on the tracked branch the pointer hasn't picked up yet
-  - `git submodule update --remote Backend` — fast-forward the pointer to the latest tracked branch tip when ready
-- **Branching** — ALWAYS create a new branch off `dev` before making any changes. Do not commit directly to `dev` or `main`.
+  - `git -C Backend fetch && git -C Backend log --oneline HEAD..origin/dev` — commits on `dev` the pointer hasn't picked up yet
+  - `git -C Backend log --oneline origin/main..origin/dev` — commits on `dev` not yet promoted to Backend `main`
+  - `cd Backend && uv run flask db heads` — must print exactly one line with `(head)`. Two heads = unmerged migrations, deploy will break.
+  - `git submodule update --remote Backend` — fast-forward the pointer to the latest `dev` tip when ready
 - **CI auto-formats** — Prettier runs as a CI job and commits fixes on push; don't be alarmed by bot commits
 - **TypeScript 6.x is blocked** — `package.json` pins `typescript >= 5.9 < 7`; Dependabot is configured to skip TS major bumps
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,20 +110,58 @@ Modular blueprint architecture (the `Backend/CLAUDE.md` is **outdated** — igno
 
 In production all secrets come from Google Secret Manager, injected at Cloud Run runtime.
 
+## Branching strategy (FINAL)
+
+Both this repo and the `Backend/` submodule follow the same model:
+
+- **`main`** — release branch. Stable. Only the bot's release commit and merges from `dev` land here. Tags fire from `main`.
+- **`dev`** — integration branch. All feature work merges here first.
+- **`feat/*`, `fix/*`, `chore/*`** — short-lived branches off `dev`. PR back into `dev`.
+
+Never commit directly to `main` or `dev`. Always branch off `dev`.
+
+The `.gitmodules` `Backend` entry tracks `dev`, so `git submodule update --remote Backend` fast-forwards to the Backend integration tip. To ship a Backend change:
+
+1. PR into Backend `dev` (in `Backend/` submodule).
+2. After it lands, in this repo: `git submodule update --remote Backend`, commit the new pointer in a cookbook PR off `dev`, merge to `main`, release.
+
+There is no path that ships Backend code without a corresponding cookbook PR — production deploys whatever SHA the cookbook submodule pins at the moment of the release tag.
+
+## Database migrations
+
+Backend migrations live in `Backend/migrations/versions/` (Alembic via Flask-Migrate). They are applied in production by a Cloud Run **Job** named `flask-backend-migrate`, wired into `cloudbuild.yaml` between "Push Flask Backend Version Tag" and "Deploy Flask Backend". The job:
+
+- Reuses the just-pushed `flask-backend:$SHORT_SHA` image
+- Overrides the container command to `flask db upgrade`
+- Mirrors the Flask service's env + secrets (`DATABASE_URL`, `FLASK_SECRET_KEY`, `FLASK_ENV=production`, etc.)
+- Runs in the same VPC/subnet so it can reach Cloud SQL via private IP
+- Runs to completion with `--wait`; a failure aborts the build and the old Flask revision keeps serving traffic
+
+When two PRs both add migrations off the same parent revision, Alembic ends up with branched heads and `flask db upgrade` refuses to run. Detect with `cd Backend && uv run flask db heads` (must be one line). To unify, generate a merge migration:
+
+```bash
+cd Backend && uv run flask db merge -m "merge <topic-a> and <topic-b> heads" <revA> <revB>
+```
+
+Commit the resulting `*_merge_*.py` file with the PR. The merge migration's `upgrade()`/`downgrade()` are typically empty — it exists only to unify the DAG. Recipe of last resort if production is already broken: run the Cloud Run job manually with `gcloud run jobs execute flask-backend-migrate --region=us-central1 --wait`.
+
 ## Deployment
 
-Two Cloud Run services in `us-central1`:
+Two Cloud Run services in `us-central1`, plus one Cloud Run Job:
 
-- `express-frontend` — Node.js, port 8080, public
-- `flask-backend` — Python (gunicorn), port 5000, no public auth
+- `express-frontend` — Node.js service, port 8080, public
+- `flask-backend` — Python (gunicorn) service, port 5000, no public auth
+- `flask-backend-migrate` — Cloud Run **Job** that runs `flask db upgrade` before each Flask service deploy (see "Database migrations" above)
 
-`cloudbuild.yaml` builds both Docker images and deploys them in sequence. Express Dockerfile is at root; Flask Dockerfile is at `Backend/Dockerfile`.
+`cloudbuild.yaml` builds both Docker images, runs the migrate Job, then deploys both services in sequence. Express Dockerfile is at root; Flask Dockerfile is at `Backend/Dockerfile`.
 
 ### Release flow
 
-1. PR merges to `main` (only path that ships).
-2. `.github/workflows/release.yml` extracts `version` from `package.json`, creates the git tag `vX.Y.Z`, pushes the tag, and publishes a GitHub Release with the matching CHANGELOG section. Idempotent — re-running on an existing tag is a no-op.
-3. The tag push hits a **Cloud Build trigger configured on the GCP side** (not in this repo). The trigger watches for tag pushes matching the regex below and runs `cloudbuild.yaml` with `_VERSION=vX.Y.Z`.
+1. Feature work on a `feat/*` / `fix/*` / `chore/*` branch off `dev`. PR into `dev`.
+2. When ready to ship: PR `dev` → `main`, bumping `package.json` version + CHANGELOG. Merge.
+3. `.github/workflows/release.yml` extracts `version` from `package.json`, creates the git tag `vX.Y.Z`, pushes the tag, and publishes a GitHub Release with the matching CHANGELOG section. Idempotent — re-running on an existing tag is a no-op.
+4. The tag push hits a **Cloud Build trigger configured on the GCP side** (not in this repo). The trigger watches for tag pushes matching the regex below and runs `cloudbuild.yaml` with `_VERSION=vX.Y.Z`.
+5. `cloudbuild.yaml` builds both images, runs the `flask-backend-migrate` Job (blocking), then deploys Flask service, then Express service.
 
 ### Cloud Build tag-push trigger (production deploy)
 
@@ -166,11 +204,12 @@ To verify the daemon is running during a session: `ps -ef | grep pm_daemon | gre
 
 - **Rate limiter** uses Valkey for distributed state across Express replicas; `server/valkey.ts` has open GH issues (#163, #162) for edge cases under broken connections — see KAN-16, KAN-17
 - **AI model names** include `models/` prefix (e.g., `models/gemini-3.1-pro-preview`); filter by `generateContent` in `supported_generation_methods`
-- **Backend submodule** — `Backend/` is a git submodule (remote: `adamtasteslikegood/tasteslikegood.com`, branch `dev/backend_sub222`) and accounts for roughly half of the project. Before starting any backend work or shipping a release, ALWAYS check the Backend repo for open PRs and recent commits that may not yet be reflected in the parent's submodule pointer. Quick checks:
+- **Backend submodule** — `Backend/` is a git submodule (remote: `adamtasteslikegood/tasteslikegood.com`, tracked branch `dev`) and accounts for roughly half of the project. Before starting any backend work or shipping a release, ALWAYS check the Backend repo for open PRs and recent commits that may not yet be reflected in the parent's submodule pointer. Quick checks:
   - `gh pr list -R adamtasteslikegood/tasteslikegood.com --state open` — open Backend PRs
-  - `git -C Backend fetch && git -C Backend log --oneline HEAD..origin/dev/backend_sub222` — commits on the tracked branch the pointer hasn't picked up yet
-  - `git submodule update --remote Backend` — fast-forward the pointer to the latest tracked branch tip when ready
-- **Branching** — ALWAYS create a new branch off `dev` before making any changes. Do not commit directly to `dev` or `main`.
+  - `git -C Backend fetch && git -C Backend log --oneline HEAD..origin/dev` — commits on `dev` the pointer hasn't picked up yet
+  - `git -C Backend log --oneline origin/main..origin/dev` — commits on `dev` not yet promoted to Backend `main`
+  - `cd Backend && uv run flask db heads` — must print exactly one line with `(head)`. Two heads = unmerged migrations, deploy will break.
+  - `git submodule update --remote Backend` — fast-forward the pointer to the latest `dev` tip when ready
 - **CI auto-formats** — Prettier runs as a CI job and commits fixes on push; don't be alarmed by bot commits
 - **TypeScript 6.x is blocked** — `package.json` pins `typescript >= 5.9 < 7`; Dependabot is configured to skip TS major bumps
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -107,7 +107,11 @@ steps:
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: 'Deploy Migrate Job'
-    waitFor: ['Push Flask Backend Version Tag']
+    # Wait on the SHORT_SHA image push, not the SemVer tag push — the Job's
+    # --image refers to flask-backend:$SHORT_SHA, so as soon as that's in
+    # Artifact Registry the Job can be deployed in parallel with the version
+    # tag push (which is for service-image traceability, not migrations).
+    waitFor: ['Push Flask Backend Image']
     entrypoint: gcloud
     args:
       - run

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -91,14 +91,69 @@ steps:
     waitFor: ['Tag Flask Backend Version']
     args: [push, '$_IMAGE_REGISTRY/flask-backend:$_VERSION']
 
+  # ── Database migration ───────────────────────────────────────────────────────
+  # Migrations run as a Cloud Run Job that reuses the just-pushed flask-backend
+  # image and overrides the command to `flask db upgrade`. The job runs to
+  # completion BEFORE the Flask service is redeployed, so a failing migration
+  # aborts the build and the old Flask revision keeps serving traffic.
+  #
+  # Why a Job and not an init container: Cloud Run services don't support init
+  # containers, and running migrations on every Flask cold-start would race
+  # under concurrency. A one-shot Job is the canonical pattern.
+  #
+  # The job's env + secrets MUST mirror the Flask service so config.py and
+  # create_app() resolve identically — otherwise FLASK_SECRET_KEY fail-fast or
+  # a missing DATABASE_URL secret will surface here, not in service logs.
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: 'Deploy Migrate Job'
+    waitFor: ['Push Flask Backend Version Tag']
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - deploy
+      - flask-backend-migrate
+      - --image=$_IMAGE_REGISTRY/flask-backend:$SHORT_SHA
+      - --region=$_REGION
+      - --command=flask
+      - --args=db,upgrade
+      - --max-retries=1
+      - --task-timeout=600
+      - --cpu=1
+      - --memory=1Gi
+      - --parallelism=1
+      - --tasks=1
+      - --set-env-vars=FLASK_APP=app.py,FLASK_ENV=production,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
+      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest
+      - --network=default
+      - --subnet=default
+      - --vpc-egress=private-ranges-only
+      - --quiet
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: 'Execute Migrate Job'
+    waitFor: ['Deploy Migrate Job']
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - execute
+      - flask-backend-migrate
+      - --region=$_REGION
+      - --wait
+      - --quiet
+
   # ── Deploy ───────────────────────────────────────────────────────────────────
   # KAN-30: Flask backend deploys first; Express frontend waits on its completion
   # so the new frontend never serves against the old API during rollout.
+  # The migrate Job above must succeed before the Flask service is redeployed
+  # so a broken migration cannot land alongside a code change that depends on it.
 
   # 4. Deploy Flask Backend
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: 'Deploy Flask Backend'
-    waitFor: ['Push Flask Backend Version Tag']
+    waitFor: ['Execute Migrate Job']
     entrypoint: gcloud
     args:
       - run


### PR DESCRIPTION
## Summary

- Wires a Cloud Run **Job** (`flask-backend-migrate`) into `cloudbuild.yaml` between "Push Flask Backend Version Tag" and "Deploy Flask Backend". The Job reuses the just-pushed `flask-backend` image, overrides the command to `flask db upgrade`, mirrors the Flask service's env + secrets + VPC config, and runs to completion with `--wait`. A failing migration aborts the build so the old Flask revision keeps serving traffic — no half-deployed schema can ship alongside code that depends on it.
- Bumps the `Backend` submodule to `dev` tip (`15ba254`) which now contains the Alembic merge migration (Backend PR #119, merged). With both pieces in place, the next release tag heals prod's `recipe.status` / `recipe.slug` / `recipe.is_public` schema gap.
- Fixes `.gitmodules`: `branch = dev/backend_sub222` → `branch = dev`. The old branch name no longer exists on the Backend remote; this restores `git submodule update --remote Backend` so the cookbook can fast-forward the pointer cleanly.
- Adds explicit "Branching strategy (FINAL)" section, new "Database migrations" section documenting the Cloud Run Job + multi-PR head conflict policy, updated "Release flow" to include the migrate step, and rewritten "Backend submodule" non-obvious pattern in `CLAUDE.md` and `AGENTS.md` (mirrored).

## Why

Recipe generation and auth are 500ing on tasteslikegood.org because the live Cloud SQL DB is missing the `recipe.status`, `recipe.slug`, and `recipe.is_public` columns. Two issues compounded:

1. **No migration step in the deploy pipeline.** `cloudbuild.yaml` built and deployed Flask but never ran `flask db upgrade`, so schema-changing PRs (Backend #115, #116) shipped code that referenced columns that didn't exist on prod.
2. **Branched Alembic heads.** `03da1e46c9a5` (`recipe.status`) and `fc014cd27ab4` (`recipe.slug`, `recipe.is_public`) both branched off `e5a1b3c7d9f2`. Even if migrations had been running, Alembic would have refused to upgrade past two heads. Resolved in Backend #119 with a merge migration (`c60f6530f4ff`).

## Test plan

- [x] Backend PR #119 merged to Backend `dev`. Merge migration verified locally on fresh SQLite — `recipe` table has `status`, `slug`, `is_public`; `alembic_version` pinned to single head.
- [x] `.gitmodules` syntax valid; submodule pointer updates cleanly with `git submodule update`.
- [ ] Cookbook CI green
- [ ] After merge to `dev`: PR `dev` → `main` with `v0.2.2` version + CHANGELOG bump. The release tag fires the new pipeline; the Cloud Run migrate Job runs against prod Cloud SQL, applies the merge migration, and the live errors clear.

## Operational notes

- The migrate Job uses `--max-retries=1`, `--task-timeout=600`, runs in the `default` VPC + subnet so it can hit Cloud SQL via private IP.
- **First execution**: when this PR's release builds, `gcloud run jobs deploy flask-backend-migrate ...` will create the Job for the first time. The subsequent `execute --wait` will apply all pending migrations (including the merge) in one shot. If something goes wrong, the Flask service is NOT redeployed and the build aborts.
- Manual override for hotfixes: `gcloud run jobs execute flask-backend-migrate --region=us-central1 --wait` after the Job exists.

## Companion

- Backend PR #119 (merged): https://github.com/adamtasteslikegood/tasteslikegood.com/pull/119

🤖 Generated with [Claude Code](https://claude.com/claude-code)