### PR TITLE
chore: gitignore auto-generated pm-daemon virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ __pycache__/
 *$py.class
 .gstack/
 
+# pm-daemon virtualenv (auto-created on session startup, see .mcp.json)
+scripts/pm/.venv/
+
 # Agent runtime state
 .claude/scheduled_tasks.lock
 .omg/state/


### PR DESCRIPTION
## Summary
- `scripts/pm/.venv/` was showing up as untracked in a fresh session because the `pm-daemon` MCP server auto-creates it on first run (per CLAUDE.md's "Startup (agent sessions)" section).
- Adds `scripts/pm/.venv/` to `.gitignore` so this local, machine-specific virtualenv is never tracked.

## Context
This surfaced while running a routine health check across CI/monitoring services — no application code was touched, this is a pure repo-hygiene fix so the auto-generated venv stops showing as dirty working-tree state.

## Test plan
- [x] Confirmed `git status` is clean after the ignore rule is added
- N/A — no functional code changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWtpYvCF3CWUmYcrVoQiip)_



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

