### PR TITLE
fix: proxy /static/* to Flask so SSR public pages get their stylesheets

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,8 @@ import {
 import { createFlaskProxy } from './proxy.js';
 import { createValkeyClient, shutdownValkey } from './valkey.js';
 
-const app = express();
+// Exported for route-mounting integration tests (server/routes.test.ts).
+export const app = express();
 const port = Number.parseInt(process.env.PORT || '8080', 10);
 const flaskUrl = process.env.FLASK_BACKEND_URL || 'http://localhost:5000';
 
@@ -24,7 +25,9 @@ app.set('trust proxy', 1);
 let server: Server | null = null;
 
 // ── Async startup ───────────────────────────────────────────────
-(async () => {
+// Exported so tests can await route mounting; under Vitest the routes are
+// mounted but the HTTP listener is not started (tests call app.listen(0)).
+export const ready = (async () => {
   // Connect to Valkey for shared rate limiting (falls back to in-memory)
   const valkeyClient = await createValkeyClient();
 
@@ -83,6 +86,13 @@ let server: Server | null = null;
   app.get('/r/*splat', staticPageLimiter, ssrProxy);
   app.get('/browse', staticPageLimiter, ssrProxy);
   app.get('/sitemap.xml', staticPageLimiter, ssrProxy);
+  // The SSR templates link their stylesheets via Flask's /static/ (e.g.
+  // /static/css/tokens.css). Without this route those requests fall through
+  // to the SPA catch-all, which answers with index.html as text/html — and
+  // Helmet's X-Content-Type-Options: nosniff makes browsers refuse to apply
+  // it, so the public pages render completely unstyled. Mounted after
+  // express.static so Angular build assets (if any collide) still win.
+  app.get('/static/*splat', staticPageLimiter, ssrProxy);
 
   app.get('{*path}', staticPageLimiter, (_req, res) => {
     res.sendFile(path.join(distPath, 'index.html'));
@@ -91,13 +101,17 @@ let server: Server | null = null;
   // Error handling middleware (must be last)
   app.use(createErrorHandler());
 
+  if (process.env.VITEST) return;
+
   server = app.listen(port, () => {
     console.log(`Server listening on port ${port}`);
     console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
     console.log(`Flask backend → ${flaskUrl}`);
     console.log(`Rate limit store: ${valkeyClient ? 'Valkey' : 'in-memory'}`);
   });
-})().catch((err) => {
+})();
+
+ready.catch((err) => {
   console.error('Fatal error during server startup:', err);
   process.exit(1);
 });

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Route-mounting integration tests for server/index.ts.
+ *
+ * Production incident 2026-07-04 (v0.3.1): the Flask SSR templates link
+ * their stylesheets at /static/css/*.css, but Express had no proxy rule for
+ * /static — the requests fell through to the SPA catch-all and came back as
+ * index.html (text/html). With Helmet's X-Content-Type-Options: nosniff the
+ * browser refuses to apply a text/html stylesheet, so every public SSR page
+ * rendered completely unstyled.
+ *
+ * These tests boot the real Express app against a stub Flask backend and
+ * assert that /static/* is proxied to Flask (not swallowed by the SPA
+ * fallback), alongside the pre-existing SSR routes.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+const STUB_CSS = ':root { --tokens: loaded; }';
+const STUB_HTML = '<!doctype html><html><body>ssr-browse</body></html>';
+
+let flaskStub: http.Server;
+let expressServer: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  // Stub Flask backend: serves the SSR stylesheet and browse page.
+  flaskStub = http.createServer((req, res) => {
+    if (req.url === '/static/css/tokens.css') {
+      res.writeHead(200, { 'content-type': 'text/css; charset=utf-8' });
+      res.end(STUB_CSS);
+    } else if (req.url === '/browse') {
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(STUB_HTML);
+    } else {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end('{"error": "not found"}');
+    }
+  });
+  await new Promise<void>((resolve) => flaskStub.listen(0, '127.0.0.1', resolve));
+  const flaskPort = (flaskStub.address() as AddressInfo).port;
+
+  // Must be set before importing index.ts — proxy.ts reads it at import time.
+  process.env.FLASK_BACKEND_URL = `http://127.0.0.1:${flaskPort}`;
+
+  const { app, ready } = await import('./index.js');
+  await ready;
+
+  expressServer = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => expressServer.once('listening', resolve));
+  baseUrl = `http://127.0.0.1:${(expressServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => expressServer.close(() => resolve()));
+  await new Promise<void>((resolve) => flaskStub.close(() => resolve()));
+});
+
+describe('SSR static asset proxying', () => {
+  it('proxies /static/* to Flask so SSR stylesheets are served as CSS', async () => {
+    const res = await fetch(`${baseUrl}/static/css/tokens.css`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/css');
+    expect(await res.text()).toBe(STUB_CSS);
+  });
+
+  it('does not serve the SPA index.html for /static/* requests', async () => {
+    const res = await fetch(`${baseUrl}/static/css/tokens.css`);
+    const body = await res.text();
+    expect(res.headers.get('content-type')).not.toContain('text/html');
+    expect(body).not.toContain('<!doctype html>');
+  });
+
+  it('proxies unknown /static/* paths to Flask (404 from Flask, not SPA 200)', async () => {
+    const res = await fetch(`${baseUrl}/static/does-not-exist.css`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('SSR page proxying (guard against regressions)', () => {
+  it('proxies /browse to Flask', async () => {
+    const res = await fetch(`${baseUrl}/browse`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(STUB_HTML);
+  });
+});


### PR DESCRIPTION
## Problem

Since v0.3.1 went live, the SSR public recipe pages (`/r/<slug>`, `/browse`) render **completely unstyled** — mobile shows the bare no-CSS page, desktop just shows default fonts.

Confirmed live:

```
$ curl -sI https://www.tasteslikegood.org/static/css/tokens.css
content-type: text/html; charset=utf-8   ← the SPA index.html, not CSS
x-content-type-options: nosniff
```

The Flask SSR templates (`Backend/templates/public/base_public.html`) link `/static/css/tokens.css` and `/static/css/recipe-site.css`, but `server/index.ts` only proxied `/r/*`, `/browse`, and `/sitemap.xml` to Flask. `/static/*` fell through to the SPA catch-all, which answers `index.html` as `text/html` with HTTP 200 — and Helmet's `nosniff` makes every browser refuse to apply a `text/html` stylesheet. So the pages ship with zero CSS on all devices; the desktop/mobile difference the user saw is just different UA default rendering of the same unstyled page.

## Fix

- **`server/index.ts`** — proxy `GET /static/*` to Flask through the existing `ssrProxy`, mounted after `express.static` so Angular build assets (if any ever collide) still win, before the SPA catch-all. Also exports `app` + `ready` and skips `listen()` under Vitest so route mounting is integration-testable.
- **`server/routes.test.ts`** — boots the real Express app against a stub Flask backend: asserts `/static/css/tokens.css` comes back as `text/css` with the stub body (not the SPA shell), unknown `/static/*` paths surface Flask's 404 (not a SPA 200), and `/browse` proxying still works.

## Verification

- New tests **fail without the route** (`× proxies /static/* to Flask…`) and pass with it.
- Full suite: 51 passed (4 files). `npm run type-check` and `npm run lint` clean.

Sibling PR for the other v0.3.1 regression (async generation retries): adamtasteslikegood/tasteslikegood.com#141

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

