### PR TITLE
fix: actionable review-bot findings from release PR #3030

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Browser → Express :8080 → Flask :5000 → Cloud SQL (PostgreSQL)
 
 **All browser traffic routes through Express** (single origin, no CORS). Express proxies `/api/*` to Flask as a raw HTTP stream — mounted **before** `express.json()` so Flask handles body parsing itself. Flask's `url_for(_external=True)` resolves correctly via `X-Forwarded-*` headers set by Express. Angular only ever uses relative URLs (`/api/...`).
 
-### Layer 1 — Angular 21 SPA (`src/`)
+### Layer 1 — Angular 22 SPA (`src/`)
 
 - Standalone components with **Signals API** (`signal()`, `computed()`, `effect()`) — no RxJS
 - Three services: `GeminiService` (recipe + image generation), `AuthService` (OAuth + guest), `PersistenceService` (localStorage-first, background sync to Flask)

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.2",
         "@typescript-eslint/eslint-plugin": "^8.62.1",
-        "@typescript-eslint/parser": "^8.20.0",
+        "@typescript-eslint/parser": "^8.62.1",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.0.0",
@@ -48,7 +48,7 @@
         "prettier": "^3.9.4",
         "typescript": "6.0.3",
         "vite": "^8.0.16",
-        "vitest": "^4.0.8"
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^25.6.2",
     "@typescript-eslint/eslint-plugin": "^8.62.1",
-    "@typescript-eslint/parser": "^8.20.0",
+    "@typescript-eslint/parser": "^8.62.1",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.0.0",
@@ -70,7 +70,7 @@
     "prettier": "^3.9.4",
     "typescript": "6.0.3",
     "vite": "^8.0.16",
-    "vitest": "^4.0.8"
+    "vitest": "^4.1.9"
   },
   "overrides": {
     "hono": "4.12.26"

--- a/scripts/gcloud/setup_valkey_ca.sh
+++ b/scripts/gcloud/setup_valkey_ca.sh
@@ -38,7 +38,8 @@ require() {
 
 require gcloud
 require python3
-gcloud config set project "$PROJECT_ID" >/dev/null
+# --project is passed per command: mutating the user's global gcloud
+# config from a setup script is a rude side effect.
 
 # ── 1. Fetch the instance CA bundle ─────────────────────────────────────────
 # During CA rotation multiple CAs are active at once; the bundle must contain
@@ -46,7 +47,7 @@ gcloud config set project "$PROJECT_ID" >/dev/null
 # concatenated PEM certs in a single value.
 log "Fetching CA bundle for Memorystore instance ${VALKEY_INSTANCE} (${REGION})"
 CA_PEM="$(gcloud memorystore instances get-certificate-authority "$VALKEY_INSTANCE" \
-  --location="$REGION" --format=json | python3 -c '
+  --project="$PROJECT_ID" --location="$REGION" --format=json | python3 -c '
 import json, sys
 data = json.load(sys.stdin)
 certs = [
@@ -65,23 +66,24 @@ fi
 log "Bundle contains $(grep -c 'BEGIN CERTIFICATE' <<<"$CA_PEM") certificate(s)"
 
 # ── 2. Create the secret / add a version only when the CA changed ──────────
-if ! gcloud secrets describe "$SECRET_NAME" >/dev/null 2>&1; then
+if ! gcloud secrets describe "$SECRET_NAME" --project="$PROJECT_ID" >/dev/null 2>&1; then
   log "Creating secret ${SECRET_NAME}"
   printf '%s\n' "$CA_PEM" | gcloud secrets create "$SECRET_NAME" \
+    --project="$PROJECT_ID" \
     --replication-policy=automatic \
     --data-file=-
 else
-  CURRENT="$(gcloud secrets versions access latest --secret="$SECRET_NAME" 2>/dev/null || true)"
+  CURRENT="$(gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT_ID" 2>/dev/null || true)"
   if [[ "$CURRENT" == "$CA_PEM" ]]; then
     log "Secret ${SECRET_NAME} already holds the current CA — nothing to do"
   else
     log "CA changed — adding new version to ${SECRET_NAME}"
-    printf '%s\n' "$CA_PEM" | gcloud secrets versions add "$SECRET_NAME" --data-file=-
+    printf '%s\n' "$CA_PEM" | gcloud secrets versions add "$SECRET_NAME" --project="$PROJECT_ID" --data-file=-
   fi
 fi
 
 # ── 3. Grant the Express runtime SA access to the secret ───────────────────
-RUNTIME_SA="$(gcloud run services describe "$EXPRESS_SERVICE" --region="$REGION" \
+RUNTIME_SA="$(gcloud run services describe "$EXPRESS_SERVICE" --project="$PROJECT_ID" --region="$REGION" \
   --format='value(spec.template.spec.serviceAccountName)' 2>/dev/null || true)"
 if [[ -z "$RUNTIME_SA" ]]; then
   PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
@@ -90,7 +92,7 @@ if [[ -z "$RUNTIME_SA" ]]; then
 fi
 
 log "Granting roles/secretmanager.secretAccessor on ${SECRET_NAME} to ${RUNTIME_SA}"
-gcloud secrets add-iam-policy-binding "$SECRET_NAME" \
+gcloud secrets add-iam-policy-binding "$SECRET_NAME" --project="$PROJECT_ID" \
   --member="serviceAccount:${RUNTIME_SA}" \
   --role="roles/secretmanager.secretAccessor" >/dev/null
 

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -66,13 +66,14 @@ if _creds and not os.path.isabs(_creds):
 
 # Claude Code cloud environments (web sessions / scheduled routines) have no
 # key file on disk and only carry single-line env vars, so the key travels as
-# base64-encoded JSON. Materialize it to a gitignored 0600 file. A key *path*
-# that resolves to a real file wins, keeping local setups unaffected.
+# base64-encoded JSON. Keep it in memory only — never on disk — and hand it to
+# the client at construction time. A key *path* that resolves to a real file
+# wins, keeping local setups unaffected.
+_SA_INFO: dict | None = None
 _creds_b64 = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_B64")
 if _creds_b64 and not (_creds and os.path.isfile(_creds)):
     try:
-        _key_bytes = base64.b64decode(_creds_b64, validate=True)
-        json.loads(_key_bytes)
+        _SA_INFO = json.loads(base64.b64decode(_creds_b64, validate=True))
     except ValueError as exc:
         print(
             "WARNING: GOOGLE_APPLICATION_CREDENTIALS_B64 is not valid "
@@ -80,14 +81,8 @@ if _creds_b64 and not (_creds and os.path.isfile(_creds)):
             file=sys.stderr,
         )
     else:
-        _key_path = Path(__file__).resolve().parent / ".gcp-sa-key.json"
-        _fd = os.open(_key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(_fd, "wb") as _fh:
-            # mode on os.open only applies at creation — re-tighten in case a
-            # previous run (or manual copy) left the file with broader perms
-            os.fchmod(_fh.fileno(), 0o600)
-            _fh.write(_key_bytes)
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(_key_path)
+        # Clean up the key file older revisions materialized here.
+        Path(__file__).resolve().with_name(".gcp-sa-key.json").unlink(missing_ok=True)
 
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "comdottasteslikegood")
 PROJECT_NAME = f"projects/{PROJECT_ID}"
@@ -150,6 +145,16 @@ def _metrics_client():
     global _client
     with _client_lock:
         if _client is None:
+            from google.cloud import monitoring_v3
+
+            if _SA_INFO is not None:
+                from google.oauth2 import service_account
+
+                _client = monitoring_v3.MetricServiceClient(
+                    credentials=service_account.Credentials.from_service_account_info(_SA_INFO)
+                )
+                return _client
+
             creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
             if creds and not os.path.isfile(creds):
                 raise RuntimeError(
@@ -158,8 +163,6 @@ def _metrics_client():
                     "MCP env block, or supply the key as "
                     "GOOGLE_APPLICATION_CREDENTIALS_B64 (base64 of the JSON)."
                 )
-            from google.cloud import monitoring_v3
-
             _client = monitoring_v3.MetricServiceClient()
         return _client
 
@@ -564,7 +567,8 @@ def list_available_metrics(prefix: str, limit: int = 50) -> str:
         descriptors = client.list_metric_descriptors(
             request={
                 "name": PROJECT_NAME,
-                "filter": f'metric.type = starts_with("{prefix}")',
+                # Strip quotes so a stray " can't break out of the filter string
+                "filter": f'metric.type = starts_with("{prefix.replace(chr(34), "")}")',
             }
         )
         from google.api import metric_pb2
@@ -614,6 +618,8 @@ def query_metric(
         e.g. '%' for utilization ratios, 'ms' for request_latencies.
     """
     minutes_back = max(1, min(int(minutes_back), 1440))
+    # Strip quotes so a stray " can't break out of the filter string
+    metric_type = metric_type.replace('"', "")
     filter_str = f'metric.type = "{metric_type}"'
     if extra_filter:
         filter_str += f" AND {extra_filter}"

--- a/scripts/pm/publish_session_log.py
+++ b/scripts/pm/publish_session_log.py
@@ -12,7 +12,9 @@ from atlassian_pm_link import AtlassianClient, AtlassianError, load_config, mark
 
 
 def default_title(markdown_path: Path) -> str:
-    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    # Seconds precision: two logs published in the same minute would otherwise
+    # collide on Confluence's unique page-title constraint.
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     stem = markdown_path.stem.replace("_", " ").replace("-", " ").strip()
     return f"Session Log - {timestamp} - {stem}" if stem else f"Session Log - {timestamp}"
 

--- a/scripts/pm/run_pm_script.sh
+++ b/scripts/pm/run_pm_script.sh
@@ -28,8 +28,9 @@ Debian/Ubuntu example: sudo apt install python3.12-venv
 EOF
     exit 1
   fi
-  "$venv_python" -m pip install --upgrade pip >/dev/null
-  "$venv_python" -m pip install -r "$requirements"
+  # stderr so stdout stays clean for callers that parse script output
+  "$venv_python" -m pip install --upgrade pip >&2
+  "$venv_python" -m pip install -r "$requirements" >&2
 fi
 
 shift

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -102,8 +102,8 @@ export class AppComponent {
     // session — writing into a cached-but-stale authenticated session gets
     // wiped by clearStaleAuthenticatedSession() right after.
     await this.authService.ready;
-    // Ensure a guest session exists so the save persists for first-time,
-    // unauthenticated visitors arriving from an SSR page.
+    // Ensure a session exists so the save persists — a no-op for signed-in
+    // users; creates a guest for first-time visitors arriving from an SSR page.
     this.authService.ensureGuestSession();
     try {
       const response = await fetch(`/api/recipes/public/${encodeURIComponent(normalizedSlug)}`);

--- a/src/services/public-recipe.mapper.test.ts
+++ b/src/services/public-recipe.mapper.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildSavedRecipeFromPublic } from './public-recipe.mapper';
 
 describe('buildSavedRecipeFromPublic', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('preserves image fields and assigns a fresh id', () => {
     vi.stubGlobal('crypto', { randomUUID: () => 'fresh-uuid' });
 
@@ -16,8 +20,6 @@ describe('buildSavedRecipeFromPublic', () => {
     expect(recipe.id).not.toBe('public-id');
     expect(recipe.ai_image_url).toBe('https://img.example/ai.png');
     expect(recipe.stock_image_url).toBe('https://img.example/stock.jpg');
-
-    vi.unstubAllGlobals();
   });
 
   it('fills safe defaults for missing fields without inventing image urls', () => {


### PR DESCRIPTION
Sweeps the actionable comments from the Copilot/Codex/Junie/Atlassian review passes on #3030 (each verified against the code before fixing):

| Finding | Fix |
|---|---|
| SA key written to disk (gcp_mcp_server.py) | key stays in memory via `from_service_account_info`; stale key file cleaned up |
| Monitoring filter interpolation | quotes stripped from `prefix`/`metric_type` |
| `gcloud config set project` side effect | per-command `--project` (7 call sites) |
| Confluence title collision (minute precision) | seconds precision |
| pip output pollutes stdout | redirected to stderr |
| `vi.unstubAllGlobals()` skipped on assert failure | moved to `afterEach` |
| AGENTS.md "Angular 21 SPA" heading | → Angular 22 |
| parser/vitest floor drift | aligned to siblings (lockfile resolution unchanged) |
| ensureGuestSession comment wording | reflects no-op-for-signed-in behavior |

**Verified false positives (replied on the PR, no change):** ioredis v5 *does* provide the named `Redis` export (checked at runtime; type-check/build/prod all pass); the `.claude/settings.json` hook quoting is valid shell (hooks run via `sh -c`, and this hook runs today); the `.pi` MODEL_CANDIDATES list is current — the bot's suggested replacements are the outdated ones.

Verified: 46/46 tests, type-check, lint, prettier, `bash -n`, `py_compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

