### PR TITLE
feat(gcp-monitor): accept connector token via ?key= query param, not just header

### DIFF
--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -198,18 +198,41 @@ version and re-running the deploy script.
 
 ### Register the connector in Claude
 
-In Claude (Settings → Connectors → Add custom connector), point it at the
-`/mcp` URL and set the auth header:
+The server accepts the token **two ways** — pick the one your client supports:
+
+**claude.ai / Claude Code web (the path that reaches cloud routines).** Its
+"Add custom connector" dialog (Settings → Connectors) takes only a URL and an
+optional OAuth Client ID/Secret — it has **no field for a bearer header or
+custom headers** ([anthropics/claude-ai-mcp#112], closed as not-planned). So the
+token rides in the URL as a query parameter, and you **leave the OAuth fields
+blank** (they drive an OAuth 2.1 + PKCE handshake this server doesn't implement —
+filling them in just makes the connection fail):
+
+```
+URL: https://<service-url>/mcp?key=<token from MCP_AUTH_TOKEN>
+```
+
+Trade-off: a URL-embedded token shows up in request logs (Cloud Run's
+load-balancer logs included). That's acceptable for a read-only
+`monitoring.viewer` token — rotate it (new secret version + redeploy) if it's
+ever exposed.
+
+**Claude Code CLI / Desktop / the API MCP connector** support a real header, so
+use that — it keeps the secret out of URLs and logs:
 
 ```
 URL:            https://<service-url>/mcp
 Authorization:  Bearer <token from MCP_AUTH_TOKEN>
 ```
 
+e.g. `claude mcp add --transport http gcp-monitor https://<service-url>/mcp --header "Authorization: Bearer <token>"`.
+
 Once connected, `check_system_health`, `list_available_metrics`, and
 `query_metric` appear as tools in cloud sessions and routines — no `.mcp.json`,
 no venv, no base64 key. The `/system-health-check` skill drives them the same
 way it drives the stdio server.
+
+[anthropics/claude-ai-mcp#112]: https://github.com/anthropics/claude-ai-mcp/issues/112
 
 ### Run the HTTP server locally (optional)
 

--- a/scripts/monitoring/deploy_mcp_cloud_run.sh
+++ b/scripts/monitoring/deploy_mcp_cloud_run.sh
@@ -91,17 +91,23 @@ gcloud run deploy "$SERVICE" \
   --quiet
 
 URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT_ID" --region "$REGION" --format 'value(status.url)')"
-TOKEN="$(gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT_ID" 2>/dev/null || true)"
 echo
 echo "Deployed. Register as a Claude custom connector."
 echo
 echo "claude.ai / Claude Code web (Settings -> Connectors -> Add custom connector):"
-echo "  Its UI has no header field, so the token rides in the URL. Paste this as"
-echo "  the URL and leave the OAuth Client ID / Secret fields BLANK:"
-if [[ -n "$TOKEN" ]]; then
-  echo "    ${URL}/mcp?key=${TOKEN}"
+echo "  Its UI has no header field, so the token rides in the URL. Use this as the"
+echo "  URL and leave the OAuth Client ID / Secret fields BLANK:"
+if [[ "${PRINT_TOKEN:-0}" == "1" ]]; then
+  # Opt-in only: the full token lands in terminal scrollback / CI logs / shared
+  # transcripts, so it's not printed by default. `tr -d '\r\n'` strips any
+  # trailing newline a manually-added secret version may carry, so the pasted
+  # URL matches what the server expects.
+  TOKEN="$(gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT_ID" 2>/dev/null | tr -d '\r\n' || true)"
+  echo "    ${URL}/mcp?key=${TOKEN:-<token>}"
 else
-  echo "    ${URL}/mcp?key=<token>   (fetch <token> with the command below)"
+  echo "    ${URL}/mcp?key=<token>"
+  echo "  (token withheld from output by default; re-run with PRINT_TOKEN=1 to"
+  echo "   inline it, or fetch it with the command below)"
 fi
 echo
 echo "Claude Code CLI / Desktop / API (header auth — keeps the token out of URLs & logs):"

--- a/scripts/monitoring/deploy_mcp_cloud_run.sh
+++ b/scripts/monitoring/deploy_mcp_cloud_run.sh
@@ -91,9 +91,22 @@ gcloud run deploy "$SERVICE" \
   --quiet
 
 URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT_ID" --region "$REGION" --format 'value(status.url)')"
+TOKEN="$(gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT_ID" 2>/dev/null || true)"
 echo
-echo "Deployed. Register this as a Claude custom connector:"
-echo "  MCP server URL : ${URL}/mcp"
-echo "  Auth header    : Authorization: Bearer <token from secret $SECRET_NAME>"
+echo "Deployed. Register as a Claude custom connector."
 echo
-echo "Token: gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"
+echo "claude.ai / Claude Code web (Settings -> Connectors -> Add custom connector):"
+echo "  Its UI has no header field, so the token rides in the URL. Paste this as"
+echo "  the URL and leave the OAuth Client ID / Secret fields BLANK:"
+if [[ -n "$TOKEN" ]]; then
+  echo "    ${URL}/mcp?key=${TOKEN}"
+else
+  echo "    ${URL}/mcp?key=<token>   (fetch <token> with the command below)"
+fi
+echo
+echo "Claude Code CLI / Desktop / API (header auth — keeps the token out of URLs & logs):"
+echo "  URL:    ${URL}/mcp"
+echo "  Header: Authorization: Bearer <token>"
+echo
+echo "Fetch the token:"
+echo "  gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -702,8 +702,14 @@ class _BearerAuthMiddleware:
 
     def _authorized(self, scope) -> bool:
         # Constant-time compares so a wrong token can't be recovered by timing.
-        headers = dict(scope.get("headers") or [])
-        presented = headers.get(b"authorization", b"").decode("latin-1")
+        # ASGI delivers headers as a list of (name, value) byte pairs; scan it
+        # directly rather than dict()-ing it, which would silently keep only the
+        # last of any duplicate header.
+        presented = ""
+        for name, value in scope.get("headers") or ():
+            if name == b"authorization":
+                presented = value.decode("latin-1")
+                break
         if hmac.compare_digest(presented, self._expected):
             return True
         query = parse_qs(scope.get("query_string", b"").decode("latin-1"))

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -40,11 +40,13 @@ Configuration (env vars, or repo-root `.env`):
 HTTP-transport-only configuration:
     MCP_TRANSPORT                   'http'/'streamable-http' to serve over HTTP;
                                     anything else (default) uses stdio.
-    MCP_AUTH_TOKEN                  shared secret required on every request as
-                                    `Authorization: Bearer <token>`. Mandatory
-                                    in HTTP mode — the server refuses to start
-                                    without it rather than expose metrics
-                                    unauthenticated.
+    MCP_AUTH_TOKEN                  shared secret required on every request,
+                                    presented as `Authorization: Bearer <token>`
+                                    (preferred) or a `?key=<token>` query param
+                                    (for the claude.ai connector UI, which has no
+                                    header field). Mandatory in HTTP mode — the
+                                    server refuses to start without it rather
+                                    than expose metrics unauthenticated.
     PORT                            listen port in HTTP mode (default 8080;
                                     Cloud Run injects this).
 """
@@ -58,6 +60,7 @@ import sys
 import threading
 from pathlib import Path
 from typing import Optional
+from urllib.parse import parse_qs
 
 from mcp.server.fastmcp import FastMCP
 
@@ -673,7 +676,18 @@ def query_metric(
 
 
 class _BearerAuthMiddleware:
-    """Pure-ASGI gate requiring `Authorization: Bearer <token>` on HTTP requests.
+    """Pure-ASGI gate requiring the shared token on HTTP requests.
+
+    The token may arrive two ways:
+      - `Authorization: Bearer <token>` header — preferred; used by Claude Code
+        (`claude mcp add --header`), the API MCP connector, and direct clients.
+        Keeps the secret out of URLs and request logs.
+      - `?key=<token>` query parameter — because Claude's claude.ai custom-
+        connector UI takes only a URL and has no field for a bearer header or
+        custom headers (anthropics/claude-ai-mcp#112), so the token has to ride
+        in the URL there. Trade-off: a URL-embedded token is visible in request
+        logs (Cloud Run's load-balancer logs included), so rotate it if exposed
+        and prefer the header wherever the client supports one.
 
     Implemented as raw ASGI (not Starlette's BaseHTTPMiddleware) so it never
     buffers the streaming/SSE responses the MCP transport relies on. Non-HTTP
@@ -682,17 +696,24 @@ class _BearerAuthMiddleware:
 
     def __init__(self, app, token: str, exempt_paths: frozenset[str]):
         self.app = app
+        self._token = token
         self._expected = f"Bearer {token}"
         self.exempt_paths = exempt_paths
+
+    def _authorized(self, scope) -> bool:
+        # Constant-time compares so a wrong token can't be recovered by timing.
+        headers = dict(scope.get("headers") or [])
+        presented = headers.get(b"authorization", b"").decode("latin-1")
+        if hmac.compare_digest(presented, self._expected):
+            return True
+        query = parse_qs(scope.get("query_string", b"").decode("latin-1"))
+        return any(hmac.compare_digest(v, self._token) for v in query.get("key", ()))
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http" or scope.get("path") in self.exempt_paths:
             await self.app(scope, receive, send)
             return
-        headers = dict(scope.get("headers") or [])
-        presented = headers.get(b"authorization", b"").decode("latin-1")
-        # Constant-time compare so a wrong token can't be recovered by timing.
-        if hmac.compare_digest(presented, self._expected):
+        if self._authorized(scope):
             await self.app(scope, receive, send)
             return
         await send(


### PR DESCRIPTION
## Description

Follow-up to #3051. When registering the hosted `gcp-monitor` server as a **claude.ai custom connector** (the path that reaches cloud routines), the "Add custom connector" dialog takes only a **URL** plus optional **OAuth Client ID/Secret** — it has **no field for an `Authorization` header or custom headers** ([anthropics/claude-ai-mcp#112](https://github.com/anthropics/claude-ai-mcp/issues/112), closed as not-planned). So the header-only bearer gate shipped in #3051 **cannot be registered there at all**, and the OAuth fields drive an OAuth 2.1 + PKCE flow this server doesn't implement.

This lets the shared token arrive **either** way:
- `Authorization: Bearer <token>` header — **preferred** (Claude Code CLI/Desktop, API MCP connector); keeps the secret out of URLs and logs.
- `?key=<token>` query parameter — so the token can ride in the URL for the header-less claude.ai UI. You register `https://<service>/mcp?key=<token>` and leave the OAuth fields blank.

Both comparisons are constant-time; `/healthz` stays unauthenticated. Trade-off documented: a URL-embedded token appears in request logs (Cloud Run's LB logs included), acceptable for a read-only `monitoring.viewer` token and rotatable.

### What's included
- `gcp_mcp_server.py`: `_BearerAuthMiddleware` now checks header **or** `?key=` query param (added `_authorized()` helper, `urllib.parse.parse_qs` import); docstring updated.
- `deploy_mcp_cloud_run.sh`: printed instructions now show the `?key=` URL for claude.ai (OAuth blank) and the header form for CLI/API, and fetch/echo the token.
- `docs/MCP_GCP_MONITORING.md` § 4.5: corrected registration section (the old text told users to set a header the UI can't send).

## Related Issues

Relates to #3051

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

Verified against `mcp 1.28.1` (`/opt/gcp-monitor-venv`):

- [x] No auth → `401`
- [x] `Authorization: Bearer <token>` → `200`
- [x] `?key=<token>` → `200`
- [x] `?key=<wrong>` → `401`
- [x] `GET /healthz` (no auth) → `200`
- [x] `py_compile` clean; `bash -n` on the deploy script clean

Node checklist items are N/A — Python + docs only, no `src/`/`server/` changes.

- [ ] Tests pass locally (`npm run test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Code is formatted (`npm run format`)
- [ ] Build succeeds (`npm run build`)
- [ ] Type checking passes (`npm run type-check`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

After this merges, **re-run `scripts/monitoring/deploy_mcp_cloud_run.sh`** to redeploy the Cloud Run service — the currently-deployed image from #3051 only checks the header, so `?key=` won't authenticate until the new image is live. Then register `https://<service>/mcp?key=<token>` as the connector URL (OAuth fields blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3QhyMrJ9vfDPUVtpvi55m

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3QhyMrJ9vfDPUVtpvi55m)_












<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

