### PR TITLE
chore: bump Backend to ef594bf — async generation retry fix (#141)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -103,6 +103,8 @@ jobs:
         run: uv sync
       - name: Run pytest
         working-directory: Backend
+        env:
+          PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest
 
   # ── Changelog ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Submodule pointer bump pulling in Backend PR adamtasteslikegood/tasteslikegood.com#141 (merged): in-process retries for async recipe generation when `gemini-3.1-pro-preview` returns malformed/truncated JSON, plus real error messages in place of "Unknown error". This is the Backend half of the post-v0.3.1 regression pair (the Express half was #3047, already merged).

Pre-bump checks per CLAUDE.md:
- `git -C Backend log b359743..origin/dev` → only the #141 merge (ef594bf)
- No changes under `migrations/` — `flask db heads` prints exactly one head (`c60f6530f4ff`)

With this + #3047 (+ #3048 test hardening) on dev, both v0.3.1 regressions are release-ready for v0.3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)












<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

