### PR TITLE
feat: prebuilt-venv path so gcp-monitor survives cloud routine cold starts

### DIFF
--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -70,10 +70,40 @@ as `pm-daemon`. Verify with `ps -ef | grep gcp_mcp_server`.
 Cloud sessions clone this repo, so `.mcp.json` auto-spawns `gcp-monitor`
 there too — but the cloud VM has neither your `.env` nor the key file. Cloud
 environments only carry **single-line** env vars (there is no secrets vault
-yet), so the key travels base64-encoded and the server materializes it to a
-gitignored `scripts/monitoring/.gcp-sa-key.json` (0600) at startup.
+yet), so the key travels base64-encoded; the server decodes it in memory and
+hands it straight to the Monitoring client (it never touches disk).
 
-1. Encode the key locally, straight to the clipboard (don't echo it):
+Two cloud-specific traps this section works around:
+
+- **Every routine run is a fresh VM.** Without preparation, the launcher
+  pip-installs its venv on every run (~45 s+), which loses the race against
+  the MCP client's 30 s startup timeout — the server gets killed
+  mid-bootstrap and no tools register.
+- **The environment's setup script runs _before_ the repo is cloned**, so it
+  cannot call anything in `scripts/`. It must build the venv at a fixed
+  path outside the repo; the launcher (`run_gcp_monitor.sh`) detects a
+  usable venv at `$GCP_MONITOR_VENV` or `/opt/gcp-monitor-venv` and uses it
+  instead of bootstrapping. The filesystem is snapshotted after the setup
+  script and reused by later runs (cache expires ~weekly and on
+  setup-script/network-host edits).
+
+Configure the environment on claude.ai → **Code** → environment settings:
+
+1. **Setup script** — build the venv at the fixed path (repo isn't cloned
+   yet, so the dependency list is inlined; keep it in sync with
+   `scripts/monitoring/requirements.txt`):
+
+   ```bash
+   #!/bin/bash
+   set -euo pipefail
+   python3 -m venv /opt/gcp-monitor-venv
+   /opt/gcp-monitor-venv/bin/pip install --upgrade pip
+   /opt/gcp-monitor-venv/bin/pip install 'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0'
+   chmod -R a+rX /opt/gcp-monitor-venv
+   ```
+
+2. Encode the key locally, straight to the clipboard (don't echo it —
+   and don't copy from a terminal that shows a `%` end-of-output marker):
 
    ```bash
    base64 < /path/to/monitoring-viewer.json | tr -d '\n' | wl-copy   # or xclip/pbcopy
@@ -82,19 +112,20 @@ gitignored `scripts/monitoring/.gcp-sa-key.json` (0600) at startup.
    (`tr -d '\n'` keeps this portable — GNU `base64` wraps at 76 columns by
    default and macOS/BSD `base64` has no `-w` flag.)
 
-2. On claude.ai → **Code** → the environment your routine uses → environment
-   settings → **Environment variables**, add:
+3. **Environment variables**:
 
    ```
    GOOGLE_APPLICATION_CREDENTIALS_B64=<paste the base64 blob>
    GCP_PROJECT_ID=comdottasteslikegood
+   MCP_TIMEOUT=120000
    ```
 
-   (`GCP_PROJECT_ID` is optional — it's the default.)
+   (`GCP_PROJECT_ID` is optional — it's the default. `MCP_TIMEOUT` is in
+   milliseconds and covers the slow rebuild after a snapshot-cache
+   expiry.)
 
-3. Make sure the environment's **network access** allows package installs —
-   the launcher pip-installs its venv on first run and the server calls
-   `monitoring.googleapis.com`.
+4. Make sure the environment's **network access** allows PyPI (for the
+   setup script) and `monitoring.googleapis.com` (for the server).
 
 Note: environment variables are visible to anyone who can edit that cloud
 environment, and any cloud session using it can read the key — acceptable

--- a/scripts/monitoring/run_gcp_monitor.sh
+++ b/scripts/monitoring/run_gcp_monitor.sh
@@ -8,6 +8,29 @@ venv_python="$venv_dir/bin/python"
 requirements="$mon_dir/requirements.txt"
 deps_stamp="$venv_dir/.deps-installed"
 
+# Claude Code cloud environments build the venv in the environment's setup
+# script, which runs BEFORE the repo is cloned — so it can't live at
+# $venv_dir and instead sits at a fixed path baked into the snapshot (see
+# docs/MCP_GCP_MONITORING.md). Use it when it's real, skipping the slow
+# in-repo bootstrap that races the MCP client's startup timeout.
+for prebuilt in "${GCP_MONITOR_VENV:-}" /opt/gcp-monitor-venv; do
+  prebuilt_python="$prebuilt/bin/python"
+  if [[ -n "$prebuilt" && -x "$prebuilt_python" ]] && "$prebuilt_python" - <<'EOF' 2>/dev/null
+import importlib.util as u
+import sys
+
+sys.exit(0 if u.find_spec("mcp") and u.find_spec("google.cloud.monitoring_v3") else 1)
+EOF
+  then
+    if [[ "${1:-}" == "--bootstrap-only" ]]; then
+      echo "Prebuilt venv OK: $prebuilt" >&2
+      exit 0
+    fi
+    cd "$repo_root"
+    exec "$prebuilt_python" "$mon_dir/gcp_mcp_server.py" "$@"
+  fi
+done
+
 # The stamp is written only after pip succeeds, so an interrupted first run
 # (e.g. the MCP client's startup timeout killing us mid-install) re-installs
 # on the next launch instead of exec'ing a half-built venv.


### PR DESCRIPTION
## Why

Follow-up to #3034. The B64 credential flow works, but routine runs still reported the `gcp-monitor` MCP server unavailable. Two compounding causes, confirmed against the Claude Code docs and by timing:

1. **Every routine run is a fresh VM** — the launcher's pip bootstrap takes ~45 s from scratch (measured), losing the race against the MCP client's 30 s startup timeout (`MCP_TIMEOUT`). The server is killed mid-install and never registers.
2. **Cloud environment setup scripts run *before* the repo is cloned** (the filesystem snapshot is taken repo-less), so a setup script cannot call `scripts/monitoring/run_gcp_monitor.sh --bootstrap-only` — it fails with exit 127 / "No such file or directory".

## What

- `run_gcp_monitor.sh`: before the in-repo bootstrap, check `$GCP_MONITOR_VENV` then `/opt/gcp-monitor-venv` for a venv whose python has `mcp` + `google.cloud.monitoring_v3` (via `importlib.util.find_spec`, no heavy imports). If found: `--bootstrap-only` exits 0 immediately, real launches `exec` it. Otherwise fall through to the existing behavior — local setups unchanged.
- `docs/MCP_GCP_MONITORING.md` §4 rewritten: setup script that builds `/opt/gcp-monitor-venv` (deps inlined since the repo isn't available; keep in sync with `requirements.txt`), `MCP_TIMEOUT=120000` env var for cache-expiry rebuilds, and corrected credential description (the key is held in memory since the #3037 refactor, not materialized to disk).

## Verified

- `bash -n` clean.
- Prebuilt venv + `--bootstrap-only` → "Prebuilt venv OK", exit 0.
- Prebuilt venv + real launch → server execs from the prebuilt venv, clean exit on stdin EOF.
- Invalid `GCP_MONITOR_VENV` → falls through to the existing in-repo bootstrap path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

