### PR TITLE
docs: update GBrain config block — Railway Postgres, gbrain 0.42.56.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,8 @@ Key routing rules:
 - Transcript ingest: incremental (initial bulk of 24 files done 2026-07-04)
 - Current repo policy: read-write (code imported: 134 pages, 831 chunks, embedded)
 - Trust policy: personal
-- Rollback backup: old 0.18.x brain (252 pages, last write 2026-05-07) preserved untouched in the `railway` database on the same Railway server
+- Rollback backup: old 0.18.x brain (252 pages, last write 2026-05-07)
+  preserved untouched in the `railway` database on the same Railway server
 
 ## GBrain Search Guidance (configured by /sync-gbrain)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,8 @@ Key routing rules:
 - Mode: local-stdio
 - Engine: postgres (Railway TCP proxy, dedicated `gbrain` database; schema v122)
 - gbrain version: 0.42.56.0 (reconfigured 2026-07-04 to Railway Postgres)
-- Embeddings: openai:text-embedding-3-large (1536d); chat/expansion: openai:gpt-5.2
+- Embeddings: openai:text-embedding-3-large (1536d)
+- chat/expansion: openai:gpt-5.2
 - Config file: `~/.gbrain/config.json` (mode 0600)
 - MCP registered: yes (user scope, `gbrain serve` via `~/.bun/bin/gbrain`)
 - Artifacts repo: https://github.com/adamtasteslikegood/gstack-artifacts-adam

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,14 +279,17 @@ Key routing rules:
 ## GBrain Configuration (configured by /setup-gbrain)
 
 - Mode: local-stdio
-- Engine: postgres (Supabase Session Pooler)
-- gbrain version: 0.28.6 (upgraded from 0.18.x on 2026-05-07; schema v38)
+- Engine: postgres (Railway TCP proxy, dedicated `gbrain` database; schema v122)
+- gbrain version: 0.42.56.0 (reconfigured 2026-07-04 to Railway Postgres)
+- Embeddings: openai:text-embedding-3-large (1536d); chat/expansion: openai:gpt-5.2
 - Config file: `~/.gbrain/config.json` (mode 0600)
 - MCP registered: yes (user scope, `gbrain serve` via `~/.bun/bin/gbrain`)
 - Artifacts repo: https://github.com/adamtasteslikegood/gstack-artifacts-adam
-- Artifacts sync: full
-- Current repo policy: read-write
-- Pre-upgrade backup: `~/.gstack-...-gbrain.../Backups/pg_dumps/` (Railway pg_dump, retained as rollback)
+- Artifacts sync: full (federated source `gstack-artifacts-adam`)
+- Transcript ingest: incremental (initial bulk of 24 files done 2026-07-04)
+- Current repo policy: read-write (code imported: 134 pages, 831 chunks, embedded)
+- Trust policy: personal
+- Rollback backup: old 0.18.x brain (252 pages, last write 2026-05-07) preserved untouched in the `railway` database on the same Railway server
 
 ## GBrain Search Guidance (configured by /sync-gbrain)
 


### PR DESCRIPTION
## Summary
- `/setup-gbrain` was re-run on this machine against a Railway-hosted Postgres (fresh `gbrain` database on the Railway server; **the old 0.18.x brain is preserved untouched in the `railway` database as rollback** — 252 pages, last write 2026-05-07).
- Updates the `## GBrain Configuration` block in CLAUDE.md to match reality: engine now Railway TCP proxy (schema v122), gbrain 0.42.56.0, OpenAI embeddings, artifacts sync full (federated source `gstack-artifacts-adam`), transcript ingest incremental, repo policy read-write with code imported (134 pages / 831 chunks, embedded), trust policy personal.

## Verification
- `gbrain doctor`: warnings-only (fresh-brain warnings), health 80/100, all ops checks OK, pgvector 0.8.2 installed
- Smoke test: `gbrain put` → `gbrain search` round-trip PASS
- MCP: `claude mcp list` shows `gbrain ✔ Connected` (user scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

