### PR TITLE
chore(pm): address PR #2912 PM-script review comments + expand v0.2.4 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.2.4] - 2026-05-04
 
-Bug-fix release on top of v0.2.3 — corrects a UX regression in browser back-button handling and bumps the Backend submodule pointer onto the green `dev` tip after the test-fixture fix lands.
+Bug-fix release on top of v0.2.3, plus PM tooling and docs reorganization. Corrects two UX regressions (browser back button, AI image persistence), ships the new Jira/Confluence/PR sync script that PR #2903 introduced, moves planning docs into `specs/`, and bumps the Backend submodule onto the green `dev` tip after the test-fixture fix lands.
 
 ### Fixed
 
-- **Browser back button now restores the correct view.** `src/app.component.ts`'s `popstate` handler had its mappings inverted: returning to a `{view: 'kitchen'}` history entry switched the user to the generator (and vice versa). Pressing back from a recipe detail dropped users on the generator instead of the kitchen, and pressing back from the kitchen was effectively a no-op. The handler now mirrors the `pushState` calls in `switchView`/`viewRecipe` so back navigation matches user intent (KAN-related, surfaced in PR #2912 review).
+- **Browser back button now restores the correct view.** `src/app.component.ts`'s `popstate` handler had its mappings inverted: returning to a `{view: 'kitchen'}` history entry switched the user to the generator (and vice versa). Pressing back from a recipe detail dropped users on the generator instead of the kitchen, and pressing back from the kitchen was effectively a no-op. The handler now mirrors the `pushState` calls in `switchView`/`viewRecipe` so back navigation matches user intent.
+- **AI-generated recipe images survive a refresh.** `src/services/auth.service.ts`'s `hydrate()` now merges `ai_image_url` from localStorage into API recipe data when the backend hasn't persisted the image URL yet (Pub/Sub write hasn't landed). The merge uses a `Map` keyed by recipe id so the cost is O(n+m) instead of O(n·m).
+- **Public recipes show up at `/browse`.** Backend `create_recipe()` now syncs the `is_public` and `slug` columns from the recipe payload on create, update, and migration paths, so saving a recipe as public actually flips the DB column the listing query filters on.
 - **Backend test fixtures reliably bind to `:memory:`** — Backend issue [#118](https://github.com/adamtasteslikegood/tasteslikegood.com/issues/118). `tests/test_migration_backfill_slug.py` had been failing on every CI run since the SSR/data-model PR landed (`table recipe has no column named status`) because the fixture updated `SQLALCHEMY_DATABASE_URI` _after_ `create_app()` had already let Flask-SQLAlchemy latch onto the file-based dev DB. `create_app()` now accepts config kwargs that are applied before `db.init_app()`, and both the `test_migration_backfill_slug.py` and `test_public_ssr.py` fixtures use the new signature. Backend pytest is fully green again on the PR-gate workflow.
+- **PM sync scripts follow the docs into `specs/`.** `sync_docs_to_confluence.py` and `scripts/pm/atlassian_pm_link.py` had their planning-doc paths still pointing at repo root; both now read from `specs/` so the Confluence sync and PM briefing pick up the canonical locations again.
+
+### Added
+
+- **`scripts/pm/sync_jira_confluence_status.py`** — one-shot sync that prints production-site health, open GitHub PR check status, open + recently-updated Jira issues for the `KAN` project, and Confluence pages mentioning the current release. The release version is read from `package.json` (override with `RELEASE_VERSION`); `ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID` and `ATLASSIAN_CONFLUENCE_KEY_PAGES` env vars let callers retarget the workspace without editing the script.
+- `scripts/pm/requirements.txt` declares the runtime deps (`requests`, `python-dotenv`).
 
 ### Changed
 
+- **Planning docs moved from repo root to `specs/`.** `plan.md`, `roadmap.md`, `planning_notes.md`, `design-plan.md`, `SCRUM_BOOTSTRAP_AND_BOARD_PLAN.md`, `SPRINT_0_PLAN.md`, `ATLASSIAN_PM_LINK.md`. `CLAUDE.md`'s pm-daemon paths reference the new locations; the watcher in `alirez-claude-skills/pm-daemon/pm_daemon.py` matches by basename so it picked up the move automatically.
+- **`AGENTS.md` rewritten for OpenCode.** Removed the gstack-specific routing block, added a `Backend submodule` "CRITICAL" section, and added pointers to the PM tooling.
+- **`.gitignore`** now ignores `.claude/scheduled_tasks.lock` and `.omg/state/` (agent runtime state, not version-controlled).
 - Backend submodule pointer bumped to the post-#127 `dev` tip so the cookbook ships with the test-fixture fix in place. No runtime behavior changes.
 
 ## [0.2.3] - 2026-04-30

--- a/scripts/pm/atlassian_pm_link.py
+++ b/scripts/pm/atlassian_pm_link.py
@@ -30,10 +30,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT = REPO_ROOT / ".agent-work" / "pm" / "PROJECT_PM_BRIEFING.md"
 DEFAULT_CACHE = REPO_ROOT / ".agent-work" / "pm" / "atlassian-state.json"
 LOCAL_PM_FILES = [
-    "planning_notes.md",
-    "plan.md",
-    "roadmap.md",
-    "design-plan.md",
+    "specs/planning_notes.md",
+    "specs/plan.md",
+    "specs/roadmap.md",
+    "specs/design-plan.md",
 ]
 
 

--- a/scripts/pm/sync_jira_confluence_status.py
+++ b/scripts/pm/sync_jira_confluence_status.py
@@ -44,7 +44,8 @@ def _read_package_version() -> str:
         return ""
 
 
-CURRENT_VERSION = os.environ.get("RELEASE_VERSION") or _read_package_version() or "0.2.4"
+# Strip a leading 'v' so a tag-style RELEASE_VERSION (e.g. "v0.2.4") doesn't yield "vv0.2.4".
+CURRENT_VERSION = (os.environ.get("RELEASE_VERSION") or _read_package_version() or "0.2.4").removeprefix("v")
 # Family prefix, e.g. "0.2" from "0.2.4" — broadens search to catch sibling patch pages.
 VERSION_FAMILY = ".".join(CURRENT_VERSION.split(".")[:2])
 SEARCH_TERMS = [

--- a/scripts/pm/sync_jira_confluence_status.py
+++ b/scripts/pm/sync_jira_confluence_status.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Fetch Jira issues, open PRs, and Confluence build-deploy status for v0.2.0/v0.2.1.
+"""Fetch Jira issues, open PRs, and Confluence build-deploy status for the current release.
+
+The release version is read from package.json so the script tracks whatever
+version the repo is currently shipping; override with RELEASE_VERSION env var.
 
 Dependencies: requests, python-dotenv (not stdlib).
 Install before running: pip install -r scripts/pm/requirements.txt
@@ -8,14 +11,17 @@ Install before running: pip install -r scripts/pm/requirements.txt
 import base64
 import json
 import os
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
 import requests
 from dotenv import load_dotenv
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 # Load env
-load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+load_dotenv(REPO_ROOT / ".env")
 
 # Normalize ATLASSIAN_URL: strip any scheme so callers can set it as either
 # "tasteslikegood.atlassian.net" or "https://tasteslikegood.atlassian.net".
@@ -28,6 +34,57 @@ SEARCH_TIMEOUT = 60
 
 # Module-level placeholder; populated by main() after env-var validation.
 HEADERS: dict = {}
+
+
+def _read_package_version() -> str:
+    pkg = REPO_ROOT / "package.json"
+    try:
+        return json.loads(pkg.read_text(encoding="utf-8")).get("version", "")
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+
+CURRENT_VERSION = os.environ.get("RELEASE_VERSION") or _read_package_version() or "0.2.4"
+# Family prefix, e.g. "0.2" from "0.2.4" — broadens search to catch sibling patch pages.
+VERSION_FAMILY = ".".join(CURRENT_VERSION.split(".")[:2])
+SEARCH_TERMS = [
+    f"v{CURRENT_VERSION}",
+    CURRENT_VERSION,
+    f"v{VERSION_FAMILY}",
+    VERSION_FAMILY,
+    "build",
+    "deploy",
+]
+PAGE_CHECK_VERSIONS = [f"v{CURRENT_VERSION}", CURRENT_VERSION, f"v{VERSION_FAMILY}", VERSION_FAMILY]
+
+# Confluence parent page ID for "Project Documentation" — override with
+# ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID if the workspace is restructured.
+PARENT_DOCUMENTATION_PAGE_ID = os.environ.get("ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID", "11796481")
+
+
+def _parse_key_pages_env(raw: str | None) -> list[tuple[str, str]] | None:
+    """Parse `id1:Name 1,id2:Name 2,...` into [(id, name), ...]."""
+    if not raw:
+        return None
+    pairs: list[tuple[str, str]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry or ":" not in entry:
+            continue
+        page_id, _, name = entry.partition(":")
+        pairs.append((page_id.strip(), name.strip()))
+    return pairs or None
+
+
+KEY_PAGES_DEFAULT = [
+    ("11206769", "CHANGELOG"),
+    ("11206815", "DEPLOYMENT_CHECKLIST"),
+    ("11174061", "Optimized Deployment Prompt"),
+    ("11174080", "TERRAFORM_DEPLOYMENT_AUDIT"),
+    ("11304994", "v0.2 Execution Plan"),
+    ("11206731", "v0.2 Project Roadmap"),
+]
+KEY_PAGES = _parse_key_pages_env(os.environ.get("ATLASSIAN_CONFLUENCE_KEY_PAGES")) or KEY_PAGES_DEFAULT
 
 
 def get_auth_headers(email: str, token: str) -> dict:
@@ -72,10 +129,7 @@ def fetch_recent_issues():
         return None
 
 def fetch_open_prs_from_github():
-    """Fetch open PRs from GitHub."""
-    # Use gh CLI or GitHub API
-    # We'll use subprocess to call gh
-    import subprocess
+    """Fetch open PRs from GitHub via the gh CLI."""
     try:
         result = subprocess.run(
             ["gh", "pr", "list", "--state", "open", "--json", "number,title,headRefName,author,statusCheckRollup,updatedAt"],
@@ -91,11 +145,11 @@ def fetch_open_prs_from_github():
         return []
 
 def search_confluence_for_versions():
-    """Search Confluence page bodies for v0.2.0 and v0.2.1 mentions using CQL."""
+    """Search Confluence page bodies for the current release family using CQL."""
     url = f"https://{URL_BASE}/wiki/rest/api/search"
     results = {}
 
-    for version in ["v0.2.0", "v0.2.1", "0.2.0", "0.2.1", "build", "deploy"]:
+    for version in SEARCH_TERMS:
         cql = f'text ~ "{version}" AND type = "page" AND space.key = "TLG"'
         params = {"cql": cql, "limit": 50, "expand": "metadata.labels"}
         try:
@@ -113,7 +167,7 @@ def search_confluence_for_versions():
     return results
 
 
-def fetch_confluence_children(parent_page_id="11796481"):
+def fetch_confluence_children(parent_page_id: str = PARENT_DOCUMENTATION_PAGE_ID):
     """Fetch child pages under Project Documentation."""
     url = f"https://{URL_BASE}/wiki/api/v2/pages/{parent_page_id}/children"
     params = {"limit": 100}
@@ -145,7 +199,7 @@ def fetch_confluence_page_content(page_id):
         return None
 
 def check_page_for_versions(page_id, page_title):
-    """Check if a page mentions v0.2.0 or v0.2.1 in its content."""
+    """Check if a page mentions the current release (or its family) in its content."""
     page = fetch_confluence_page_content(page_id)
     if not page:
         print(f"Skipping Confluence page '{page_title}' ({page_id}): unable to fetch content")
@@ -153,8 +207,8 @@ def check_page_for_versions(page_id, page_title):
     body = page.get("body", {}).get("storage", {}).get("value", "")
     text_lower = body.lower()
     mentions = []
-    for version in ["v0.2.0", "v0.2.1", "0.2.0", "0.2.1"]:
-        if version in text_lower:
+    for version in PAGE_CHECK_VERSIONS:
+        if version.lower() in text_lower:
             mentions.append(version)
     return len(mentions) > 0, mentions
 
@@ -264,7 +318,9 @@ def main():
     print()
 
     # 5. Confluence CQL search for versions
-    print("## 5. CONFLUENCE PAGES MENTIONING v0.2.0 / v0.2.1 / BUILD / DEPLOY")
+    print(
+        f"## 5. CONFLUENCE PAGES MENTIONING v{CURRENT_VERSION} / v{VERSION_FAMILY} / BUILD / DEPLOY"
+    )
     cf_results = search_confluence_for_versions()
     found_any = False
     for term, hits in cf_results.items():
@@ -276,25 +332,29 @@ def main():
                 page_title = hit.get("title") or hit.get("content", {}).get("title", "(no title)")
                 page_id = hit.get("content", {}).get("id", "")
                 print(f"    - {page_title} (ID: {page_id})")
+    # Fetch the parent's child pages once and reuse for both the CQL fallback
+    # and the all-children overview below.
+    children = fetch_confluence_children()
     if not found_any:
         print("  No CQL matches found. Checking child pages under Project Documentation...")
-        children = fetch_confluence_children()
         if children:
+            title_keywords = list({
+                f"v{CURRENT_VERSION}".lower(),
+                CURRENT_VERSION.lower(),
+                f"v{VERSION_FAMILY}".lower(),
+                VERSION_FAMILY.lower(),
+                "deploy",
+                "build",
+                "release",
+                "changelog",
+            })
             for page in children.get("results", [])[:30]:
                 title = page.get("title", "")
-                if any(k in title.lower() for k in ["v0.2", "0.2", "deploy", "build", "release", "changelog"]):
+                if any(k in title.lower() for k in title_keywords):
                     print(f"    - {title} (ID: {page.get('id')})")
-    # Also scan content of key pages
+    # Also scan content of key pages (override list via ATLASSIAN_CONFLUENCE_KEY_PAGES).
     print("  Scanning content of key pages for version mentions...")
-    key_pages = [
-        ("11206769", "CHANGELOG"),
-        ("11206815", "DEPLOYMENT_CHECKLIST"),
-        ("11174061", "Optimized Deployment Prompt"),
-        ("11174080", "TERRAFORM_DEPLOYMENT_AUDIT"),
-        ("11304994", "v0.2 Execution Plan"),
-        ("11206731", "v0.2 Project Roadmap"),
-    ]
-    for page_id, page_name in key_pages:
+    for page_id, page_name in KEY_PAGES:
         has_mentions, versions = check_page_for_versions(page_id, page_name)
         if has_mentions:
             print(f"    ✅ {page_name} mentions: {', '.join(set(versions))}")
@@ -302,7 +362,6 @@ def main():
 
     # 6. Child pages overview
     print("## 6. ALL CONFLUENCE CHILD PAGES (Project Documentation)")
-    children = fetch_confluence_children()
     if children:
         for page in children.get("results", [])[:50]:
             print(f"  - {page.get('title')} (ID: {page.get('id')})")

--- a/sync_docs_to_confluence.py
+++ b/sync_docs_to_confluence.py
@@ -69,9 +69,9 @@ def create_page(title, markdown_content):
         print(f"Error creating page {title}: {e}")
 
 files_to_upload = [
-    ("v0.2 Execution Plan", "plan.md"),
-    ("v0.2 Project Roadmap", "roadmap.md"),
-    ("v0.2 Planning Session Review & Notes", "planning_notes.md"),
+    ("v0.2 Execution Plan", "specs/plan.md"),
+    ("v0.2 Project Roadmap", "specs/roadmap.md"),
+    ("v0.2 Planning Session Review & Notes", "specs/planning_notes.md"),
 ]
 
 test_plan_files = glob.glob(os.path.expanduser('~/.gemstack/projects/adamtasteslikegood-tasteslikegoodtheangularsvegancookbook/adam-dev-test-plan-*.md'))


### PR DESCRIPTION
## Summary

Follow-up to PR #2917 (already merged) — addresses the **substantive** review comments on PR #2912 (the `dev → main` v0.2.4 release PR), specifically the ones aimed at the PM tooling and the CHANGELOG.

### What this fixes

**P1 (Codex, 2026-05-05) — doc-move blocker:**
- `sync_docs_to_confluence.py` was still uploading `plan.md`/`roadmap.md`/`planning_notes.md` from repo root. After PR #2912's `specs/` move those paths don't exist, so the explicit list silently failed `open()`.
- `scripts/pm/atlassian_pm_link.py:LOCAL_PM_FILES` resolved each filename via `REPO_ROOT / filename`, so the briefing's "Local PM Artifacts" section went empty after the move.
- Both fixed by pointing at `specs/<filename>`.

**`scripts/pm/sync_jira_confluence_status.py` — review comment cleanup:**
- `import subprocess` moved to the top (PEP 8 — flagged twice).
- Hardcoded `v0.2.0/v0.2.1` removed throughout. `CURRENT_VERSION` is now read from `package.json` (override with `RELEASE_VERSION` env var), and `VERSION_FAMILY` (e.g. `0.2` from `0.2.4`) is derived from it. `SEARCH_TERMS`, `PAGE_CHECK_VERSIONS`, the section-5 header, and the title-keyword fallback list all use those constants.
- Hardcoded `parent_page_id="11796481"` is now `PARENT_DOCUMENTATION_PAGE_ID`, overridable via `ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID`.
- Hardcoded `key_pages` list of `(id, name)` tuples is now `KEY_PAGES_DEFAULT`, overridable via `ATLASSIAN_CONFLUENCE_KEY_PAGES` (`id1:Name 1,id2:Name 2,...` format).
- `fetch_confluence_children()` was called twice in `main()`; now fetched once and reused.

**CHANGELOG:**
- Reviewer flagged the prior v0.2.4 entry as too narrow. Expanded to cover everything shipping in v0.2.4: popstate fix, image persistence (`hydrate()`), public-recipe `is_public`/`slug` sync, Backend test-fixture fix, the new PM sync script, the `specs/` doc move, the AGENTS.md rewrite, and the `.gitignore` additions.

### Defer (with rationale)

Two suggestions from the bot reviewers are ignored intentionally:

| Suggestion | Reason |
|---|---|
| Combine `fetch_jira_issues` and `fetch_recent_issues` into one JQL-parameterized function | Pure refactor, both functions work correctly. YAGNI. |
| Combine the per-version CQL queries into a single OR'd query (one API call instead of six) | Optimization for a one-shot manual diagnostic script that runs sequentially once on demand. Not worth the complexity here. |

### Verified

- All four `specs/` paths resolve (`specs/plan.md`, `specs/roadmap.md`, `specs/planning_notes.md`, `specs/design-plan.md`).
- Module-load smoke test confirms `CURRENT_VERSION = '0.2.4'`, `VERSION_FAMILY = '0.2'`, all env-var overrides take effect.
- `python3 -m py_compile` clean on all three modified scripts.
- `npm run lint` / `npm run format:check` / `npm run type-check` all clean.

### What this PR does NOT do

- It does **not** bump `package.json` again (still v0.2.4 — that bump landed in #2917).
- It does **not** touch `pm_daemon.py` (lives in the `alirez-claude-skills` submodule, out of scope; its watcher already matches files by basename so the `specs/` move is invisible to it).

## Test plan

- [x] `npm run lint`, `format:check`, `type-check` clean
- [x] Python syntax + module-load smoke test
- [x] `specs/*.md` paths resolve under `REPO_ROOT`
- [ ] PR-gate CI green
- [ ] Manual: run `scripts/pm/sync_jira_confluence_status.py` against live creds and confirm v0.2.4 mentions surface (post-merge sanity)

## Follow-up

Once this lands on `dev`, the existing `dev → main` release PR (#2912) carries everything needed to ship v0.2.4 via the tag-push trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)