### PR TITLE
fix: pre-approve project MCP servers for cloud routine sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enabledMcpjsonServers": ["pm-daemon", "gcp-monitor"],
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Why

Final gap in the gcp-monitor cloud-routine chain (#3034 → #3043): the last health-check routine run had working credentials and the prebuilt venv, but the `gcp-monitor` MCP tools never registered — the routine had to call the server's functions directly via the venv.

Cause: project-scoped `.mcp.json` servers require one-time user approval before Claude Code starts them. Locally that approval was granted interactively and lives in the uncommitted `settings.local.json`; a routine's fresh cloud VM has no stored approval and no prompt, so `pm-daemon` and `gcp-monitor` are silently skipped.

## What

Add `"enabledMcpjsonServers": ["pm-daemon", "gcp-monitor"]` to the committed `.claude/settings.json` — pre-approves exactly these two servers for every session cloning the repo (cloud routines included). An explicit allowlist rather than `enableAllProjectMcpServers: true`, so arbitrary future `.mcp.json` entries still require approval.

## Verified

- `settings.json` parses as valid JSON.
- Both server names match the keys in `.mcp.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

