### PR TITLE
ci: run lint/test/build gate on PRs targeting dev

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,7 +12,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
-    branches: [main]
+    branches: [main, dev, 'dev/**']
 
 jobs:
   install:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -10,7 +10,7 @@ name: PR Gate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev, 'dev/**']
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:


### PR DESCRIPTION
## What

Add `dev` and `dev/**` to the `pull_request.branches` trigger in both `ci-cd.yml` and `pr-gate.yml`, so PRs targeting `dev` run the same quality gate as PRs targeting `main`.

## Why

Currently only CodeQL, Prettier, and automated reviewers fire on `dev`-targeted PRs. The actual lint/type-check/test/build suite only runs against `main`. This means proposed version bumps (and any other `dev` PR) land without CI verification.

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci-cd.yml` | `pull_request.branches: [main]` → `[main, dev, 'dev/**']` |
| `.github/workflows/pr-gate.yml` | same |

## Notes

- The `push` triggers are unchanged
- `ci.yml` already covers `dev` pushes/PRs — this just brings `ci-cd.yml` and `pr-gate.yml` in line
- Spotted during health-check review of PR #3047, which had no CI coverage because it targeted `dev`



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

