### PR TITLE
fix: SSR-save auth race + dropped image fields (from #3030 review)

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { GeminiService } from './services/gemini.service';
 import { AuthService } from './services/auth.service';
 import { PersistenceService } from './services/persistence.service';
+import { buildSavedRecipeFromPublic } from './services/public-recipe.mapper';
 import { Ingredient, IngredientGroup, InstructionStep, Recipe } from './recipe.types';
 
 @Component({
@@ -97,6 +98,10 @@ export class AppComponent {
       console.warn(`Ignoring save request for invalid recipe slug: "${slug}"`);
       return;
     }
+    // Wait for the startup auth check so the save lands in the reconciled
+    // session — writing into a cached-but-stale authenticated session gets
+    // wiped by clearStaleAuthenticatedSession() right after.
+    await this.authService.ready;
     // Ensure a guest session exists so the save persists for first-time,
     // unauthenticated visitors arriving from an SSR page.
     this.authService.ensureGuestSession();
@@ -107,22 +112,7 @@ export class AppComponent {
         return;
       }
       const recipeData = await response.json();
-      const recipe: Recipe = {
-        // Always assign a fresh id: a saved copy is a new entry in the user's
-        // cookbook. Reusing the source public recipe's id makes the API POST
-        // collide with the existing row (409 → treated as success), so it would
-        // never persist to the server cookbook / other devices.
-        id: crypto.randomUUID(),
-        name: recipeData.name || 'Saved Recipe',
-        ingredients: recipeData.ingredients || { wet: [], dry: [], other: [] },
-        instructions: recipeData.instructions || [],
-        prepTime: recipeData.prepTime ?? 0,
-        cookTime: recipeData.cookTime ?? 0,
-        servings: recipeData.servings ?? 0,
-        description: recipeData.description || '',
-        tags: recipeData.tags || [],
-        notes: recipeData.notes || '',
-      };
+      const recipe: Recipe = buildSavedRecipeFromPublic(recipeData);
       // persistenceService.saveRecipe writes localStorage first (via
       // auth.saveRecipe) and then syncs to the API, so a separate
       // authService.saveRecipe call here would be a redundant double-write.

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -135,6 +135,58 @@ describe('AuthService auth-check startup behavior', () => {
     );
   });
 
+  it('ensureGuestSession does not restore a cached authenticated session while the auth check is pending', async () => {
+    const cachedUser = createAuthenticatedUser();
+    localStorage.setItem(AuthService.SESSION_STORAGE_KEY, JSON.stringify(cachedUser));
+
+    // Auth check never resolves within the test — simulates the in-flight window
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+
+    const authService = new AuthService();
+    authService.ensureGuestSession();
+
+    // Must neither render the possibly-stale user nor clobber their cache
+    expect(authService.currentUser()).toBeNull();
+    expect(JSON.parse(localStorage.getItem(AuthService.SESSION_STORAGE_KEY) || '{}')).toEqual(
+      cachedUser
+    );
+  });
+
+  it('ensureGuestSession restores a cached guest session while the auth check is pending', async () => {
+    const guestUser: User = {
+      id: 'guest-1',
+      name: 'Guest Chef',
+      isGuest: true,
+      authProvider: 'guest',
+      savedRecipes: [],
+      cookbooks: [],
+      deletedRecipes: [],
+    };
+    localStorage.setItem(AuthService.SESSION_STORAGE_KEY, JSON.stringify(guestUser));
+
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+
+    const authService = new AuthService();
+    authService.ensureGuestSession();
+
+    expect(authService.currentUser()).toEqual(guestUser);
+  });
+
+  it('exposes a ready promise that resolves once the auth check completes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ authenticated: false }),
+      })
+    );
+
+    const authService = new AuthService();
+    await authService.ready;
+
+    expect(authService.authLoading()).toBe(false);
+  });
+
   it('preserves cached authenticated state when auth-check fails with a transport error', async () => {
     const cachedUser = createAuthenticatedUser();
     localStorage.setItem(AuthService.SESSION_STORAGE_KEY, JSON.stringify(cachedUser));

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -25,8 +25,11 @@ export class AuthService {
   private readonly STORAGE_KEY_SESSION = AuthService.SESSION_STORAGE_KEY;
   private readonly API_BASE = environment.flaskApiUrl; // '' = relative (proxied)
 
+  /** Resolves once the startup auth check has completed and local state is reconciled. */
+  readonly ready: Promise<void>;
+
   constructor() {
-    this.init();
+    this.ready = this.init();
   }
 
   // ─── Initialization ───────────────────────────────────────────
@@ -188,7 +191,14 @@ export class AuthService {
     // check resolves.)
     const existing = this.getLocalSession();
     if (existing) {
-      this.currentUser.set(existing);
+      // A cached *authenticated* session may be stale while the startup auth
+      // check is still in flight: restoring it would briefly render another
+      // user's data on shared devices, and a save written into it disappears
+      // if clearStaleAuthenticatedSession() wipes it moments later. Callers
+      // that need a session for a save must await `ready` first.
+      if (existing.isGuest || !this.authLoading()) {
+        this.currentUser.set(existing);
+      }
       return;
     }
 

--- a/src/services/public-recipe.mapper.test.ts
+++ b/src/services/public-recipe.mapper.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildSavedRecipeFromPublic } from './public-recipe.mapper';
+
+describe('buildSavedRecipeFromPublic', () => {
+  it('preserves image fields and assigns a fresh id', () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'fresh-uuid' });
+
+    const recipe = buildSavedRecipeFromPublic({
+      id: 'public-id',
+      name: 'Thai Peanut Noodles',
+      ai_image_url: 'https://img.example/ai.png',
+      stock_image_url: 'https://img.example/stock.jpg',
+    });
+
+    expect(recipe.id).toBe('fresh-uuid');
+    expect(recipe.id).not.toBe('public-id');
+    expect(recipe.ai_image_url).toBe('https://img.example/ai.png');
+    expect(recipe.stock_image_url).toBe('https://img.example/stock.jpg');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('fills safe defaults for missing fields without inventing image urls', () => {
+    const recipe = buildSavedRecipeFromPublic({});
+
+    expect(recipe.name).toBe('Saved Recipe');
+    expect(recipe.ingredients).toEqual({ wet: [], dry: [], other: [] });
+    expect(recipe.instructions).toEqual([]);
+    expect(recipe.ai_image_url).toBeUndefined();
+    expect(recipe.stock_image_url).toBeUndefined();
+  });
+});

--- a/src/services/public-recipe.mapper.ts
+++ b/src/services/public-recipe.mapper.ts
@@ -1,0 +1,29 @@
+import type { Recipe } from '../recipe.types';
+
+/**
+ * Build a cookbook-savable Recipe from the public SSR endpoint's payload
+ * (`/api/recipes/public/<slug>`).
+ *
+ * Always assigns a fresh id: a saved copy is a new entry in the user's
+ * cookbook. Reusing the source public recipe's id makes the API POST collide
+ * with the existing row (409 → treated as success), so it would never persist
+ * to the server cookbook / other devices.
+ */
+export function buildSavedRecipeFromPublic(recipeData: Partial<Recipe>): Recipe {
+  return {
+    id: crypto.randomUUID(),
+    name: recipeData.name || 'Saved Recipe',
+    ingredients: recipeData.ingredients || { wet: [], dry: [], other: [] },
+    instructions: recipeData.instructions || [],
+    prepTime: recipeData.prepTime ?? 0,
+    cookTime: recipeData.cookTime ?? 0,
+    servings: recipeData.servings ?? 0,
+    description: recipeData.description || '',
+    tags: recipeData.tags || [],
+    notes: recipeData.notes || '',
+    // The public pages are photo-backed; without these the kitchen card
+    // falls back to a placeholder even though the source recipe had an image.
+    ai_image_url: recipeData.ai_image_url,
+    stock_image_url: recipeData.stock_image_url,
+  };
+}


### PR DESCRIPTION
Fixes the two real findings from the Copilot/Codex reviews on release PR #3030 (both verified in code before fixing):

1. **Auth race in the `?save=` flow** — `ensureGuestSession()` restored a cached *authenticated* session while `/api/auth/check` was still in flight; the save landed in a record that `clearStaleAuthenticatedSession()` could wipe seconds later (and briefly rendered another user's data on shared devices). Now: guest sessions restore immediately, non-guest sessions are not touched until init() reconciles, and `handleSaveFromSSR()` awaits the new `AuthService.ready` promise.
2. **Saved public recipes lost their photo** — the rebuilt `Recipe` omitted `ai_image_url`/`stock_image_url`. Mapping extracted to `buildSavedRecipeFromPublic()` and unit-tested.

TDD: 5 new tests written first and watched fail. Full suite 45/45, type-check + lint + prettier clean.

Note: Copilot's third comment (embedded quotes in the `.claude/settings.json` hook command) is a false positive — Claude Code executes hooks via a shell, and this exact hook has been running in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

