### PR TITLE
chore: refresh GBrain search guidance in CLAUDE.md via /sync-gbrain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ __pycache__/
 .claude/scheduled_tasks.lock
 .omg/state/
 scripts/pm/.venv/
+.gbrain-source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,7 @@ Key routing rules:
 
 - Mode: local-stdio
 - Engine: postgres (Supabase Session Pooler)
-- gbrain version: 0.28.6 (upgraded from 0.18.x on 2026-05-07; schema v38)
+- gbrain version: 0.42.56.0 (upgraded from 0.28.6 on 2026-07-04)
 - Config file: `~/.gbrain/config.json` (mode 0600)
 - MCP registered: yes (user scope, `gbrain serve` via `~/.bun/bin/gbrain`)
 - Artifacts repo: https://github.com/adamtasteslikegood/gstack-artifacts-adam
@@ -289,30 +289,51 @@ Key routing rules:
 - Pre-upgrade backup: `~/.gstack-...-gbrain.../Backups/pg_dumps/` (Railway pg_dump, retained as rollback)
 
 ## GBrain Search Guidance (configured by /sync-gbrain)
-
 <!-- gstack-gbrain-search-guidance:start -->
 
 GBrain is set up and synced on this machine. The agent should prefer gbrain
 over Grep when the question is semantic or when you don't know the exact
-identifier yet. Two indexed corpora available via the `gbrain` CLI:
+identifier yet.
 
-- This repo's code (registered as `gstack-code-<repo>` source).
+**This worktree is pinned to a worktree-scoped code source** via the
+`.gbrain-source` file in the repo root (kubectl-style context).
+`gbrain code-def`, `code-refs`, `code-callers`, `code-callees`, `search`, and
+`query` from anywhere under this worktree route to that source by default —
+no `--source` flag needed (gbrain >= 0.41.38.0; on older gbrain the call-graph
+commands need `--source "$(cat .gbrain-source)"`). Conductor sibling worktrees
+of the same repo each have their own pin and their own indexed pages, so
+semantic results match the code on disk here.
+
+Call-graph queries (`code-callers`/`code-callees`) also need the graph to be
+built first — run `/sync-gbrain --dream` (or `--full`) if they return
+`count: 0`. This only works if this source's gbrain schema pack extracts code
+symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
+and reports a WARN. `code-def`/`code-refs` need the same extraction.
+
+Two indexed corpora available via the `gbrain` CLI:
+- This worktree's code (auto-pinned via `.gbrain-source`).
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
 Prefer gbrain when:
-
 - "Where is X handled?" / semantic intent, no exact string yet:
-  `gbrain search "<terms>"` or `gbrain query "<question>"`
+    `gbrain search "<terms>"` or `gbrain query "<question>"`
 - "Where is symbol Y defined?" / symbol-based code questions:
-  `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
+    `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
 - "What calls Y?" / "What does Y depend on?":
-  `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+    `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
 - "What did we decide last time?" / past plans, retros, learnings:
-  `gbrain search "<terms>" --source gstack-brain-<user>`
+    `gbrain search "<terms>" --source gstack-brain-<user>`
 
 Grep is still right for known exact strings, regex, multiline patterns, and
-file globs. The brain auto-syncs incrementally on every gstack skill start.
-Run `/sync-gbrain` to force-refresh, `/sync-gbrain --full` for full reindex.
+file globs. Run `/sync-gbrain` after meaningful code changes; for ongoing
+auto-sync across all worktrees, run `gbrain autopilot --install` once per
+machine — gbrain's daemon handles incremental refresh on a schedule.
+
+Safety: don't run `/sync-gbrain` while `gbrain autopilot` is active — the
+orchestrator refuses destructive source ops when it detects a running autopilot
+to avoid racing it (#1734). Prefer registering user repos with `gbrain sources
+add --path <dir>` (no `--url`): URL-managed sources can auto-reclone, and the
+sync code walk for them requires an explicit `--allow-reclone` opt-in.
 
 <!-- gstack-gbrain-search-guidance:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,7 @@ Key routing rules:
 - Pre-upgrade backup: `~/.gstack-...-gbrain.../Backups/pg_dumps/` (Railway pg_dump, retained as rollback)
 
 ## GBrain Search Guidance (configured by /sync-gbrain)
+
 <!-- gstack-gbrain-search-guidance:start -->
 
 GBrain is set up and synced on this machine. The agent should prefer gbrain
@@ -311,19 +312,21 @@ symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
 and reports a WARN. `code-def`/`code-refs` need the same extraction.
 
 Two indexed corpora available via the `gbrain` CLI:
+
 - This worktree's code (auto-pinned via `.gbrain-source`).
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
 Prefer gbrain when:
+
 - "Where is X handled?" / semantic intent, no exact string yet:
-    `gbrain search "<terms>"` or `gbrain query "<question>"`
+  `gbrain search "<terms>"` or `gbrain query "<question>"`
 - "Where is symbol Y defined?" / symbol-based code questions:
-    `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
+  `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
 - "What calls Y?" / "What does Y depend on?":
-    `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+  `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
 - "What did we decide last time?" / past plans, retros, learnings:
-    `gbrain search "<terms>" --source gstack-brain-<user>`
+  `gbrain search "<terms>" --source gstack-brain-<user>`
 
 Grep is still right for known exact strings, regex, multiline patterns, and
 file globs. Run `/sync-gbrain` after meaningful code changes; for ongoing


### PR DESCRIPTION
## Summary

Refreshes the machine-generated GBrain sections of `CLAUDE.md` after running `/sync-gbrain`, which did the repo's first full code index (84 files, 822 chunks) and pinned this checkout to a worktree-scoped source.

- **`## GBrain Search Guidance` block** — replaced with the current skill version: worktree-scoped `.gbrain-source` pinning (kubectl-style context), call-graph build guidance (`/sync-gbrain --dream`), schema-pack caveats, and autopilot/source-registration safety notes. This block is verbatim skill-managed content between HTML markers; `/sync-gbrain` rewrites it on each run.
- **`## GBrain Configuration`** — recorded gbrain version updated `0.28.6` → `0.42.56.0` (upgraded 2026-07-04) so the config section no longer contradicts the guidance block's `>= 0.41.38.0` routing requirement.
- **`.gitignore`** — adds `.gbrain-source` (machine-local worktree pin written by the gstack orchestrator; exact unanchored form kept for orchestrator idempotency).

## Test Coverage

No application code changed — no new code paths to audit.

## Pre-Landing Review

No issues found (docs/config-only diff; no checklist category applies).

**Adversarial review (Claude subagent):** 5 findings triaged —
- [FIXED] Stale `gbrain version: 0.28.6` line contradicted the new block's `>= 0.41.38.0` requirement → updated to the installed 0.42.56.0.
- [WON'T FIX] 3 doc-content suggestions (missing-pin fallback, staleness check, autopilot race detection) target the verbatim skill-managed block — hand-edits there are overwritten by the next `/sync-gbrain` run, and the gstack skill preambles already handle the unpinned case (falls back to Grep).
- [WON'T FIX] Anchoring `.gitignore` entry as `/.gbrain-source` — kept the orchestrator's canonical form so its idempotency check doesn't re-add a duplicate.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — intent was "commit the /sync-gbrain output"; diff is exactly those two files plus the one review fix.

## Plan Completion

No plan file detected.

## Test plan

- [x] Vitest server suite passes (47 tests, 3 files) — re-run fresh after the review fix
- [x] Live-verified the documented behavior: `.gbrain-source` pin exists and is ignored, `gbrain code-def`/`code-callers` return results, write+search capability round-trip OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)













<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

