### PR TITLE
fix(deploy): attach Cloud SQL instance to migrate Job (v0.2.3 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Hotfix on top of v0.2.2 — the migrate Job couldn't reach Cloud SQL.
 
 ### Fixed
 
-- `cloudbuild.yaml`: add `--set-cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db` to the `flask-backend-migrate` Cloud Run Job. The `DATABASE_URL` secret is configured for a Cloud SQL Unix-socket connection (`postgresql://...?host=/cloudsql/<instance>`) — without this flag the socket path doesn't exist in the Job container and SQLAlchemy falls back to localhost, failing with `OperationalError: Is the server running locally and accepting connections on that socket?`. The v0.2.2 build aborted at "Execute Migrate Job" because of this; the new Flask revision was correctly *not* deployed (the gate worked), but no migration ran. v0.2.3 rebuilds with the corrected Job spec.
+- `cloudbuild.yaml`: add `--set-cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db` to the `flask-backend-migrate` Cloud Run Job. The `DATABASE_URL` secret is configured for a Cloud SQL Unix-socket connection (`postgresql://...?host=/cloudsql/<instance>`) — without this flag the socket path doesn't exist in the Job container and SQLAlchemy falls back to localhost, failing with `OperationalError: Is the server running locally and accepting connections on that socket?`. The v0.2.2 build aborted at "Execute Migrate Job" because of this; the new Flask revision was correctly _not_ deployed (the gate worked), but no migration ran. v0.2.3 rebuilds with the corrected Job spec.
 
 ## [0.2.2] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-30
+
+Hotfix on top of v0.2.2 — the migrate Job couldn't reach Cloud SQL.
+
+### Fixed
+
+- `cloudbuild.yaml`: add `--set-cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db` to the `flask-backend-migrate` Cloud Run Job. The `DATABASE_URL` secret is configured for a Cloud SQL Unix-socket connection (`postgresql://...?host=/cloudsql/<instance>`) — without this flag the socket path doesn't exist in the Job container and SQLAlchemy falls back to localhost, failing with `OperationalError: Is the server running locally and accepting connections on that socket?`. The v0.2.2 build aborted at "Execute Migrate Job" because of this; the new Flask revision was correctly *not* deployed (the gate worked), but no migration ran. v0.2.3 rebuilds with the corrected Job spec.
+
 ## [0.2.2] - 2026-04-30
 
 Production hotfix: restore recipe generation and auth on tasteslikegood.org.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -130,6 +130,14 @@ steps:
       - --tasks=1
       - --set-env-vars=FLASK_APP=app.py,FLASK_ENV=production,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
       - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest
+      # The DATABASE_URL secret is configured for Cloud SQL Unix-socket
+      # connection (postgresql://...?host=/cloudsql/<instance>), matching
+      # the Flask service. Without this flag the socket path doesn't exist
+      # in the Job container and SQLAlchemy falls back to localhost:5432
+      # ("Is the server running locally and accepting connections on that
+      # socket?"). The flask-backend Cloud Run service has the same
+      # `run.googleapis.com/cloudsql-instances` annotation set.
+      - --set-cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db
       - --network=default
       - --subnet=default
       - --vpc-egress=private-ranges-only

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
## Summary

v0.2.2 hotfix: the migrate Job couldn't reach Cloud SQL.

The v0.2.2 build aborted at step 11 "Execute Migrate Job" with:

\`\`\`
sqlalchemy.exc.OperationalError: ... Is the server running locally
and accepting connections on that socket?
\`\`\`

Root cause: \`DATABASE_URL\` secret is configured for Cloud SQL Unix-socket connection (\`postgresql://...?host=/cloudsql/<instance>\`), matching how the \`flask-backend\` Cloud Run service connects. The new Job spec from v0.2.2 had VPC + private-ranges egress (for Valkey) but **no `--set-cloudsql-instances`**, so `/cloudsql/<instance>` didn't exist in the Job container and SQLAlchemy fell back to localhost:5432.

Verified against the live `flask-backend` service:

\`\`\`
$ gcloud run services describe flask-backend ... \\
    --format='value(spec.template.metadata.annotations)' | tr ';' '\\n' | grep cloudsql
run.googleapis.com/cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db
\`\`\`

## What this PR does

- Adds `--set-cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db` to the `Deploy Migrate Job` step in `cloudbuild.yaml` so the Cloud SQL Auth Proxy mounts at `/cloudsql/<instance>` inside the Job container.
- Bumps `package.json` 0.2.2 → 0.2.3 + CHANGELOG entry.

## Why direct to main

Hotfix on top of yesterday's prod-fix release that didn't fully fix prod. Same urgency profile — once this lands and v0.2.3 builds successfully, the migrate Job will apply the merge migration + new columns and Flask/Express redeploy.

## Verification path

On merge → `release.yml` tags `v0.2.3` → Cloud Build trigger fires → cloudbuild.yaml runs:

- [ ] Build images succeeds (no app changes — same Backend SHA `15ba254`)
- [ ] Deploy Migrate Job succeeds (with the new flag)
- [ ] **Execute Migrate Job succeeds** ← the actual fix verification
- [ ] Migrate Job logs show `Running upgrade ... -> c60f6530f4ff, merge status and slug heads`
- [ ] Flask service redeploys
- [ ] Express service redeploys
- [ ] `https://www.tasteslikegood.org/` recipe generation + auth work end-to-end

## Note on the gate

The gate behaved exactly as designed in v0.2.2: Execute Migrate Job failed, so Flask + Express never deployed and the old Flask revision kept serving. Prod outage didn't get worse. This is the system working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)