### PR TITLE
fix: trust Memorystore CA for Valkey TLS via VALKEY_CA_CERT

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -203,7 +203,10 @@ steps:
       - --image=$_IMAGE_REGISTRY/express-frontend:$SHORT_SHA
       - --region=$_REGION
       - --min-instances=0
-      - --set-secrets=GEMINI_API_KEY=GEMINI_API_KEY:latest
+      # VALKEY_CA_CERT: Memorystore's Google-managed CA cert, created by
+      # scripts/gcloud/setup_valkey_ca.sh. Without it TLS verification of the
+      # Valkey endpoint fails and rate limiting falls back to in-memory (#163).
+      - --set-secrets=GEMINI_API_KEY=GEMINI_API_KEY:latest,VALKEY_CA_CERT=VALKEY_CA_CERT:latest
       - --allow-unauthenticated
       - --quiet
 

--- a/scripts/gcloud/setup_valkey_ca.sh
+++ b/scripts/gcloud/setup_valkey_ca.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Idempotent setup for the VALKEY_CA_CERT secret: fetches the Google-managed
+# CA certificate of the Memorystore (Valkey) instance and stores it in Secret
+# Manager so the Express service can verify the instance's TLS cert.
+#
+# Without this secret, Node.js rejects the Memorystore server cert
+# ("self-signed certificate in certificate chain") and the rate limiter
+# silently falls back to in-memory state (GH #163 / #162, KAN-16 / KAN-17).
+#
+# Run BEFORE the first deploy that includes VALKEY_CA_CERT in cloudbuild.yaml.
+# Safe to re-run; a new secret version is only added when the CA changed.
+#
+# Required env vars (with sensible defaults):
+#   PROJECT_ID       — GCP project (default: comdottasteslikegood)
+#   REGION           — Memorystore location (default: us-central1)
+#   VALKEY_INSTANCE  — Memorystore instance id (default: veganchef-valkeymem)
+#   EXPRESS_SERVICE  — Cloud Run service name (default: express-frontend)
+#
+# Usage:
+#   ./scripts/gcloud/setup_valkey_ca.sh
+#   PROJECT_ID=staging-tlg ./scripts/gcloud/setup_valkey_ca.sh
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-comdottasteslikegood}"
+REGION="${REGION:-us-central1}"
+VALKEY_INSTANCE="${VALKEY_INSTANCE:-veganchef-valkeymem}"
+EXPRESS_SERVICE="${EXPRESS_SERVICE:-express-frontend}"
+
+SECRET_NAME="VALKEY_CA_CERT"
+
+log() { printf '\033[36m[setup-valkey-ca]\033[0m %s\n' "$*"; }
+warn() { printf '\033[33m[setup-valkey-ca] WARN:\033[0m %s\n' "$*" >&2; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found in PATH"; exit 1; }
+}
+
+require gcloud
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+# ── 1. Fetch the instance CA certificate ────────────────────────────────────
+log "Fetching CA cert for Memorystore instance ${VALKEY_INSTANCE} (${REGION})"
+CA_PEM="$(gcloud memorystore instances get-certificate-authority "$VALKEY_INSTANCE" \
+  --location="$REGION" \
+  --format='value(managedServerCa.caCerts[0].certificates[0])')"
+
+if [[ "$CA_PEM" != *"BEGIN CERTIFICATE"* ]]; then
+  echo "ERROR: response does not look like a PEM certificate:"
+  echo "$CA_PEM" | head -3
+  exit 1
+fi
+
+# ── 2. Create the secret / add a version only when the CA changed ──────────
+if ! gcloud secrets describe "$SECRET_NAME" >/dev/null 2>&1; then
+  log "Creating secret ${SECRET_NAME}"
+  printf '%s\n' "$CA_PEM" | gcloud secrets create "$SECRET_NAME" \
+    --replication-policy=automatic \
+    --data-file=-
+else
+  CURRENT="$(gcloud secrets versions access latest --secret="$SECRET_NAME" 2>/dev/null || true)"
+  if [[ "$CURRENT" == "$CA_PEM" ]]; then
+    log "Secret ${SECRET_NAME} already holds the current CA — nothing to do"
+  else
+    log "CA changed — adding new version to ${SECRET_NAME}"
+    printf '%s\n' "$CA_PEM" | gcloud secrets versions add "$SECRET_NAME" --data-file=-
+  fi
+fi
+
+# ── 3. Grant the Express runtime SA access to the secret ───────────────────
+RUNTIME_SA="$(gcloud run services describe "$EXPRESS_SERVICE" --region="$REGION" \
+  --format='value(spec.template.spec.serviceAccountName)' 2>/dev/null || true)"
+if [[ -z "$RUNTIME_SA" ]]; then
+  PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+  RUNTIME_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+  warn "Service ${EXPRESS_SERVICE} has no explicit SA — using default compute SA"
+fi
+
+log "Granting roles/secretmanager.secretAccessor on ${SECRET_NAME} to ${RUNTIME_SA}"
+gcloud secrets add-iam-policy-binding "$SECRET_NAME" \
+  --member="serviceAccount:${RUNTIME_SA}" \
+  --role="roles/secretmanager.secretAccessor" >/dev/null
+
+log "Done. Next deploy (cloudbuild.yaml) injects ${SECRET_NAME} into ${EXPRESS_SERVICE}."

--- a/scripts/gcloud/setup_valkey_ca.sh
+++ b/scripts/gcloud/setup_valkey_ca.sh
@@ -37,19 +37,32 @@ require() {
 }
 
 require gcloud
+require python3
 gcloud config set project "$PROJECT_ID" >/dev/null
 
-# ── 1. Fetch the instance CA certificate ────────────────────────────────────
-log "Fetching CA cert for Memorystore instance ${VALKEY_INSTANCE} (${REGION})"
+# ── 1. Fetch the instance CA bundle ─────────────────────────────────────────
+# During CA rotation multiple CAs are active at once; the bundle must contain
+# every certificate or TLS breaks again mid-rotation. Node's tls.ca accepts
+# concatenated PEM certs in a single value.
+log "Fetching CA bundle for Memorystore instance ${VALKEY_INSTANCE} (${REGION})"
 CA_PEM="$(gcloud memorystore instances get-certificate-authority "$VALKEY_INSTANCE" \
-  --location="$REGION" \
-  --format='value(managedServerCa.caCerts[0].certificates[0])')"
+  --location="$REGION" --format=json | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+certs = [
+    cert
+    for ca in data.get("managedServerCa", {}).get("caCerts", [])
+    for cert in ca.get("certificates", [])
+]
+print("\n".join(c.strip() for c in certs))
+')"
 
 if [[ "$CA_PEM" != *"BEGIN CERTIFICATE"* ]]; then
-  echo "ERROR: response does not look like a PEM certificate:"
+  echo "ERROR: response does not look like a PEM certificate bundle:"
   echo "$CA_PEM" | head -3
   exit 1
 fi
+log "Bundle contains $(grep -c 'BEGIN CERTIFICATE' <<<"$CA_PEM") certificate(s)"
 
 # ── 2. Create the secret / add a version only when the CA changed ──────────
 if ! gcloud secrets describe "$SECRET_NAME" >/dev/null 2>&1; then

--- a/server/server.test.ts
+++ b/server/server.test.ts
@@ -208,6 +208,7 @@ describe('createValkeyClient', () => {
     delete process.env.VALKEY_PORT;
     delete process.env.VALKEY_AUTH_MODE;
     delete process.env.VALKEY_TLS_INSECURE;
+    delete process.env.VALKEY_CA_CERT;
   });
 
   afterEach(async () => {
@@ -220,6 +221,7 @@ describe('createValkeyClient', () => {
     delete process.env.VALKEY_AUTH_MODE;
     delete process.env.VALKEY_PORT;
     delete process.env.VALKEY_TLS_INSECURE;
+    delete process.env.VALKEY_CA_CERT;
   });
 
   it('returns null when VALKEY_HOST is not set', async () => {
@@ -248,6 +250,32 @@ describe('createValkeyClient', () => {
         tls: expect.any(Object),
       })
     );
+  });
+
+  it('sets tls.ca from VALKEY_CA_CERT when VALKEY_AUTH_MODE=iam', async () => {
+    const pem = '-----BEGIN CERTIFICATE-----\nMIIFakeCaCert\n-----END CERTIFICATE-----\n';
+    process.env.VALKEY_HOST = '10.0.0.1';
+    process.env.VALKEY_AUTH_MODE = 'iam';
+    process.env.VALKEY_CA_CERT = pem;
+    const { createValkeyClient } = await import('./valkey.js');
+    await createValkeyClient();
+    expect(MockRedis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tls: expect.objectContaining({ ca: pem }),
+      })
+    );
+    // Supplying a CA must not weaken verification
+    const callArg = (MockRedis.mock.calls[0] as unknown[])?.[0] as { tls: Record<string, unknown> };
+    expect(callArg.tls).not.toHaveProperty('rejectUnauthorized');
+  });
+
+  it('does not set tls.ca when VALKEY_CA_CERT is unset', async () => {
+    process.env.VALKEY_HOST = '10.0.0.1';
+    process.env.VALKEY_AUTH_MODE = 'iam';
+    const { createValkeyClient } = await import('./valkey.js');
+    await createValkeyClient();
+    const callArg = (MockRedis.mock.calls[0] as unknown[])?.[0] as { tls: Record<string, unknown> };
+    expect(callArg.tls).not.toHaveProperty('ca');
   });
 
   it('does NOT set password or tls when VALKEY_AUTH_MODE is not iam', async () => {

--- a/server/valkey.ts
+++ b/server/valkey.ts
@@ -116,6 +116,11 @@ export async function createValkeyClient(): Promise<Redis | null> {
     if (authMode === 'iam') {
       const { token, email } = await getIAMToken();
       const tlsOptions: Record<string, unknown> = {};
+      // Memorystore server certs chain to a Google-managed private CA that the
+      // system trust store can't verify — trust it explicitly via VALKEY_CA_CERT.
+      if (process.env.VALKEY_CA_CERT) {
+        tlsOptions.ca = process.env.VALKEY_CA_CERT;
+      }
       if (process.env.VALKEY_TLS_INSECURE === 'true') {
         tlsOptions.rejectUnauthorized = false;
         console.warn(


### PR DESCRIPTION
## Problem

Production `express-frontend` has **never** connected to Valkey. Cloud Logging shows the same sequence on every cold start (verified over the last 6+ hours; Memorystore `connected_clients` is flat at 0):

```
[Valkey] Using IAM auth (sa=unknown)
[ioredis] Unhandled error event: Error: self-signed certificate in certificate chain  (×4)
[Valkey] Connection failed, falling back to in-memory rate limiting: MaxRetriesPerRequestError
```

In IAM mode `server/valkey.ts` enables TLS with empty options, so Node validates the Memorystore server cert against the public system CA store. Memorystore certs chain to a **Google-managed private CA**, so verification fails before `AUTH` is even attempted, and rate limiting silently degrades to per-instance in-memory state — the failure mode tracked in #163 / #162 (KAN-16 / KAN-17).

## Fix

- **`server/valkey.ts`** — in IAM mode, pass the PEM from the new `VALKEY_CA_CERT` env var as `tls.ca`. Full certificate verification stays on; this is strictly narrower than `VALKEY_TLS_INSECURE=true`.
- **`cloudbuild.yaml`** — inject the `VALKEY_CA_CERT` Secret Manager secret into the `express-frontend` deploy step.
- **`scripts/gcloud/setup_valkey_ca.sh`** — new idempotent setup script: fetches the instance CA via `gcloud memorystore instances get-certificate-authority`, creates/rotates the secret, grants the runtime SA `secretAccessor`.

## Tests

TDD: new Vitest cases (watched fail first) assert the client is constructed with `tls.ca` when `VALKEY_CA_CERT` is set in IAM mode, that supplying a CA does not weaken verification, and that `tls.ca` stays unset otherwise. All 37 server tests pass; lint + type-check clean.

## ⚠️ Manual step before the next release

Run once with prod credentials (I was not authorized to create the secret from the agent session):

```bash
./scripts/gcloud/setup_valkey_ca.sh
```

Without it the next deploy fails on the missing `VALKEY_CA_CERT` secret reference.

Fixes #163. Related #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

