### PR TITLE
release(v0.3.1): deploy hotfix — Backend pin b359743 restores runtime deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-04
+
+Deploy hotfix. The v0.3.0 tag was cut but its Cloud Build died in the `flask-backend-migrate` job (`ModuleNotFoundError: flask_cors`) before either service deployed — production kept serving v0.2.5 throughout. v0.3.1 is v0.3.0 plus the dependency fix; it is the release that actually ships the v0.3.0 feature set.
+
+### Fixed
+
+- **Backend image lost 14 runtime dependencies** (Backend [#140](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/140)): a Dependabot uv-group bump (Backend #133) regenerated `requirements.txt` — which the Dockerfile installs from — dropping flask-cors, flask-migrate, flask-sqlalchemy, alembic, psycopg2-binary, google-cloud-storage, google-cloud-pubsub, redis and more. `google-cloud-storage`/`google-cloud-pubsub`/`redis` are now declared in `pyproject.toml` (they were imported by services but never listed there), `requirements.txt` is regenerated from `uv.lock`, and a new Backend CI step fails on any future drift between the two. Backend submodule pin: `2baccf2` → `b359743`.
+
 ## [0.3.0] - 2026-07-04
 
 Feature release: server-rendered public recipe/browse pages with a styled shell and Save-to-Cookbook flow, the Angular 22 + TypeScript 6 upgrade, GCP monitoring tooling, a production Valkey TLS fix, Atlassian/PM tooling, a repository cleanup, and a batch of dependency updates.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
v0.3.0's tag-triggered Cloud Build failed at **Execute Migrate Job** and never deployed (production still on v0.2.5). Root cause + fix landed as Backend #140 — see its description. This PR makes the cookbook side of the re-release:

- Backend pin `2baccf2` → `b359743` (the dependency fix; single migration head `c60f6530f4ff` verified)
- version `0.3.0` → `0.3.1`
- CHANGELOG: new 0.3.1 section explaining the burned v0.3.0 tag

After this merges to dev, the dev→main release PR ships `v0.3.1` — which is the build that actually deploys the v0.3.0 feature set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

