### PR TITLE
feat(gcp-monitor): serve monitoring tools over authenticated HTTP for a Cloud Run connector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ Project MCP servers are declared in `.mcp.json` at the repo root. When Claude Co
 
 - `gcp-monitor` — runs `scripts/monitoring/run_gcp_monitor.sh`, which creates its venv on first run, then launches `scripts/monitoring/gcp_mcp_server.py`. Exposes read-only Cloud Monitoring tools (`check_system_health`, `list_available_metrics`, `query_metric`) covering the production stack (Cloud Run frontend/backend, Cloud SQL, Valkey, Pub/Sub). Requires `GOOGLE_APPLICATION_CREDENTIALS` (+ optional `GCP_PROJECT_ID`) in `.env`; without them the tools register but return a credential error instead of metrics. The `/system-health-check` skill (`.claude/skills/system-health-check/`) drives the full SRE health-report routine. Setup: `docs/MCP_GCP_MONITORING.md`.
 
+  **Cloud sessions & routines** don't spawn `.mcp.json` stdio servers (their tool registry only wires up remote connectors), so `gcp-monitor` is unreachable there via stdio — routines have to invoke the script directly as a workaround. The same server also runs over authenticated Streamable HTTP (`MCP_TRANSPORT=http`): deploy it to Cloud Run with `scripts/monitoring/deploy_mcp_cloud_run.sh` (keyless — runs as a `roles/monitoring.viewer` SA via ADC, no base64 key; bearer-token auth from a Secret Manager `MCP_AUTH_TOKEN`) and register the printed `/mcp` URL as a Claude **custom connector**. Routines then get the tools first-class. See `docs/MCP_GCP_MONITORING.md` § 4.5.
+
 Requirements for `pm-daemon` to actually sync:
 
 - `.env` (project root) must contain `ATLASSIAN_EMAIL` and `ATLASSIAN_API_TOKEN`. Without them the MCP tools register but Confluence sync logs `WARNING: Atlassian credentials missing` and no-ops.

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -101,7 +101,7 @@ Configure the environment on claude.ai → **Code** → environment settings:
    python3 -m venv /opt/gcp-monitor-venv
    for attempt in 1 2 3; do
      /opt/gcp-monitor-venv/bin/pip install --retries 10 --timeout 60 \
-       'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0' && break
+       'mcp>=1.10.0' 'google-cloud-monitoring>=2.21.0' && break
      echo "pip attempt $attempt of 3 failed" >&2
      if [[ "$attempt" -lt 3 ]]; then sleep 10; fi
    done
@@ -144,6 +144,83 @@ here because the service account is read-only (`roles/monitoring.viewer`),
 but don't reuse this pattern for write-capable credentials. A key _path_ in
 `GOOGLE_APPLICATION_CREDENTIALS` that resolves to a real file always wins
 over the B64 var, so local setups are unaffected.
+
+> **Better option for cloud sessions & routines:** the stdio path above is
+> fragile in the cloud — Claude Code's cloud/routine environment does **not**
+> spawn the `.mcp.json` stdio servers at all (only remote connectors show up
+> there), so routines fall back to invoking the script directly. Section 4.5
+> hosts the same server as a remote connector and removes that whole class of
+> problem, along with the base64 key.
+
+## 4.5. Hosted remote connector (Cloud Run) — recommended for cloud/routines
+
+The same `gcp_mcp_server.py` also serves its tools over **authenticated
+Streamable HTTP** (`MCP_TRANSPORT=http`). Hosted on Cloud Run and registered as
+a Claude **custom connector**, it becomes a first-class tool in exactly the
+place the stdio path can't reach: web sessions and scheduled routines, whose
+tool registry only wires up remote connectors.
+
+Two wins over the stdio/base64 setup:
+
+- **Keyless.** The Cloud Run service runs _as_ a service account with
+  `roles/monitoring.viewer`; the Monitoring client picks up ADC. There is no
+  key file and no `GOOGLE_APPLICATION_CREDENTIALS_B64` — nothing to leak from an
+  environment-variable pane.
+- **Headless-safe auth.** The connector carries a static bearer token on every
+  request (no interactive OAuth grant that a non-interactive routine might not
+  have), so it behaves identically in a routine and on your desktop.
+
+### Deploy
+
+One idempotent script provisions the service account, the token secret, and the
+Cloud Run service:
+
+```bash
+scripts/monitoring/deploy_mcp_cloud_run.sh
+# override defaults if needed:
+PROJECT_ID=comdottasteslikegood REGION=us-central1 \
+  scripts/monitoring/deploy_mcp_cloud_run.sh
+```
+
+It prints the connector URL (`https://<service-url>/mcp`) and the command to
+read the generated token:
+
+```bash
+gcloud secrets versions access latest --secret=MCP_AUTH_TOKEN --project=comdottasteslikegood
+```
+
+Ingress is public because Claude's servers must reach it and can't authenticate
+with GCP IAM — **the bearer token is the access control.** It gates every
+request except `/healthz` (an unauthenticated liveness probe that reveals
+nothing); the server refuses to start in HTTP mode if `MCP_AUTH_TOKEN` is unset,
+so it can never accidentally serve metrics open. Rotate by adding a new secret
+version and re-running the deploy script.
+
+### Register the connector in Claude
+
+In Claude (Settings → Connectors → Add custom connector), point it at the
+`/mcp` URL and set the auth header:
+
+```
+URL:            https://<service-url>/mcp
+Authorization:  Bearer <token from MCP_AUTH_TOKEN>
+```
+
+Once connected, `check_system_health`, `list_available_metrics`, and
+`query_metric` appear as tools in cloud sessions and routines — no `.mcp.json`,
+no venv, no base64 key. The `/system-health-check` skill drives them the same
+way it drives the stdio server.
+
+### Run the HTTP server locally (optional)
+
+```bash
+MCP_TRANSPORT=http MCP_AUTH_TOKEN=dev-secret PORT=8080 \
+  scripts/monitoring/run_gcp_monitor.sh --http
+curl -s localhost:8080/healthz   # -> ok
+```
+
+Local runs still resolve credentials the normal way (`.env` key path or
+`GOOGLE_APPLICATION_CREDENTIALS_B64`); only Cloud Run relies on ADC.
 
 ## 5. Claude Desktop
 

--- a/scripts/monitoring/.dockerignore
+++ b/scripts/monitoring/.dockerignore
@@ -1,0 +1,10 @@
+# Keep the build context minimal — only the server + its requirements are
+# needed. Everything else in scripts/monitoring/ (venvs, launcher, stamps) is
+# for the stdio path and must not bloat or leak into the image.
+.venv/
+__pycache__/
+*.pyc
+.deps-installed
+.gcp-sa-key.json
+run_gcp_monitor.sh
+deploy_mcp_cloud_run.sh

--- a/scripts/monitoring/Dockerfile
+++ b/scripts/monitoring/Dockerfile
@@ -1,0 +1,33 @@
+# Hosted GCP monitoring MCP server for Cloud Run.
+#
+# Build context is this directory (scripts/monitoring/):
+#   gcloud run deploy gcp-monitor-mcp --source scripts/monitoring ...
+# or via scripts/monitoring/deploy_mcp_cloud_run.sh.
+#
+# The container serves the read-only Cloud Monitoring tools over authenticated
+# Streamable HTTP so Claude can reach them as a custom connector. On Cloud Run
+# it runs as a service account with roles/monitoring.viewer, so the Monitoring
+# client authenticates via ADC — there is NO key file or GOOGLE_APPLICATION_
+# CREDENTIALS_B64 in the image or its env.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Dependencies first for layer caching.
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY gcp_mcp_server.py ./gcp_mcp_server.py
+
+# HTTP transport; Cloud Run overrides PORT and injects MCP_AUTH_TOKEN + secrets.
+ENV MCP_TRANSPORT=http \
+    PORT=8080 \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+
+# Run as a non-root user (Cloud Run does not require it, but defense in depth).
+RUN useradd --create-home --uid 10001 appuser
+USER appuser
+
+CMD ["python", "gcp_mcp_server.py"]

--- a/scripts/monitoring/deploy_mcp_cloud_run.sh
+++ b/scripts/monitoring/deploy_mcp_cloud_run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Deploy the GCP monitoring MCP server to Cloud Run as an authenticated remote
+# connector. Idempotent — safe to re-run to roll out a new revision.
+#
+# What it provisions (only what's missing):
+#   1. A dedicated service account with roles/monitoring.viewer. The Cloud Run
+#      service runs AS this SA, so the Monitoring client authenticates via ADC.
+#      No key file, no GOOGLE_APPLICATION_CREDENTIALS_B64 anywhere.
+#   2. A Secret Manager secret (MCP_AUTH_TOKEN) holding the shared bearer token
+#      Claude presents on every request. Generated on first run if absent.
+#   3. The Cloud Run service itself, built from scripts/monitoring/Dockerfile.
+#
+# Ingress is public (Claude's servers must reach it and cannot do GCP IAM), so
+# the bearer token IS the access control. Rotate it by adding a new secret
+# version and redeploying.
+#
+# Usage:
+#   scripts/monitoring/deploy_mcp_cloud_run.sh
+#   PROJECT_ID=comdottasteslikegood REGION=us-central1 \
+#     scripts/monitoring/deploy_mcp_cloud_run.sh
+#
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-${GCP_PROJECT_ID:-comdottasteslikegood}}"
+REGION="${REGION:-us-central1}"
+SERVICE="${SERVICE:-gcp-monitor-mcp}"
+SA_NAME="${SA_NAME:-gcp-monitor-mcp}"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+SECRET_NAME="${SECRET_NAME:-MCP_AUTH_TOKEN}"
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Project:  $PROJECT_ID"
+echo "Region:   $REGION"
+echo "Service:  $SERVICE"
+echo "SA:       $SA_EMAIL"
+echo
+
+# ── 1. Service account + roles/monitoring.viewer ────────────────────────────
+if ! gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "Creating service account $SA_EMAIL"
+  gcloud iam service-accounts create "$SA_NAME" \
+    --project "$PROJECT_ID" \
+    --display-name "GCP monitoring MCP connector (read-only)"
+else
+  echo "Service account $SA_EMAIL already exists"
+fi
+
+echo "Ensuring roles/monitoring.viewer on $SA_EMAIL"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:$SA_EMAIL" \
+  --role roles/monitoring.viewer \
+  --condition None >/dev/null
+
+# ── 2. Bearer token secret ──────────────────────────────────────────────────
+if ! gcloud secrets describe "$SECRET_NAME" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "Creating secret $SECRET_NAME with a freshly generated token"
+  gcloud secrets create "$SECRET_NAME" \
+    --project "$PROJECT_ID" \
+    --replication-policy automatic
+  # 32 random bytes, URL-safe — plenty for a bearer secret.
+  openssl rand -base64 32 | tr -d '\n' | tr '+/' '-_' \
+    | gcloud secrets versions add "$SECRET_NAME" --project "$PROJECT_ID" --data-file=-
+  echo "Generated a new token — retrieve it for the connector config with:"
+  echo "  gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"
+else
+  echo "Secret $SECRET_NAME already exists (reusing current token)"
+fi
+
+# Let the runtime SA read the token at container start.
+gcloud secrets add-iam-policy-binding "$SECRET_NAME" \
+  --project "$PROJECT_ID" \
+  --member "serviceAccount:$SA_EMAIL" \
+  --role roles/secretmanager.secretAccessor \
+  --condition None >/dev/null
+
+# ── 3. Deploy the Cloud Run service ─────────────────────────────────────────
+echo "Deploying $SERVICE from $SOURCE_DIR"
+gcloud run deploy "$SERVICE" \
+  --project "$PROJECT_ID" \
+  --region "$REGION" \
+  --source "$SOURCE_DIR" \
+  --service-account "$SA_EMAIL" \
+  --set-env-vars "MCP_TRANSPORT=http,GCP_PROJECT_ID=$PROJECT_ID" \
+  --set-secrets "MCP_AUTH_TOKEN=${SECRET_NAME}:latest" \
+  --allow-unauthenticated \
+  --min-instances 0 \
+  --cpu 1 \
+  --memory 512Mi \
+  --port 8080 \
+  --quiet
+
+URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT_ID" --region "$REGION" --format 'value(status.url)')"
+echo
+echo "Deployed. Register this as a Claude custom connector:"
+echo "  MCP server URL : ${URL}/mcp"
+echo "  Auth header    : Authorization: Bearer <token from secret $SECRET_NAME>"
+echo
+echo "Token: gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -16,18 +16,42 @@ GOOGLE_APPLICATION_CREDENTIALS. `roles/monitoring.viewer` is sufficient for
 every tool in this server — Pub/Sub metrics are read through the Monitoring
 API, not the Pub/Sub admin API.
 
+Transports:
+    stdio (default)     for local `.mcp.json` spawns and Claude Desktop.
+    streamable-http     for a hosted remote MCP server registered as a Claude
+                        custom connector — the only kind of MCP server that
+                        Claude Code's cloud/routine environment wires up (it
+                        does not spawn the stdio servers from `.mcp.json`). Set
+                        MCP_TRANSPORT=http (or pass --http). See
+                        docs/MCP_GCP_MONITORING.md § "Hosted remote connector".
+
 Configuration (env vars, or repo-root `.env`):
     GOOGLE_APPLICATION_CREDENTIALS      path to the service-account JSON key
     GOOGLE_APPLICATION_CREDENTIALS_B64  base64 of the key JSON itself — for
                                         Claude Code cloud environments, which
                                         only carry single-line env vars; used
-                                        when no key file path resolves
+                                        when no key file path resolves. NOT
+                                        needed on Cloud Run, where the service
+                                        runs as a service account and the
+                                        Monitoring client picks up ADC.
     GCP_PROJECT_ID                  defaults to comdottasteslikegood
     EXPRESS_SERVICE / FLASK_SERVICE / CLOUDSQL_INSTANCE  resource overrides
+
+HTTP-transport-only configuration:
+    MCP_TRANSPORT                   'http'/'streamable-http' to serve over HTTP;
+                                    anything else (default) uses stdio.
+    MCP_AUTH_TOKEN                  shared secret required on every request as
+                                    `Authorization: Bearer <token>`. Mandatory
+                                    in HTTP mode — the server refuses to start
+                                    without it rather than expose metrics
+                                    unauthenticated.
+    PORT                            listen port in HTTP mode (default 8080;
+                                    Cloud Run injects this).
 """
 
 import base64
 import datetime
+import hmac
 import json
 import os
 import sys
@@ -641,5 +665,83 @@ def query_metric(
     return "\n".join(lines) or f"No data for {metric_type} in the last {minutes_back} min."
 
 
+class _BearerAuthMiddleware:
+    """Pure-ASGI gate requiring `Authorization: Bearer <token>` on HTTP requests.
+
+    Implemented as raw ASGI (not Starlette's BaseHTTPMiddleware) so it never
+    buffers the streaming/SSE responses the MCP transport relies on. Non-HTTP
+    scopes (lifespan, websocket) and exempt paths pass straight through.
+    """
+
+    def __init__(self, app, token: str, exempt_paths: frozenset[str]):
+        self.app = app
+        self._expected = f"Bearer {token}"
+        self.exempt_paths = exempt_paths
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or scope.get("path") in self.exempt_paths:
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers") or [])
+        presented = headers.get(b"authorization", b"").decode("latin-1")
+        # Constant-time compare so a wrong token can't be recovered by timing.
+        if hmac.compare_digest(presented, self._expected):
+            await self.app(scope, receive, send)
+            return
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"www-authenticate", b'Bearer realm="gcp-monitor"'),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"error":"unauthorized"}'})
+
+
+def _run_http() -> None:
+    """Serve the MCP tools over authenticated Streamable HTTP (for Cloud Run)."""
+    token = os.environ.get("MCP_AUTH_TOKEN")
+    if not token:
+        print(
+            "FATAL: MCP_AUTH_TOKEN is unset. Refusing to serve the monitoring "
+            "tools over HTTP without authentication. Set MCP_AUTH_TOKEN (from "
+            "Secret Manager on Cloud Run) and retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    import uvicorn
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+
+    async def _healthz(_request):
+        # Unauthenticated liveness probe — deliberately reveals nothing.
+        return PlainTextResponse("ok")
+
+    app = mcp.streamable_http_app()
+    # Cloud Run's startup/liveness probes and any uptime check hit /healthz
+    # without a token, so it must sit outside the auth gate.
+    app.router.routes.append(Route("/healthz", _healthz, methods=["GET"]))
+    app.add_middleware(
+        _BearerAuthMiddleware, token=token, exempt_paths=frozenset({"/healthz"})
+    )
+
+    port = int(os.environ.get("PORT", "8080"))
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
+
+
+def main() -> None:
+    transport = os.environ.get("MCP_TRANSPORT", "stdio").strip().lower()
+    if "--http" in sys.argv:
+        transport = "http"
+    if transport in ("http", "streamable-http"):
+        _run_http()
+    else:
+        mcp.run(transport="stdio")
+
+
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    main()

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -61,7 +61,14 @@ from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+_RESOLVED = Path(__file__).resolve()
+# In the repo the server lives at scripts/monitoring/<file>, so parents[2] is
+# the repo root — used to locate .env and to resolve a relative
+# GOOGLE_APPLICATION_CREDENTIALS path. In the Cloud Run image the file sits at
+# /app/<file> with no such ancestor (and neither .env nor a relative key path is
+# used there — auth is ADC + env vars), so fall back to the file's directory
+# instead of raising IndexError at import and crashing the container.
+REPO_ROOT = _RESOLVED.parents[2] if len(_RESOLVED.parents) > 2 else _RESOLVED.parent
 
 
 def _load_dotenv(path: Path) -> None:
@@ -703,12 +710,16 @@ class _BearerAuthMiddleware:
 
 def _run_http() -> None:
     """Serve the MCP tools over authenticated Streamable HTTP (for Cloud Run)."""
-    token = os.environ.get("MCP_AUTH_TOKEN")
+    # Strip so a secret provisioned with a stray trailing newline/space (a very
+    # easy mistake with `echo | gcloud secrets versions add`) doesn't silently
+    # become a token that never matches the header, and a whitespace-only value
+    # fails closed rather than "authenticating".
+    token = (os.environ.get("MCP_AUTH_TOKEN") or "").strip()
     if not token:
         print(
-            "FATAL: MCP_AUTH_TOKEN is unset. Refusing to serve the monitoring "
-            "tools over HTTP without authentication. Set MCP_AUTH_TOKEN (from "
-            "Secret Manager on Cloud Run) and retry.",
+            "FATAL: MCP_AUTH_TOKEN is unset or blank. Refusing to serve the "
+            "monitoring tools over HTTP without authentication. Set "
+            "MCP_AUTH_TOKEN (from Secret Manager on Cloud Run) and retry.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/scripts/monitoring/requirements.txt
+++ b/scripts/monitoring/requirements.txt
@@ -1,4 +1,11 @@
 # Runtime dependencies for scripts/monitoring/gcp_mcp_server.py
 # Install with: pip install -r scripts/monitoring/requirements.txt
-mcp>=1.2.0
+#
+# mcp >= 1.10 is required for the Streamable HTTP transport used by the hosted
+# Cloud Run connector (mcp.streamable_http_app()); stdio mode works on older
+# releases but the pin is unified so both transports share one venv/image.
+mcp>=1.10.0
 google-cloud-monitoring>=2.21.0
+# Only used by the HTTP transport (_run_http); ships with mcp's server extra but
+# pinned explicitly so the Cloud Run image doesn't depend on that being present.
+uvicorn>=0.30.0


### PR DESCRIPTION
## Description

Claude Code's cloud/routine environment never spawns the `.mcp.json` **stdio** MCP servers — its tool registry only wires up **remote connectors** (that's why only Atlassian/Linear/Gmail/GitHub show up there). So `gcp-monitor` has been unreachable in routines, which had to fall back to invoking `scripts/monitoring/gcp_mcp_server.py` directly through the prebuilt `/opt/gcp-monitor-venv` as a workaround.

This teaches the same server to serve its tools over **authenticated Streamable HTTP** (`MCP_TRANSPORT=http`) so it can be hosted on Cloud Run and registered as a Claude **custom connector**, making `check_system_health` / `list_available_metrics` / `query_metric` first-class tools in web sessions and routines.

Two wins beyond accessibility:
- **Keyless** — the Cloud Run service runs *as* a `roles/monitoring.viewer` service account and the Monitoring client picks up ADC, eliminating the `GOOGLE_APPLICATION_CREDENTIALS_B64` key blob entirely.
- **Headless-safe auth** — a static bearer token (no interactive OAuth grant a non-interactive routine might lack) carried on every request, stored in Secret Manager.

**stdio remains the default transport**, so local `.mcp.json` spawns and Claude Desktop are unchanged.

### What's included
- `gcp_mcp_server.py`: `_run_http()` path with a pure-ASGI bearer-token gate (constant-time compare, streaming/SSE-safe — not `BaseHTTPMiddleware`), an unauthenticated `/healthz` probe, and fail-closed startup when `MCP_AUTH_TOKEN` is unset.
- `scripts/monitoring/Dockerfile` + `.dockerignore`: minimal image serving the HTTP transport as a non-root user.
- `scripts/monitoring/deploy_mcp_cloud_run.sh`: idempotent deploy — provisions the keyless SA + `MCP_AUTH_TOKEN` secret + Cloud Run service, prints the `/mcp` connector URL.
- `requirements.txt`: bump `mcp` to `>=1.10.0` (`streamable_http_app`), add `uvicorn`.
- `docs/MCP_GCP_MONITORING.md` § 4.5 + `CLAUDE.md`: deploy steps, auth model, and connector registration.

## Related Issues

<!-- none -->

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

Exercised the HTTP transport end-to-end against the real `mcp 1.28.1` runtime (`/opt/gcp-monitor-venv`):

- [x] Fail-closed: `MCP_TRANSPORT=http` with no `MCP_AUTH_TOKEN` → prints FATAL and exits 1
- [x] `GET /healthz` (no auth) → `200 ok`
- [x] `POST /mcp` with no token → `401`
- [x] `POST /mcp` with wrong token → `401`
- [x] `POST /mcp initialize` with correct token → `200`, MCP session created
- [x] `python -m py_compile` clean; stdio default path unchanged

Node test/lint/build checklist items below are N/A — this change touches only the Python monitoring server, its Docker image, and docs (no `src/` or `server/` code).

- [ ] Tests pass locally (`npm run test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Code is formatted (`npm run format`)
- [ ] Build succeeds (`npm run build`)
- [ ] Type checking passes (`npm run type-check`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- Ingress is public because Claude's servers must reach the endpoint and can't authenticate with GCP IAM — **the bearer token is the access control**, gating everything except `/healthz`. Rotate by adding a new secret version and re-running the deploy script.
- Follow-up (out of scope, one-time by Adam): run `scripts/monitoring/deploy_mcp_cloud_run.sh`, then add the printed `/mcp` URL + `Authorization: Bearer <token>` as a custom connector in Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3QhyMrJ9vfDPUVtpvi55m

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3QhyMrJ9vfDPUVtpvi55m)_






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

