### PR TITLE
fix: remove static sitemap.xml shadowing Flask's dynamic sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.tasteslikegood.org/</loc>
-    <lastmod>2026-03-20</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>


### PR DESCRIPTION
Found during post-v0.3.1 verification: https://www.tasteslikegood.org/sitemap.xml serves a hardcoded March file with only the root URL, not Flask's dynamic sitemap with /browse + all 20 public recipes. `express.static(dist)` (server/index.ts:68) matches before the SSR proxy route (line 85) because the Angular build copies `public/sitemap.xml` into dist. Removing the static file lets the request fall through to the proxy — no code change needed. The SSR/SEO work ships its full value once this deploys with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

