### PR TITLE
feat: accept base64 GCP key so cloud-environment routines can use gcp-monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ dist-ssr
 .env
 .env.local
 .env.*.local
+# Service-account key materialized from GOOGLE_APPLICATION_CREDENTIALS_B64
+scripts/monitoring/.gcp-sa-key.json
 
 # Angular
 .angular/

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -76,8 +76,11 @@ gitignored `scripts/monitoring/.gcp-sa-key.json` (0600) at startup.
 1. Encode the key locally, straight to the clipboard (don't echo it):
 
    ```bash
-   base64 -w0 < /path/to/monitoring-viewer.json | wl-copy   # or xclip/pbcopy
+   base64 < /path/to/monitoring-viewer.json | tr -d '\n' | wl-copy   # or xclip/pbcopy
    ```
+
+   (`tr -d '\n'` keeps this portable — GNU `base64` wraps at 76 columns by
+   default and macOS/BSD `base64` has no `-w` flag.)
 
 2. On claude.ai → **Code** → the environment your routine uses → environment
    settings → **Environment variables**, add:

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -4,13 +4,13 @@ A stdio MCP server (`scripts/monitoring/gcp_mcp_server.py`) that lets Claude
 query live Cloud Monitoring telemetry for the production stack and run the
 **"Run System Health Check"** routine. It covers:
 
-| Component  | GCP resource                                        |
-| ---------- | --------------------------------------------------- |
-| `frontend` | Cloud Run service `express-frontend`                 |
-| `backend`  | Cloud Run service `flask-backend`                    |
+| Component  | GCP resource                                             |
+| ---------- | -------------------------------------------------------- |
+| `frontend` | Cloud Run service `express-frontend`                     |
+| `backend`  | Cloud Run service `flask-backend`                        |
 | `database` | Cloud SQL instance `comdottasteslikegood:vegangenius-db` |
-| `valkey`   | Memorystore Valkey rate-limiter store                |
-| `pubsub`   | Generation topics + push subscriptions (incl. DLQ)   |
+| `valkey`   | Memorystore Valkey rate-limiter store                    |
+| `pubsub`   | Generation topics + push subscriptions (incl. DLQ)       |
 
 ```
 [ Claude (Code or Desktop) ]
@@ -65,7 +65,42 @@ Nothing else to do — the server is registered in `.mcp.json` as
 `gcp-monitor` and auto-spawns when a session starts in this directory, same
 as `pm-daemon`. Verify with `ps -ef | grep gcp_mcp_server`.
 
-## 4. Claude Desktop
+## 4. Claude Code cloud environments (web sessions & scheduled routines)
+
+Cloud sessions clone this repo, so `.mcp.json` auto-spawns `gcp-monitor`
+there too — but the cloud VM has neither your `.env` nor the key file. Cloud
+environments only carry **single-line** env vars (there is no secrets vault
+yet), so the key travels base64-encoded and the server materializes it to a
+gitignored `scripts/monitoring/.gcp-sa-key.json` (0600) at startup.
+
+1. Encode the key locally, straight to the clipboard (don't echo it):
+
+   ```bash
+   base64 -w0 < /path/to/monitoring-viewer.json | wl-copy   # or xclip/pbcopy
+   ```
+
+2. On claude.ai → **Code** → the environment your routine uses → environment
+   settings → **Environment variables**, add:
+
+   ```
+   GOOGLE_APPLICATION_CREDENTIALS_B64=<paste the base64 blob>
+   GCP_PROJECT_ID=comdottasteslikegood
+   ```
+
+   (`GCP_PROJECT_ID` is optional — it's the default.)
+
+3. Make sure the environment's **network access** allows package installs —
+   the launcher pip-installs its venv on first run and the server calls
+   `monitoring.googleapis.com`.
+
+Note: environment variables are visible to anyone who can edit that cloud
+environment, and any cloud session using it can read the key — acceptable
+here because the service account is read-only (`roles/monitoring.viewer`),
+but don't reuse this pattern for write-capable credentials. A key _path_ in
+`GOOGLE_APPLICATION_CREDENTIALS` that resolves to a real file always wins
+over the B64 var, so local setups are unaffected.
+
+## 5. Claude Desktop
 
 Edit the desktop config file:
 
@@ -99,7 +134,7 @@ Analysis") and paste the routine from
 `.claude/skills/system-health-check/SKILL.md` into its Custom Instructions.
 Trigger it with: **Run System Health Check**.
 
-## 5. Tools exposed
+## 6. Tools exposed
 
 - `check_system_health(target_component="all", minutes_back=15)` — summarized
   metrics (latest | mean | max per series) for one component or the whole
@@ -113,7 +148,7 @@ Trigger it with: **Run System Health Check**.
 - `query_metric(metric_type, minutes_back, aligner, group_by, extra_filter)` —
   ad-hoc query for any metric the curated probes don't cover.
 
-## 6. Running the routine
+## 7. Running the routine
 
 In Claude Code, say **"Run System Health Check"** or invoke
 `/system-health-check`. Claude collects telemetry for all five components,

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -17,13 +17,20 @@ every tool in this server — Pub/Sub metrics are read through the Monitoring
 API, not the Pub/Sub admin API.
 
 Configuration (env vars, or repo-root `.env`):
-    GOOGLE_APPLICATION_CREDENTIALS  path to the service-account JSON key
+    GOOGLE_APPLICATION_CREDENTIALS      path to the service-account JSON key
+    GOOGLE_APPLICATION_CREDENTIALS_B64  base64 of the key JSON itself — for
+                                        Claude Code cloud environments, which
+                                        only carry single-line env vars; used
+                                        when no key file path resolves
     GCP_PROJECT_ID                  defaults to comdottasteslikegood
     EXPRESS_SERVICE / FLASK_SERVICE / CLOUDSQL_INSTANCE  resource overrides
 """
 
+import base64
 import datetime
+import json
 import os
+import sys
 import threading
 from pathlib import Path
 from typing import Optional
@@ -54,7 +61,30 @@ _load_dotenv(REPO_ROOT / ".env")
 # the same entry works regardless of the agent's working directory.
 _creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
 if _creds and not os.path.isabs(_creds):
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(REPO_ROOT / _creds)
+    _creds = str(REPO_ROOT / _creds)
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = _creds
+
+# Claude Code cloud environments (web sessions / scheduled routines) have no
+# key file on disk and only carry single-line env vars, so the key travels as
+# base64-encoded JSON. Materialize it to a gitignored 0600 file. A key *path*
+# that resolves to a real file wins, keeping local setups unaffected.
+_creds_b64 = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_B64")
+if _creds_b64 and not (_creds and os.path.isfile(_creds)):
+    try:
+        _key_bytes = base64.b64decode(_creds_b64, validate=True)
+        json.loads(_key_bytes)
+    except ValueError as exc:
+        print(
+            "WARNING: GOOGLE_APPLICATION_CREDENTIALS_B64 is not valid "
+            f"base64-encoded JSON; ignoring it ({exc})",
+            file=sys.stderr,
+        )
+    else:
+        _key_path = Path(__file__).resolve().parent / ".gcp-sa-key.json"
+        _fd = os.open(_key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(_fd, "wb") as _fh:
+            _fh.write(_key_bytes)
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(_key_path)
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "comdottasteslikegood")
 PROJECT_NAME = f"projects/{PROJECT_ID}"
@@ -122,7 +152,8 @@ def _metrics_client():
                 raise RuntimeError(
                     f"GOOGLE_APPLICATION_CREDENTIALS points to '{creds}' but no "
                     "such file exists. Fix the path in .env (repo root) or the "
-                    "MCP env block."
+                    "MCP env block, or supply the key as "
+                    "GOOGLE_APPLICATION_CREDENTIALS_B64 (base64 of the JSON)."
                 )
             from google.cloud import monitoring_v3
 

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -83,6 +83,9 @@ if _creds_b64 and not (_creds and os.path.isfile(_creds)):
         _key_path = Path(__file__).resolve().parent / ".gcp-sa-key.json"
         _fd = os.open(_key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(_fd, "wb") as _fh:
+            # mode on os.open only applies at creation — re-tighten in case a
+            # previous run (or manual copy) left the file with broader perms
+            os.fchmod(_fh.fileno(), 0o600)
             _fh.write(_key_bytes)
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(_key_path)
 


### PR DESCRIPTION
## Why

The `gcp-monitor` MCP server (`.mcp.json`) auto-starts in Claude Code cloud sessions and scheduled routines because it's part of the clone — but it can't authenticate there: it reads `GOOGLE_APPLICATION_CREDENTIALS` (a key **file path**) from the repo-root `.env`, and the cloud VM has neither. Cloud environments only carry single-line env vars (no secrets vault yet), so a raw multi-line service-account JSON can't be pasted either.

## What

- `scripts/monitoring/gcp_mcp_server.py` now accepts **`GOOGLE_APPLICATION_CREDENTIALS_B64`** — base64 of the service-account key JSON — and materializes it to a gitignored `scripts/monitoring/.gcp-sa-key.json` (0600) at startup, pointing `GOOGLE_APPLICATION_CREDENTIALS` at it.
- Precedence: a key *path* that resolves to a real file always wins, so local `.env` setups are unaffected.
- Invalid base64/JSON logs a stderr warning and is ignored (server still starts; tools return the existing actionable error).
- `.gitignore` entry for the materialized key; `docs/MCP_GCP_MONITORING.md` gains a cloud-environment setup section (encode command, where to paste the env var, network-access note, visibility caveat — key is read-only `roles/monitoring.viewer`).

## Verified

Ran the module in a clean worktree (no `.env`, simulating the cloud VM):
- valid B64 → key file written with `0600`, content roundtrips, env var points at it
- garbage B64 → warning on stderr, env left unset
- both path + B64 set → path wins
- `git status` does not see the materialized key

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

