### PR TITLE
chore: harden test-mode listen guard (post-merge review of #3047)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -101,7 +101,9 @@ export const ready = (async () => {
   // Error handling middleware (must be last)
   app.use(createErrorHandler());
 
-  if (process.env.VITEST) return;
+  // Skip the real listener under test runners: Vitest sets VITEST itself,
+  // and NODE_ENV=test covers any other harness importing this module.
+  if (process.env.VITEST || process.env.NODE_ENV === 'test') return;
 
   server = app.listen(port, () => {
     console.log(`Server listening on port ${port}`);

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -23,6 +23,10 @@ let flaskStub: http.Server;
 let expressServer: http.Server;
 let baseUrl: string;
 
+// Captured so the env overrides below can be restored for other test files.
+const originalVitestEnv = process.env.VITEST;
+const originalFlaskUrl = process.env.FLASK_BACKEND_URL;
+
 beforeAll(async () => {
   // Stub Flask backend: serves the SSR stylesheet and browse page.
   flaskStub = http.createServer((req, res) => {
@@ -42,6 +46,9 @@ beforeAll(async () => {
 
   // Must be set before importing index.ts — proxy.ts reads it at import time.
   process.env.FLASK_BACKEND_URL = `http://127.0.0.1:${flaskPort}`;
+  // Vitest sets this itself, but make the dependency explicit: index.ts must
+  // see it (or NODE_ENV=test) to skip binding the real listener on import.
+  process.env.VITEST = process.env.VITEST || 'true';
 
   const { app, ready } = await import('./index.js');
   await ready;
@@ -52,6 +59,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (originalVitestEnv === undefined) {
+    delete process.env.VITEST;
+  } else {
+    process.env.VITEST = originalVitestEnv;
+  }
+  if (originalFlaskUrl === undefined) {
+    delete process.env.FLASK_BACKEND_URL;
+  } else {
+    process.env.FLASK_BACKEND_URL = originalFlaskUrl;
+  }
   await new Promise<void>((resolve) => expressServer.close(() => resolve()));
   await new Promise<void>((resolve) => flaskStub.close(() => resolve()));
 });


### PR DESCRIPTION
Addresses the three Copilot comments that landed on #3047 after it merged:

- **`server/index.ts`** — the listener is now skipped when `NODE_ENV === 'test'` as well as under `VITEST`, so import-time tests can't accidentally bind the real port if the runner env changes.
- **`server/routes.test.ts`** — sets `process.env.VITEST` explicitly before the dynamic import (the dependency is now self-contained rather than relying on Vitest's implicit env), and captures + restores the original `VITEST` and `FLASK_BACKEND_URL` values in `afterAll` so other test files are unaffected.

Verification: 51 tests pass, `npm run type-check` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

