### PR TITLE
fix: dedupe @angular/* ignore in dependabot.yml (unfails #3030 config check)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,7 +67,10 @@ updates:
           - 'postcss'
     # Ignore known breaking major updates that require manual migration
     ignore:
-      # Angular and TypeScript major upgrades must be coordinated with Angular ESLint and project migrations.
+      # Angular majors require TypeScript majors (e.g. Angular 22 needs TS >=6.0,
+      # which the root typescript pin deliberately blocks). Angular major upgrades
+      # are manual migrations coordinated with @angular-eslint and the TS pin —
+      # see PR #2996 which broke npm ci on dev.
       - dependency-name: '@angular/*'
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular-eslint/*'
@@ -79,11 +82,6 @@ updates:
       # Tailwind v4 requires @tailwindcss/postcss plugin and full config migration.
       # Review periodically — remove this ignore when ready to migrate (see postcss.config.js).
       - dependency-name: 'tailwindcss'
-        update-types: ['version-update:semver-major']
-      # Angular majors require TypeScript majors (e.g. Angular 22 needs TS >=6.0,
-      # which the root typescript pin deliberately blocks). Angular major upgrades
-      # are manual migrations — see PR #2996 which broke npm ci on dev.
-      - dependency-name: '@angular/*'
         update-types: ['version-update:semver-major']
     open-pull-requests-limit: 15
 


### PR DESCRIPTION
Dependabot's config check on #3030 fails with `updates/1/ignore/5 includes a duplicate` — the #2981 merge unioned both sides' ignore lists and doubled the `@angular/*` semver-major rule. Removed the duplicate (keeping the richer comment) and validated the whole file: no remaining duplicate (dependency-name, update-types) combos in any ecosystem; all three blocks target `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

