### PR TITLE
fix: correct popstate view mapping, bump to v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-05-04
+
+Bug-fix release on top of v0.2.3 — corrects a UX regression in browser back-button handling and bumps the Backend submodule pointer onto the green `dev` tip after the test-fixture fix lands.
+
+### Fixed
+
+- **Browser back button now restores the correct view.** `src/app.component.ts`'s `popstate` handler had its mappings inverted: returning to a `{view: 'kitchen'}` history entry switched the user to the generator (and vice versa). Pressing back from a recipe detail dropped users on the generator instead of the kitchen, and pressing back from the kitchen was effectively a no-op. The handler now mirrors the `pushState` calls in `switchView`/`viewRecipe` so back navigation matches user intent (KAN-related, surfaced in PR #2912 review).
+- **Backend test fixtures reliably bind to `:memory:`** — Backend issue [#118](https://github.com/adamtasteslikegood/tasteslikegood.com/issues/118). `tests/test_migration_backfill_slug.py` had been failing on every CI run since the SSR/data-model PR landed (`table recipe has no column named status`) because the fixture updated `SQLALCHEMY_DATABASE_URI` _after_ `create_app()` had already let Flask-SQLAlchemy latch onto the file-based dev DB. `create_app()` now accepts config kwargs that are applied before `db.init_app()`, and both the `test_migration_backfill_slug.py` and `test_public_ssr.py` fixtures use the new signature. Backend pytest is fully green again on the PR-gate workflow.
+
+### Changed
+
+- Backend submodule pointer bumped to the post-#127 `dev` tip so the cookbook ships with the test-fixture fix in place. No runtime behavior changes.
+
 ## [0.2.3] - 2026-04-30
 
 Hotfix on top of v0.2.2 — the migrate Job couldn't reach Cloud SQL.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "dev": "ng serve",

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -22,14 +22,17 @@ export class AppComponent {
   activeView = signal<'generator' | 'kitchen'>('generator');
 
   constructor() {
-    // Browser back button: restore previous view based on history state
+    // Browser back button: restore previous view based on history state.
+    // event.state is the entry we're navigating *to*, so the mapping mirrors
+    // the pushState calls in switchView/viewRecipe: a 'kitchen' entry on the
+    // stack means we're returning to the cookbook list; the initial null
+    // entry means we're returning to the generator.
     window.addEventListener('popstate', (event) => {
       const state = event.state as { view?: string } | null;
       if (state?.view === 'kitchen') {
-        this.activeView.set('generator');
-      } else if (state?.view === 'recipe-detail') {
-        // Restore kitchen view (cookbook context preserved)
         this.activeView.set('kitchen');
+      } else {
+        this.activeView.set('generator');
       }
     });
   }


### PR DESCRIPTION
## Summary

Clean replacement for #2915 (closed) — the v0.2.4 release prep, all in one PR.

- **`src/app.component.ts`** — fix browser back-button regression. The popstate handler had its mappings inverted: returning to a `{view: 'kitchen'}` history entry switched the user to the generator (and the absent/null initial entry did nothing at all). Pressing back from a recipe detail dropped users on the generator instead of the kitchen, and pressing back from the kitchen was effectively a no-op. The handler now mirrors the `pushState` calls in `switchView`/`viewRecipe`.
- **`package.json`** — bump 0.2.3 → 0.2.4 so the dev→main release PR can fire the tag-push workflow.
- **`CHANGELOG.md`** — new `## [0.2.4]` section documenting the popstate fix and the Backend test-fixture fix shipping in this release.
- **`Backend` submodule** — bumped `20644f2` → `aeeb3a0` to pick up Backend PR #127 (issue #118): `create_app()` now accepts config overrides so test fixtures can bind `:memory:` before `db.init_app()` latches onto the file-based dev DB. Backend pytest is green again.

## Why a new branch instead of fixing #2915

#2915 had drifted from `origin/dev` (stray `Konsole` file, unrelated tooling churn) and would have needed a non-trivial rebase. Branching fresh off `origin/dev` and bringing only the substantive deltas keeps the diff reviewable and the history clean.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] `npm run format:check` — clean
- [x] Backend pytest — all 109 green at submodule tip `aeeb3a0`
- [ ] Manual smoke: navigate generator → kitchen → recipe detail → back → back, verify each back step lands on the expected view
- [ ] PR-gate CI green

## Follow-up

Once this merges to `dev`, the existing `dev → main` release PR (#2912) ships v0.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)