### PR TITLE
fix: harden gcp-monitor cloud setup script against transient PyPI timeouts

### DIFF
--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -91,16 +91,27 @@ Configure the environment on claude.ai → **Code** → environment settings:
 
 1. **Setup script** — build the venv at the fixed path (repo isn't cloned
    yet, so the dependency list is inlined; keep it in sync with
-   `scripts/monitoring/requirements.txt`):
+   `scripts/monitoring/requirements.txt`). PyPI reads from the cloud VM
+   time out sporadically, so the install retries and the final import
+   check is what actually gates success:
 
    ```bash
    #!/bin/bash
    set -euo pipefail
    python3 -m venv /opt/gcp-monitor-venv
-   /opt/gcp-monitor-venv/bin/pip install --upgrade pip
-   /opt/gcp-monitor-venv/bin/pip install 'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0'
+   for attempt in 1 2 3; do
+     /opt/gcp-monitor-venv/bin/pip install --retries 10 --timeout 60 \
+       'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0' && break
+     echo "pip attempt $attempt failed; retrying in 10s" >&2
+     sleep 10
+   done
+   /opt/gcp-monitor-venv/bin/python -c 'import importlib.util as u, sys; sys.exit(0 if u.find_spec("mcp") and u.find_spec("google.cloud.monitoring_v3") else 1)'
    chmod -R a+rX /opt/gcp-monitor-venv
    ```
+
+   (No `pip install --upgrade pip` — the venv's bundled pip installs these
+   wheels fine, and every extra download is another chance to hit a
+   transient timeout.)
 
 2. Encode the key locally, straight to the clipboard (don't echo it —
    and don't copy from a terminal that shows a `%` end-of-output marker):

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -102,8 +102,8 @@ Configure the environment on claude.ai → **Code** → environment settings:
    for attempt in 1 2 3; do
      /opt/gcp-monitor-venv/bin/pip install --retries 10 --timeout 60 \
        'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0' && break
-     echo "pip attempt $attempt failed; retrying in 10s" >&2
-     sleep 10
+     echo "pip attempt $attempt of 3 failed" >&2
+     if [[ "$attempt" -lt 3 ]]; then sleep 10; fi
    done
    /opt/gcp-monitor-venv/bin/python -c 'import importlib.util as u, sys; sys.exit(0 if u.find_spec("mcp") and u.find_spec("google.cloud.monitoring_v3") else 1)'
    chmod -R a+rX /opt/gcp-monitor-venv


### PR DESCRIPTION
## Why

A cloud environment snapshot rebuild failed with `ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org') Read timed out` during the documented setup script. With `set -euo pipefail`, a single flaky PyPI read kills the whole script and the environment build.

## What

Docs-only — hardens the canonical setup script in `docs/MCP_GCP_MONITORING.md` §4:

- Wrap the install in a 3-attempt retry loop with `--retries 10 --timeout 60` (pip defaults are 5 / 15 s).
- Gate success on a final `find_spec` import check (same check the launcher uses), so a partially failed install can't produce a "successful" snapshot.
- Drop `pip install --upgrade pip` — the bundled pip installs these wheels fine and the extra download was the failure surface in the observed crash (the traceback shows pip 24.0 dying mid-download).

## Verified

Extracted the script verbatim from the doc, ran it against a temp path: exit 0, and `import mcp, google.cloud.monitoring_v3` succeeds in the resulting venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

