### PR TITLE
release: v0.3.2 — SSR styling + async-generation retry regression fixes, gcp-monitor Cloud Run connector

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enabledMcpjsonServers": ["pm-daemon", "gcp-monitor"],
   "hooks": {
     "PreToolUse": [
       {

--- a/.github/workflows/ci-cd-backend.yml
+++ b/.github/workflows/ci-cd-backend.yml
@@ -30,4 +30,9 @@ jobs:
         run: uv sync
       - name: Run pytest
         working-directory: Backend
+        env:
+          # services/pubsub_service.py builds its Pub/Sub client at import
+          # time; without this the suite needs real ADC and dies with
+          # DefaultCredentialsError (same env as pr-gate.yml's pytest job).
+          PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,7 +12,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
-    branches: [main]
+    branches: [main, dev, 'dev/**']
 
 jobs:
   install:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -10,7 +10,7 @@ name: PR Gate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev, 'dev/**']
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -103,6 +103,8 @@ jobs:
         run: uv sync
       - name: Run pytest
         working-directory: Backend
+        env:
+          PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest
 
   # ── Changelog ─────────────────────────────────────────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ __pycache__/
 .claude/scheduled_tasks.lock
 .omg/state/
 scripts/pm/.venv/
+.gbrain-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-05
+
+Regression-fix release for v0.3.1: restores styling on the server-rendered public pages, makes async recipe generation retry transient model failures, and un-shadows the dynamic sitemap. Also brings the GCP monitoring MCP server to Cloud Run as an authenticated Claude connector and gates PRs targeting `dev` with the full CI suite.
+
+### Fixed
+
+- **Public SSR pages render styled again** ([#3047](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3047), [#3048](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3048)): Express proxied `/r/*`, `/browse`, and `/sitemap.xml` to Flask but not `/static/*`, so the SSR templates' stylesheet requests fell through to the SPA catch-all and came back as `index.html` (`text/html`) — Helmet's `X-Content-Type-Options: nosniff` then made browsers refuse to apply them, leaving every public page unstyled. `GET /static/*` is now proxied to Flask (mounted after `express.static`, so Angular build assets still win on collision). `server/index.ts` exports `app` and a `ready` promise with the listener skipped under `VITEST`/`NODE_ENV=test`, backed by new route-mounting integration tests (`server/routes.test.ts`).
+- **Async recipe generation survives flaky model responses** (Backend [#141](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/141) via [#3049](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3049)): `gemini-3.1-pro-preview` intermittently returns truncated JSON, and the Pub/Sub worker was single-shot with only "Unknown error" logging — users saw "generation failed during async processing". The worker now retries transient generation failures up to `GENERATION_MAX_ATTEMPTS` (default 3) and failure records carry the real error message (validation failures wrapped as `ValidationError`). Backend submodule `b359743` → `ef594bf`.
+- **Dynamic sitemap unshadowed** ([#3041](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3041)): a stale static `public/sitemap.xml` was served by `express.static` ahead of the Flask proxy route, hiding the dynamic sitemap of public recipes shipped in v0.3.1. Deleted.
+
+### Added
+
+- **GCP monitoring served over HTTP for Claude connectors** ([#3051](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3051), [#3052](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3052)): the gcp-monitor MCP server can now run as an authenticated Streamable-HTTP service on Cloud Run — keyless (runs as a `roles/monitoring.viewer` service account via ADC), bearer-token auth from Secret Manager, token also accepted via `?key=` query param for connector UIs without header support — with a Dockerfile and `deploy_mcp_cloud_run.sh`. Cloud routines get the monitoring tools first-class instead of shelling out to scripts.
+- **gcp-monitor cloud-session resilience** ([#3043](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3043), [#3044](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3044), [#3046](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3046)): prebuilt-venv fast path so the stdio server survives cloud-routine cold starts, retries around transient PyPI timeouts in the setup script, and project MCP servers pre-approved in `.claude/settings.json` for cloud sessions.
+
+### Changed
+
+- **CI: pull requests targeting `dev` now run the lint/test/build gate** ([#3050](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3050)) — previously the gate only ran on pushes, so a broken PR could merge green.
+- Docs: GBrain config + search guidance in `CLAUDE.md` refreshed ([#3042](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3042), [#3045](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3045)); `docs/MCP_GCP_MONITORING.md` expanded with the Cloud Run connector setup (§ 4.5).
+
 ## [0.3.1] - 2026-07-04
 
 Deploy hotfix. The v0.3.0 tag was cut but its Cloud Build died in the `flask-backend-migrate` job (`ModuleNotFoundError: flask_cors`) before either service deployed — production kept serving v0.2.5 throughout. v0.3.1 is v0.3.0 plus the dependency fix; it is the release that actually ships the v0.3.0 feature set.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,14 +279,19 @@ Key routing rules:
 ## GBrain Configuration (configured by /setup-gbrain)
 
 - Mode: local-stdio
-- Engine: postgres (Supabase Session Pooler)
-- gbrain version: 0.28.6 (upgraded from 0.18.x on 2026-05-07; schema v38)
+- Engine: postgres (Railway TCP proxy, dedicated `gbrain` database; schema v122)
+- gbrain version: 0.42.56.0 (reconfigured 2026-07-04 to Railway Postgres)
+- Embeddings: openai:text-embedding-3-large (1536d)
+- chat/expansion: openai:gpt-5.2
 - Config file: `~/.gbrain/config.json` (mode 0600)
 - MCP registered: yes (user scope, `gbrain serve` via `~/.bun/bin/gbrain`)
 - Artifacts repo: https://github.com/adamtasteslikegood/gstack-artifacts-adam
-- Artifacts sync: full
-- Current repo policy: read-write
-- Pre-upgrade backup: `~/.gstack-...-gbrain.../Backups/pg_dumps/` (Railway pg_dump, retained as rollback)
+- Artifacts sync: full (federated source `gstack-artifacts-adam`)
+- Transcript ingest: incremental (initial bulk of 24 files done 2026-07-04)
+- Current repo policy: read-write (code imported: 134 pages, 831 chunks, embedded)
+- Trust policy: personal
+- Rollback backup: old 0.18.x brain (252 pages, last write 2026-05-07)
+  preserved untouched in the `railway` database on the same Railway server
 
 ## GBrain Search Guidance (configured by /sync-gbrain)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ Project MCP servers are declared in `.mcp.json` at the repo root. When Claude Co
 
 - `gcp-monitor` — runs `scripts/monitoring/run_gcp_monitor.sh`, which creates its venv on first run, then launches `scripts/monitoring/gcp_mcp_server.py`. Exposes read-only Cloud Monitoring tools (`check_system_health`, `list_available_metrics`, `query_metric`) covering the production stack (Cloud Run frontend/backend, Cloud SQL, Valkey, Pub/Sub). Requires `GOOGLE_APPLICATION_CREDENTIALS` (+ optional `GCP_PROJECT_ID`) in `.env`; without them the tools register but return a credential error instead of metrics. The `/system-health-check` skill (`.claude/skills/system-health-check/`) drives the full SRE health-report routine. Setup: `docs/MCP_GCP_MONITORING.md`.
 
+  **Cloud sessions & routines** don't spawn `.mcp.json` stdio servers (their tool registry only wires up remote connectors), so `gcp-monitor` is unreachable there via stdio — routines have to invoke the script directly as a workaround. The same server also runs over authenticated Streamable HTTP (`MCP_TRANSPORT=http`): deploy it to Cloud Run with `scripts/monitoring/deploy_mcp_cloud_run.sh` (keyless — runs as a `roles/monitoring.viewer` SA via ADC, no base64 key; bearer-token auth from a Secret Manager `MCP_AUTH_TOKEN`) and register the printed `/mcp` URL as a Claude **custom connector**. Routines then get the tools first-class. See `docs/MCP_GCP_MONITORING.md` § 4.5.
+
 Requirements for `pm-daemon` to actually sync:
 
 - `.env` (project root) must contain `ATLASSIAN_EMAIL` and `ATLASSIAN_API_TOKEN`. Without them the MCP tools register but Confluence sync logs `WARNING: Atlassian credentials missing` and no-ops.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,9 +299,26 @@ Key routing rules:
 
 GBrain is set up and synced on this machine. The agent should prefer gbrain
 over Grep when the question is semantic or when you don't know the exact
-identifier yet. Two indexed corpora available via the `gbrain` CLI:
+identifier yet.
 
-- This repo's code (registered as `gstack-code-<repo>` source).
+**This worktree is pinned to a worktree-scoped code source** via the
+`.gbrain-source` file in the repo root (kubectl-style context).
+`gbrain code-def`, `code-refs`, `code-callers`, `code-callees`, `search`, and
+`query` from anywhere under this worktree route to that source by default —
+no `--source` flag needed (gbrain >= 0.41.38.0; on older gbrain the call-graph
+commands need `--source "$(cat .gbrain-source)"`). Conductor sibling worktrees
+of the same repo each have their own pin and their own indexed pages, so
+semantic results match the code on disk here.
+
+Call-graph queries (`code-callers`/`code-callees`) also need the graph to be
+built first — run `/sync-gbrain --dream` (or `--full`) if they return
+`count: 0`. This only works if this source's gbrain schema pack extracts code
+symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
+and reports a WARN. `code-def`/`code-refs` need the same extraction.
+
+Two indexed corpora available via the `gbrain` CLI:
+
+- This worktree's code (auto-pinned via `.gbrain-source`).
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
@@ -317,7 +334,14 @@ Prefer gbrain when:
   `gbrain search "<terms>" --source gstack-brain-<user>`
 
 Grep is still right for known exact strings, regex, multiline patterns, and
-file globs. The brain auto-syncs incrementally on every gstack skill start.
-Run `/sync-gbrain` to force-refresh, `/sync-gbrain --full` for full reindex.
+file globs. Run `/sync-gbrain` after meaningful code changes; for ongoing
+auto-sync across all worktrees, run `gbrain autopilot --install` once per
+machine — gbrain's daemon handles incremental refresh on a schedule.
+
+Safety: don't run `/sync-gbrain` while `gbrain autopilot` is active — the
+orchestrator refuses destructive source ops when it detects a running autopilot
+to avoid racing it (#1734). Prefer registering user repos with `gbrain sources
+add --path <dir>` (no `--url`): URL-managed sources can auto-reclone, and the
+sync code walk for them requires an explicit `--allow-reclone` opt-in.
 
 <!-- gstack-gbrain-search-guidance:end -->

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -198,18 +198,41 @@ version and re-running the deploy script.
 
 ### Register the connector in Claude
 
-In Claude (Settings → Connectors → Add custom connector), point it at the
-`/mcp` URL and set the auth header:
+The server accepts the token **two ways** — pick the one your client supports:
+
+**claude.ai / Claude Code web (the path that reaches cloud routines).** Its
+"Add custom connector" dialog (Settings → Connectors) takes only a URL and an
+optional OAuth Client ID/Secret — it has **no field for a bearer header or
+custom headers** ([anthropics/claude-ai-mcp#112], closed as not-planned). So the
+token rides in the URL as a query parameter, and you **leave the OAuth fields
+blank** (they drive an OAuth 2.1 + PKCE handshake this server doesn't implement —
+filling them in just makes the connection fail):
+
+```
+URL: https://<service-url>/mcp?key=<token from MCP_AUTH_TOKEN>
+```
+
+Trade-off: a URL-embedded token shows up in request logs (Cloud Run's
+load-balancer logs included). That's acceptable for a read-only
+`monitoring.viewer` token — rotate it (new secret version + redeploy) if it's
+ever exposed.
+
+**Claude Code CLI / Desktop / the API MCP connector** support a real header, so
+use that — it keeps the secret out of URLs and logs:
 
 ```
 URL:            https://<service-url>/mcp
 Authorization:  Bearer <token from MCP_AUTH_TOKEN>
 ```
 
+e.g. `claude mcp add --transport http gcp-monitor https://<service-url>/mcp --header "Authorization: Bearer <token>"`.
+
 Once connected, `check_system_health`, `list_available_metrics`, and
 `query_metric` appear as tools in cloud sessions and routines — no `.mcp.json`,
 no venv, no base64 key. The `/system-health-check` skill drives them the same
 way it drives the stdio server.
+
+[anthropics/claude-ai-mcp#112]: https://github.com/anthropics/claude-ai-mcp/issues/112
 
 ### Run the HTTP server locally (optional)
 

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -101,7 +101,7 @@ Configure the environment on claude.ai → **Code** → environment settings:
    python3 -m venv /opt/gcp-monitor-venv
    for attempt in 1 2 3; do
      /opt/gcp-monitor-venv/bin/pip install --retries 10 --timeout 60 \
-       'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0' && break
+       'mcp>=1.10.0' 'google-cloud-monitoring>=2.21.0' && break
      echo "pip attempt $attempt of 3 failed" >&2
      if [[ "$attempt" -lt 3 ]]; then sleep 10; fi
    done
@@ -144,6 +144,83 @@ here because the service account is read-only (`roles/monitoring.viewer`),
 but don't reuse this pattern for write-capable credentials. A key _path_ in
 `GOOGLE_APPLICATION_CREDENTIALS` that resolves to a real file always wins
 over the B64 var, so local setups are unaffected.
+
+> **Better option for cloud sessions & routines:** the stdio path above is
+> fragile in the cloud — Claude Code's cloud/routine environment does **not**
+> spawn the `.mcp.json` stdio servers at all (only remote connectors show up
+> there), so routines fall back to invoking the script directly. Section 4.5
+> hosts the same server as a remote connector and removes that whole class of
+> problem, along with the base64 key.
+
+## 4.5. Hosted remote connector (Cloud Run) — recommended for cloud/routines
+
+The same `gcp_mcp_server.py` also serves its tools over **authenticated
+Streamable HTTP** (`MCP_TRANSPORT=http`). Hosted on Cloud Run and registered as
+a Claude **custom connector**, it becomes a first-class tool in exactly the
+place the stdio path can't reach: web sessions and scheduled routines, whose
+tool registry only wires up remote connectors.
+
+Two wins over the stdio/base64 setup:
+
+- **Keyless.** The Cloud Run service runs _as_ a service account with
+  `roles/monitoring.viewer`; the Monitoring client picks up ADC. There is no
+  key file and no `GOOGLE_APPLICATION_CREDENTIALS_B64` — nothing to leak from an
+  environment-variable pane.
+- **Headless-safe auth.** The connector carries a static bearer token on every
+  request (no interactive OAuth grant that a non-interactive routine might not
+  have), so it behaves identically in a routine and on your desktop.
+
+### Deploy
+
+One idempotent script provisions the service account, the token secret, and the
+Cloud Run service:
+
+```bash
+scripts/monitoring/deploy_mcp_cloud_run.sh
+# override defaults if needed:
+PROJECT_ID=comdottasteslikegood REGION=us-central1 \
+  scripts/monitoring/deploy_mcp_cloud_run.sh
+```
+
+It prints the connector URL (`https://<service-url>/mcp`) and the command to
+read the generated token:
+
+```bash
+gcloud secrets versions access latest --secret=MCP_AUTH_TOKEN --project=comdottasteslikegood
+```
+
+Ingress is public because Claude's servers must reach it and can't authenticate
+with GCP IAM — **the bearer token is the access control.** It gates every
+request except `/healthz` (an unauthenticated liveness probe that reveals
+nothing); the server refuses to start in HTTP mode if `MCP_AUTH_TOKEN` is unset,
+so it can never accidentally serve metrics open. Rotate by adding a new secret
+version and re-running the deploy script.
+
+### Register the connector in Claude
+
+In Claude (Settings → Connectors → Add custom connector), point it at the
+`/mcp` URL and set the auth header:
+
+```
+URL:            https://<service-url>/mcp
+Authorization:  Bearer <token from MCP_AUTH_TOKEN>
+```
+
+Once connected, `check_system_health`, `list_available_metrics`, and
+`query_metric` appear as tools in cloud sessions and routines — no `.mcp.json`,
+no venv, no base64 key. The `/system-health-check` skill drives them the same
+way it drives the stdio server.
+
+### Run the HTTP server locally (optional)
+
+```bash
+MCP_TRANSPORT=http MCP_AUTH_TOKEN=dev-secret PORT=8080 \
+  scripts/monitoring/run_gcp_monitor.sh --http
+curl -s localhost:8080/healthz   # -> ok
+```
+
+Local runs still resolve credentials the normal way (`.env` key path or
+`GOOGLE_APPLICATION_CREDENTIALS_B64`); only Cloud Run relies on ADC.
 
 ## 5. Claude Desktop
 

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -91,16 +91,27 @@ Configure the environment on claude.ai → **Code** → environment settings:
 
 1. **Setup script** — build the venv at the fixed path (repo isn't cloned
    yet, so the dependency list is inlined; keep it in sync with
-   `scripts/monitoring/requirements.txt`):
+   `scripts/monitoring/requirements.txt`). PyPI reads from the cloud VM
+   time out sporadically, so the install retries and the final import
+   check is what actually gates success:
 
    ```bash
    #!/bin/bash
    set -euo pipefail
    python3 -m venv /opt/gcp-monitor-venv
-   /opt/gcp-monitor-venv/bin/pip install --upgrade pip
-   /opt/gcp-monitor-venv/bin/pip install 'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0'
+   for attempt in 1 2 3; do
+     /opt/gcp-monitor-venv/bin/pip install --retries 10 --timeout 60 \
+       'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0' && break
+     echo "pip attempt $attempt of 3 failed" >&2
+     if [[ "$attempt" -lt 3 ]]; then sleep 10; fi
+   done
+   /opt/gcp-monitor-venv/bin/python -c 'import importlib.util as u, sys; sys.exit(0 if u.find_spec("mcp") and u.find_spec("google.cloud.monitoring_v3") else 1)'
    chmod -R a+rX /opt/gcp-monitor-venv
    ```
+
+   (No `pip install --upgrade pip` — the venv's bundled pip installs these
+   wheels fine, and every extra download is another chance to hit a
+   transient timeout.)
 
 2. Encode the key locally, straight to the clipboard (don't echo it —
    and don't copy from a terminal that shows a `%` end-of-output marker):

--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -70,10 +70,40 @@ as `pm-daemon`. Verify with `ps -ef | grep gcp_mcp_server`.
 Cloud sessions clone this repo, so `.mcp.json` auto-spawns `gcp-monitor`
 there too — but the cloud VM has neither your `.env` nor the key file. Cloud
 environments only carry **single-line** env vars (there is no secrets vault
-yet), so the key travels base64-encoded and the server materializes it to a
-gitignored `scripts/monitoring/.gcp-sa-key.json` (0600) at startup.
+yet), so the key travels base64-encoded; the server decodes it in memory and
+hands it straight to the Monitoring client (it never touches disk).
 
-1. Encode the key locally, straight to the clipboard (don't echo it):
+Two cloud-specific traps this section works around:
+
+- **Every routine run is a fresh VM.** Without preparation, the launcher
+  pip-installs its venv on every run (~45 s+), which loses the race against
+  the MCP client's 30 s startup timeout — the server gets killed
+  mid-bootstrap and no tools register.
+- **The environment's setup script runs _before_ the repo is cloned**, so it
+  cannot call anything in `scripts/`. It must build the venv at a fixed
+  path outside the repo; the launcher (`run_gcp_monitor.sh`) detects a
+  usable venv at `$GCP_MONITOR_VENV` or `/opt/gcp-monitor-venv` and uses it
+  instead of bootstrapping. The filesystem is snapshotted after the setup
+  script and reused by later runs (cache expires ~weekly and on
+  setup-script/network-host edits).
+
+Configure the environment on claude.ai → **Code** → environment settings:
+
+1. **Setup script** — build the venv at the fixed path (repo isn't cloned
+   yet, so the dependency list is inlined; keep it in sync with
+   `scripts/monitoring/requirements.txt`):
+
+   ```bash
+   #!/bin/bash
+   set -euo pipefail
+   python3 -m venv /opt/gcp-monitor-venv
+   /opt/gcp-monitor-venv/bin/pip install --upgrade pip
+   /opt/gcp-monitor-venv/bin/pip install 'mcp>=1.2.0' 'google-cloud-monitoring>=2.21.0'
+   chmod -R a+rX /opt/gcp-monitor-venv
+   ```
+
+2. Encode the key locally, straight to the clipboard (don't echo it —
+   and don't copy from a terminal that shows a `%` end-of-output marker):
 
    ```bash
    base64 < /path/to/monitoring-viewer.json | tr -d '\n' | wl-copy   # or xclip/pbcopy
@@ -82,19 +112,20 @@ gitignored `scripts/monitoring/.gcp-sa-key.json` (0600) at startup.
    (`tr -d '\n'` keeps this portable — GNU `base64` wraps at 76 columns by
    default and macOS/BSD `base64` has no `-w` flag.)
 
-2. On claude.ai → **Code** → the environment your routine uses → environment
-   settings → **Environment variables**, add:
+3. **Environment variables**:
 
    ```
    GOOGLE_APPLICATION_CREDENTIALS_B64=<paste the base64 blob>
    GCP_PROJECT_ID=comdottasteslikegood
+   MCP_TIMEOUT=120000
    ```
 
-   (`GCP_PROJECT_ID` is optional — it's the default.)
+   (`GCP_PROJECT_ID` is optional — it's the default. `MCP_TIMEOUT` is in
+   milliseconds and covers the slow rebuild after a snapshot-cache
+   expiry.)
 
-3. Make sure the environment's **network access** allows package installs —
-   the launcher pip-installs its venv on first run and the server calls
-   `monitoring.googleapis.com`.
+4. Make sure the environment's **network access** allows PyPI (for the
+   setup script) and `monitoring.googleapis.com` (for the server).
 
 Note: environment variables are visible to anyone who can edit that cloud
 environment, and any cloud session using it can read the key — acceptable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@angular/build": "22.0.5",
         "@angular/cli": "22.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "ng serve",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.tasteslikegood.org/</loc>
-    <lastmod>2026-03-20</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>

--- a/scripts/monitoring/.dockerignore
+++ b/scripts/monitoring/.dockerignore
@@ -1,0 +1,10 @@
+# Keep the build context minimal — only the server + its requirements are
+# needed. Everything else in scripts/monitoring/ (venvs, launcher, stamps) is
+# for the stdio path and must not bloat or leak into the image.
+.venv/
+__pycache__/
+*.pyc
+.deps-installed
+.gcp-sa-key.json
+run_gcp_monitor.sh
+deploy_mcp_cloud_run.sh

--- a/scripts/monitoring/Dockerfile
+++ b/scripts/monitoring/Dockerfile
@@ -1,0 +1,33 @@
+# Hosted GCP monitoring MCP server for Cloud Run.
+#
+# Build context is this directory (scripts/monitoring/):
+#   gcloud run deploy gcp-monitor-mcp --source scripts/monitoring ...
+# or via scripts/monitoring/deploy_mcp_cloud_run.sh.
+#
+# The container serves the read-only Cloud Monitoring tools over authenticated
+# Streamable HTTP so Claude can reach them as a custom connector. On Cloud Run
+# it runs as a service account with roles/monitoring.viewer, so the Monitoring
+# client authenticates via ADC — there is NO key file or GOOGLE_APPLICATION_
+# CREDENTIALS_B64 in the image or its env.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Dependencies first for layer caching.
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY gcp_mcp_server.py ./gcp_mcp_server.py
+
+# HTTP transport; Cloud Run overrides PORT and injects MCP_AUTH_TOKEN + secrets.
+ENV MCP_TRANSPORT=http \
+    PORT=8080 \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+
+# Run as a non-root user (Cloud Run does not require it, but defense in depth).
+RUN useradd --create-home --uid 10001 appuser
+USER appuser
+
+CMD ["python", "gcp_mcp_server.py"]

--- a/scripts/monitoring/deploy_mcp_cloud_run.sh
+++ b/scripts/monitoring/deploy_mcp_cloud_run.sh
@@ -92,8 +92,27 @@ gcloud run deploy "$SERVICE" \
 
 URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT_ID" --region "$REGION" --format 'value(status.url)')"
 echo
-echo "Deployed. Register this as a Claude custom connector:"
-echo "  MCP server URL : ${URL}/mcp"
-echo "  Auth header    : Authorization: Bearer <token from secret $SECRET_NAME>"
+echo "Deployed. Register as a Claude custom connector."
 echo
-echo "Token: gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"
+echo "claude.ai / Claude Code web (Settings -> Connectors -> Add custom connector):"
+echo "  Its UI has no header field, so the token rides in the URL. Use this as the"
+echo "  URL and leave the OAuth Client ID / Secret fields BLANK:"
+if [[ "${PRINT_TOKEN:-0}" == "1" ]]; then
+  # Opt-in only: the full token lands in terminal scrollback / CI logs / shared
+  # transcripts, so it's not printed by default. `tr -d '\r\n'` strips any
+  # trailing newline a manually-added secret version may carry, so the pasted
+  # URL matches what the server expects.
+  TOKEN="$(gcloud secrets versions access latest --secret="$SECRET_NAME" --project="$PROJECT_ID" 2>/dev/null | tr -d '\r\n' || true)"
+  echo "    ${URL}/mcp?key=${TOKEN:-<token>}"
+else
+  echo "    ${URL}/mcp?key=<token>"
+  echo "  (token withheld from output by default; re-run with PRINT_TOKEN=1 to"
+  echo "   inline it, or fetch it with the command below)"
+fi
+echo
+echo "Claude Code CLI / Desktop / API (header auth — keeps the token out of URLs & logs):"
+echo "  URL:    ${URL}/mcp"
+echo "  Header: Authorization: Bearer <token>"
+echo
+echo "Fetch the token:"
+echo "  gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"

--- a/scripts/monitoring/deploy_mcp_cloud_run.sh
+++ b/scripts/monitoring/deploy_mcp_cloud_run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Deploy the GCP monitoring MCP server to Cloud Run as an authenticated remote
+# connector. Idempotent — safe to re-run to roll out a new revision.
+#
+# What it provisions (only what's missing):
+#   1. A dedicated service account with roles/monitoring.viewer. The Cloud Run
+#      service runs AS this SA, so the Monitoring client authenticates via ADC.
+#      No key file, no GOOGLE_APPLICATION_CREDENTIALS_B64 anywhere.
+#   2. A Secret Manager secret (MCP_AUTH_TOKEN) holding the shared bearer token
+#      Claude presents on every request. Generated on first run if absent.
+#   3. The Cloud Run service itself, built from scripts/monitoring/Dockerfile.
+#
+# Ingress is public (Claude's servers must reach it and cannot do GCP IAM), so
+# the bearer token IS the access control. Rotate it by adding a new secret
+# version and redeploying.
+#
+# Usage:
+#   scripts/monitoring/deploy_mcp_cloud_run.sh
+#   PROJECT_ID=comdottasteslikegood REGION=us-central1 \
+#     scripts/monitoring/deploy_mcp_cloud_run.sh
+#
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-${GCP_PROJECT_ID:-comdottasteslikegood}}"
+REGION="${REGION:-us-central1}"
+SERVICE="${SERVICE:-gcp-monitor-mcp}"
+SA_NAME="${SA_NAME:-gcp-monitor-mcp}"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+SECRET_NAME="${SECRET_NAME:-MCP_AUTH_TOKEN}"
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Project:  $PROJECT_ID"
+echo "Region:   $REGION"
+echo "Service:  $SERVICE"
+echo "SA:       $SA_EMAIL"
+echo
+
+# ── 1. Service account + roles/monitoring.viewer ────────────────────────────
+if ! gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "Creating service account $SA_EMAIL"
+  gcloud iam service-accounts create "$SA_NAME" \
+    --project "$PROJECT_ID" \
+    --display-name "GCP monitoring MCP connector (read-only)"
+else
+  echo "Service account $SA_EMAIL already exists"
+fi
+
+echo "Ensuring roles/monitoring.viewer on $SA_EMAIL"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:$SA_EMAIL" \
+  --role roles/monitoring.viewer \
+  --condition None >/dev/null
+
+# ── 2. Bearer token secret ──────────────────────────────────────────────────
+if ! gcloud secrets describe "$SECRET_NAME" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "Creating secret $SECRET_NAME with a freshly generated token"
+  gcloud secrets create "$SECRET_NAME" \
+    --project "$PROJECT_ID" \
+    --replication-policy automatic
+  # 32 random bytes, URL-safe — plenty for a bearer secret.
+  openssl rand -base64 32 | tr -d '\n' | tr '+/' '-_' \
+    | gcloud secrets versions add "$SECRET_NAME" --project "$PROJECT_ID" --data-file=-
+  echo "Generated a new token — retrieve it for the connector config with:"
+  echo "  gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"
+else
+  echo "Secret $SECRET_NAME already exists (reusing current token)"
+fi
+
+# Let the runtime SA read the token at container start.
+gcloud secrets add-iam-policy-binding "$SECRET_NAME" \
+  --project "$PROJECT_ID" \
+  --member "serviceAccount:$SA_EMAIL" \
+  --role roles/secretmanager.secretAccessor \
+  --condition None >/dev/null
+
+# ── 3. Deploy the Cloud Run service ─────────────────────────────────────────
+echo "Deploying $SERVICE from $SOURCE_DIR"
+gcloud run deploy "$SERVICE" \
+  --project "$PROJECT_ID" \
+  --region "$REGION" \
+  --source "$SOURCE_DIR" \
+  --service-account "$SA_EMAIL" \
+  --set-env-vars "MCP_TRANSPORT=http,GCP_PROJECT_ID=$PROJECT_ID" \
+  --set-secrets "MCP_AUTH_TOKEN=${SECRET_NAME}:latest" \
+  --allow-unauthenticated \
+  --min-instances 0 \
+  --cpu 1 \
+  --memory 512Mi \
+  --port 8080 \
+  --quiet
+
+URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT_ID" --region "$REGION" --format 'value(status.url)')"
+echo
+echo "Deployed. Register this as a Claude custom connector:"
+echo "  MCP server URL : ${URL}/mcp"
+echo "  Auth header    : Authorization: Bearer <token from secret $SECRET_NAME>"
+echo
+echo "Token: gcloud secrets versions access latest --secret=$SECRET_NAME --project=$PROJECT_ID"

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -40,11 +40,13 @@ Configuration (env vars, or repo-root `.env`):
 HTTP-transport-only configuration:
     MCP_TRANSPORT                   'http'/'streamable-http' to serve over HTTP;
                                     anything else (default) uses stdio.
-    MCP_AUTH_TOKEN                  shared secret required on every request as
-                                    `Authorization: Bearer <token>`. Mandatory
-                                    in HTTP mode — the server refuses to start
-                                    without it rather than expose metrics
-                                    unauthenticated.
+    MCP_AUTH_TOKEN                  shared secret required on every request,
+                                    presented as `Authorization: Bearer <token>`
+                                    (preferred) or a `?key=<token>` query param
+                                    (for the claude.ai connector UI, which has no
+                                    header field). Mandatory in HTTP mode — the
+                                    server refuses to start without it rather
+                                    than expose metrics unauthenticated.
     PORT                            listen port in HTTP mode (default 8080;
                                     Cloud Run injects this).
 """
@@ -58,6 +60,7 @@ import sys
 import threading
 from pathlib import Path
 from typing import Optional
+from urllib.parse import parse_qs
 
 from mcp.server.fastmcp import FastMCP
 
@@ -673,7 +676,18 @@ def query_metric(
 
 
 class _BearerAuthMiddleware:
-    """Pure-ASGI gate requiring `Authorization: Bearer <token>` on HTTP requests.
+    """Pure-ASGI gate requiring the shared token on HTTP requests.
+
+    The token may arrive two ways:
+      - `Authorization: Bearer <token>` header — preferred; used by Claude Code
+        (`claude mcp add --header`), the API MCP connector, and direct clients.
+        Keeps the secret out of URLs and request logs.
+      - `?key=<token>` query parameter — because Claude's claude.ai custom-
+        connector UI takes only a URL and has no field for a bearer header or
+        custom headers (anthropics/claude-ai-mcp#112), so the token has to ride
+        in the URL there. Trade-off: a URL-embedded token is visible in request
+        logs (Cloud Run's load-balancer logs included), so rotate it if exposed
+        and prefer the header wherever the client supports one.
 
     Implemented as raw ASGI (not Starlette's BaseHTTPMiddleware) so it never
     buffers the streaming/SSE responses the MCP transport relies on. Non-HTTP
@@ -682,17 +696,30 @@ class _BearerAuthMiddleware:
 
     def __init__(self, app, token: str, exempt_paths: frozenset[str]):
         self.app = app
+        self._token = token
         self._expected = f"Bearer {token}"
         self.exempt_paths = exempt_paths
+
+    def _authorized(self, scope) -> bool:
+        # Constant-time compares so a wrong token can't be recovered by timing.
+        # ASGI delivers headers as a list of (name, value) byte pairs; scan it
+        # directly rather than dict()-ing it, which would silently keep only the
+        # last of any duplicate header.
+        presented = ""
+        for name, value in scope.get("headers") or ():
+            if name == b"authorization":
+                presented = value.decode("latin-1")
+                break
+        if hmac.compare_digest(presented, self._expected):
+            return True
+        query = parse_qs(scope.get("query_string", b"").decode("latin-1"))
+        return any(hmac.compare_digest(v, self._token) for v in query.get("key", ()))
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http" or scope.get("path") in self.exempt_paths:
             await self.app(scope, receive, send)
             return
-        headers = dict(scope.get("headers") or [])
-        presented = headers.get(b"authorization", b"").decode("latin-1")
-        # Constant-time compare so a wrong token can't be recovered by timing.
-        if hmac.compare_digest(presented, self._expected):
+        if self._authorized(scope):
             await self.app(scope, receive, send)
             return
         await send(

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -16,18 +16,42 @@ GOOGLE_APPLICATION_CREDENTIALS. `roles/monitoring.viewer` is sufficient for
 every tool in this server — Pub/Sub metrics are read through the Monitoring
 API, not the Pub/Sub admin API.
 
+Transports:
+    stdio (default)     for local `.mcp.json` spawns and Claude Desktop.
+    streamable-http     for a hosted remote MCP server registered as a Claude
+                        custom connector — the only kind of MCP server that
+                        Claude Code's cloud/routine environment wires up (it
+                        does not spawn the stdio servers from `.mcp.json`). Set
+                        MCP_TRANSPORT=http (or pass --http). See
+                        docs/MCP_GCP_MONITORING.md § "Hosted remote connector".
+
 Configuration (env vars, or repo-root `.env`):
     GOOGLE_APPLICATION_CREDENTIALS      path to the service-account JSON key
     GOOGLE_APPLICATION_CREDENTIALS_B64  base64 of the key JSON itself — for
                                         Claude Code cloud environments, which
                                         only carry single-line env vars; used
-                                        when no key file path resolves
+                                        when no key file path resolves. NOT
+                                        needed on Cloud Run, where the service
+                                        runs as a service account and the
+                                        Monitoring client picks up ADC.
     GCP_PROJECT_ID                  defaults to comdottasteslikegood
     EXPRESS_SERVICE / FLASK_SERVICE / CLOUDSQL_INSTANCE  resource overrides
+
+HTTP-transport-only configuration:
+    MCP_TRANSPORT                   'http'/'streamable-http' to serve over HTTP;
+                                    anything else (default) uses stdio.
+    MCP_AUTH_TOKEN                  shared secret required on every request as
+                                    `Authorization: Bearer <token>`. Mandatory
+                                    in HTTP mode — the server refuses to start
+                                    without it rather than expose metrics
+                                    unauthenticated.
+    PORT                            listen port in HTTP mode (default 8080;
+                                    Cloud Run injects this).
 """
 
 import base64
 import datetime
+import hmac
 import json
 import os
 import sys
@@ -37,7 +61,14 @@ from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+_RESOLVED = Path(__file__).resolve()
+# In the repo the server lives at scripts/monitoring/<file>, so parents[2] is
+# the repo root — used to locate .env and to resolve a relative
+# GOOGLE_APPLICATION_CREDENTIALS path. In the Cloud Run image the file sits at
+# /app/<file> with no such ancestor (and neither .env nor a relative key path is
+# used there — auth is ADC + env vars), so fall back to the file's directory
+# instead of raising IndexError at import and crashing the container.
+REPO_ROOT = _RESOLVED.parents[2] if len(_RESOLVED.parents) > 2 else _RESOLVED.parent
 
 
 def _load_dotenv(path: Path) -> None:
@@ -641,5 +672,87 @@ def query_metric(
     return "\n".join(lines) or f"No data for {metric_type} in the last {minutes_back} min."
 
 
+class _BearerAuthMiddleware:
+    """Pure-ASGI gate requiring `Authorization: Bearer <token>` on HTTP requests.
+
+    Implemented as raw ASGI (not Starlette's BaseHTTPMiddleware) so it never
+    buffers the streaming/SSE responses the MCP transport relies on. Non-HTTP
+    scopes (lifespan, websocket) and exempt paths pass straight through.
+    """
+
+    def __init__(self, app, token: str, exempt_paths: frozenset[str]):
+        self.app = app
+        self._expected = f"Bearer {token}"
+        self.exempt_paths = exempt_paths
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or scope.get("path") in self.exempt_paths:
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers") or [])
+        presented = headers.get(b"authorization", b"").decode("latin-1")
+        # Constant-time compare so a wrong token can't be recovered by timing.
+        if hmac.compare_digest(presented, self._expected):
+            await self.app(scope, receive, send)
+            return
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"www-authenticate", b'Bearer realm="gcp-monitor"'),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"error":"unauthorized"}'})
+
+
+def _run_http() -> None:
+    """Serve the MCP tools over authenticated Streamable HTTP (for Cloud Run)."""
+    # Strip so a secret provisioned with a stray trailing newline/space (a very
+    # easy mistake with `echo | gcloud secrets versions add`) doesn't silently
+    # become a token that never matches the header, and a whitespace-only value
+    # fails closed rather than "authenticating".
+    token = (os.environ.get("MCP_AUTH_TOKEN") or "").strip()
+    if not token:
+        print(
+            "FATAL: MCP_AUTH_TOKEN is unset or blank. Refusing to serve the "
+            "monitoring tools over HTTP without authentication. Set "
+            "MCP_AUTH_TOKEN (from Secret Manager on Cloud Run) and retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    import uvicorn
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+
+    async def _healthz(_request):
+        # Unauthenticated liveness probe — deliberately reveals nothing.
+        return PlainTextResponse("ok")
+
+    app = mcp.streamable_http_app()
+    # Cloud Run's startup/liveness probes and any uptime check hit /healthz
+    # without a token, so it must sit outside the auth gate.
+    app.router.routes.append(Route("/healthz", _healthz, methods=["GET"]))
+    app.add_middleware(
+        _BearerAuthMiddleware, token=token, exempt_paths=frozenset({"/healthz"})
+    )
+
+    port = int(os.environ.get("PORT", "8080"))
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
+
+
+def main() -> None:
+    transport = os.environ.get("MCP_TRANSPORT", "stdio").strip().lower()
+    if "--http" in sys.argv:
+        transport = "http"
+    if transport in ("http", "streamable-http"):
+        _run_http()
+    else:
+        mcp.run(transport="stdio")
+
+
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    main()

--- a/scripts/monitoring/requirements.txt
+++ b/scripts/monitoring/requirements.txt
@@ -6,6 +6,9 @@
 # releases but the pin is unified so both transports share one venv/image.
 mcp>=1.10.0
 google-cloud-monitoring>=2.21.0
-# Only used by the HTTP transport (_run_http); ships with mcp's server extra but
-# pinned explicitly so the Cloud Run image doesn't depend on that being present.
+# Only used by the HTTP transport (_run_http); both ship with mcp's server
+# extra, but gcp_mcp_server.py imports starlette directly and uvicorn is the
+# HTTP entrypoint, so both are pinned explicitly — the Cloud Run image must
+# not depend on mcp's dependency graph keeping them around.
+starlette>=0.40.0
 uvicorn>=0.30.0

--- a/scripts/monitoring/requirements.txt
+++ b/scripts/monitoring/requirements.txt
@@ -1,4 +1,11 @@
 # Runtime dependencies for scripts/monitoring/gcp_mcp_server.py
 # Install with: pip install -r scripts/monitoring/requirements.txt
-mcp>=1.2.0
+#
+# mcp >= 1.10 is required for the Streamable HTTP transport used by the hosted
+# Cloud Run connector (mcp.streamable_http_app()); stdio mode works on older
+# releases but the pin is unified so both transports share one venv/image.
+mcp>=1.10.0
 google-cloud-monitoring>=2.21.0
+# Only used by the HTTP transport (_run_http); ships with mcp's server extra but
+# pinned explicitly so the Cloud Run image doesn't depend on that being present.
+uvicorn>=0.30.0

--- a/scripts/monitoring/run_gcp_monitor.sh
+++ b/scripts/monitoring/run_gcp_monitor.sh
@@ -8,6 +8,29 @@ venv_python="$venv_dir/bin/python"
 requirements="$mon_dir/requirements.txt"
 deps_stamp="$venv_dir/.deps-installed"
 
+# Claude Code cloud environments build the venv in the environment's setup
+# script, which runs BEFORE the repo is cloned — so it can't live at
+# $venv_dir and instead sits at a fixed path baked into the snapshot (see
+# docs/MCP_GCP_MONITORING.md). Use it when it's real, skipping the slow
+# in-repo bootstrap that races the MCP client's startup timeout.
+for prebuilt in "${GCP_MONITOR_VENV:-}" /opt/gcp-monitor-venv; do
+  prebuilt_python="$prebuilt/bin/python"
+  if [[ -n "$prebuilt" && -x "$prebuilt_python" ]] && "$prebuilt_python" - <<'EOF' 2>/dev/null
+import importlib.util as u
+import sys
+
+sys.exit(0 if u.find_spec("mcp") and u.find_spec("google.cloud.monitoring_v3") else 1)
+EOF
+  then
+    if [[ "${1:-}" == "--bootstrap-only" ]]; then
+      echo "Prebuilt venv OK: $prebuilt" >&2
+      exit 0
+    fi
+    cd "$repo_root"
+    exec "$prebuilt_python" "$mon_dir/gcp_mcp_server.py" "$@"
+  fi
+done
+
 # The stamp is written only after pip succeeds, so an interrupted first run
 # (e.g. the MCP client's startup timeout killing us mid-install) re-installs
 # on the next launch instead of exec'ing a half-built venv.

--- a/server/index.ts
+++ b/server/index.ts
@@ -101,7 +101,9 @@ export const ready = (async () => {
   // Error handling middleware (must be last)
   app.use(createErrorHandler());
 
-  if (process.env.VITEST) return;
+  // Skip the real listener under test runners: Vitest sets VITEST itself,
+  // and NODE_ENV=test covers any other harness importing this module.
+  if (process.env.VITEST || process.env.NODE_ENV === 'test') return;
 
   server = app.listen(port, () => {
     console.log(`Server listening on port ${port}`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,8 @@ import {
 import { createFlaskProxy } from './proxy.js';
 import { createValkeyClient, shutdownValkey } from './valkey.js';
 
-const app = express();
+// Exported for route-mounting integration tests (server/routes.test.ts).
+export const app = express();
 const port = Number.parseInt(process.env.PORT || '8080', 10);
 const flaskUrl = process.env.FLASK_BACKEND_URL || 'http://localhost:5000';
 
@@ -24,7 +25,9 @@ app.set('trust proxy', 1);
 let server: Server | null = null;
 
 // ── Async startup ───────────────────────────────────────────────
-(async () => {
+// Exported so tests can await route mounting; under Vitest the routes are
+// mounted but the HTTP listener is not started (tests call app.listen(0)).
+export const ready = (async () => {
   // Connect to Valkey for shared rate limiting (falls back to in-memory)
   const valkeyClient = await createValkeyClient();
 
@@ -83,6 +86,13 @@ let server: Server | null = null;
   app.get('/r/*splat', staticPageLimiter, ssrProxy);
   app.get('/browse', staticPageLimiter, ssrProxy);
   app.get('/sitemap.xml', staticPageLimiter, ssrProxy);
+  // The SSR templates link their stylesheets via Flask's /static/ (e.g.
+  // /static/css/tokens.css). Without this route those requests fall through
+  // to the SPA catch-all, which answers with index.html as text/html — and
+  // Helmet's X-Content-Type-Options: nosniff makes browsers refuse to apply
+  // it, so the public pages render completely unstyled. Mounted after
+  // express.static so Angular build assets (if any collide) still win.
+  app.get('/static/*splat', staticPageLimiter, ssrProxy);
 
   app.get('{*path}', staticPageLimiter, (_req, res) => {
     res.sendFile(path.join(distPath, 'index.html'));
@@ -91,13 +101,17 @@ let server: Server | null = null;
   // Error handling middleware (must be last)
   app.use(createErrorHandler());
 
+  if (process.env.VITEST) return;
+
   server = app.listen(port, () => {
     console.log(`Server listening on port ${port}`);
     console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
     console.log(`Flask backend → ${flaskUrl}`);
     console.log(`Rate limit store: ${valkeyClient ? 'Valkey' : 'in-memory'}`);
   });
-})().catch((err) => {
+})();
+
+ready.catch((err) => {
   console.error('Fatal error during server startup:', err);
   process.exit(1);
 });

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -23,6 +23,10 @@ let flaskStub: http.Server;
 let expressServer: http.Server;
 let baseUrl: string;
 
+// Captured so the env overrides below can be restored for other test files.
+const originalVitestEnv = process.env.VITEST;
+const originalFlaskUrl = process.env.FLASK_BACKEND_URL;
+
 beforeAll(async () => {
   // Stub Flask backend: serves the SSR stylesheet and browse page.
   flaskStub = http.createServer((req, res) => {
@@ -42,6 +46,9 @@ beforeAll(async () => {
 
   // Must be set before importing index.ts — proxy.ts reads it at import time.
   process.env.FLASK_BACKEND_URL = `http://127.0.0.1:${flaskPort}`;
+  // Vitest sets this itself, but make the dependency explicit: index.ts must
+  // see it (or NODE_ENV=test) to skip binding the real listener on import.
+  process.env.VITEST = process.env.VITEST || 'true';
 
   const { app, ready } = await import('./index.js');
   await ready;
@@ -52,6 +59,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (originalVitestEnv === undefined) {
+    delete process.env.VITEST;
+  } else {
+    process.env.VITEST = originalVitestEnv;
+  }
+  if (originalFlaskUrl === undefined) {
+    delete process.env.FLASK_BACKEND_URL;
+  } else {
+    process.env.FLASK_BACKEND_URL = originalFlaskUrl;
+  }
   await new Promise<void>((resolve) => expressServer.close(() => resolve()));
   await new Promise<void>((resolve) => flaskStub.close(() => resolve()));
 });

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Route-mounting integration tests for server/index.ts.
+ *
+ * Production incident 2026-07-04 (v0.3.1): the Flask SSR templates link
+ * their stylesheets at /static/css/*.css, but Express had no proxy rule for
+ * /static — the requests fell through to the SPA catch-all and came back as
+ * index.html (text/html). With Helmet's X-Content-Type-Options: nosniff the
+ * browser refuses to apply a text/html stylesheet, so every public SSR page
+ * rendered completely unstyled.
+ *
+ * These tests boot the real Express app against a stub Flask backend and
+ * assert that /static/* is proxied to Flask (not swallowed by the SPA
+ * fallback), alongside the pre-existing SSR routes.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+const STUB_CSS = ':root { --tokens: loaded; }';
+const STUB_HTML = '<!doctype html><html><body>ssr-browse</body></html>';
+
+let flaskStub: http.Server;
+let expressServer: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  // Stub Flask backend: serves the SSR stylesheet and browse page.
+  flaskStub = http.createServer((req, res) => {
+    if (req.url === '/static/css/tokens.css') {
+      res.writeHead(200, { 'content-type': 'text/css; charset=utf-8' });
+      res.end(STUB_CSS);
+    } else if (req.url === '/browse') {
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(STUB_HTML);
+    } else {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end('{"error": "not found"}');
+    }
+  });
+  await new Promise<void>((resolve) => flaskStub.listen(0, '127.0.0.1', resolve));
+  const flaskPort = (flaskStub.address() as AddressInfo).port;
+
+  // Must be set before importing index.ts — proxy.ts reads it at import time.
+  process.env.FLASK_BACKEND_URL = `http://127.0.0.1:${flaskPort}`;
+
+  const { app, ready } = await import('./index.js');
+  await ready;
+
+  expressServer = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => expressServer.once('listening', resolve));
+  baseUrl = `http://127.0.0.1:${(expressServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => expressServer.close(() => resolve()));
+  await new Promise<void>((resolve) => flaskStub.close(() => resolve()));
+});
+
+describe('SSR static asset proxying', () => {
+  it('proxies /static/* to Flask so SSR stylesheets are served as CSS', async () => {
+    const res = await fetch(`${baseUrl}/static/css/tokens.css`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/css');
+    expect(await res.text()).toBe(STUB_CSS);
+  });
+
+  it('does not serve the SPA index.html for /static/* requests', async () => {
+    const res = await fetch(`${baseUrl}/static/css/tokens.css`);
+    const body = await res.text();
+    expect(res.headers.get('content-type')).not.toContain('text/html');
+    expect(body).not.toContain('<!doctype html>');
+  });
+
+  it('proxies unknown /static/* paths to Flask (404 from Flask, not SPA 200)', async () => {
+    const res = await fetch(`${baseUrl}/static/does-not-exist.css`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('SSR page proxying (guard against regressions)', () => {
+  it('proxies /browse to Flask', async () => {
+    const res = await fetch(`${baseUrl}/browse`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(STUB_HTML);
+  });
+});


### PR DESCRIPTION
## Summary

**v0.3.2** — regression-fix release for v0.3.1, plus monitoring/CI infrastructure. Promotes 15 commits from `dev` to `main`; the `v0.3.2` tag cut from `main` fires the Cloud Build production deploy (migrate job → Flask → Express).

**Fixed — v0.3.1 production regressions:**
- **Public SSR pages render styled again** (#3047, #3048): `GET /static/*` is now proxied to Flask. Previously stylesheet requests fell through to the SPA catch-all, returned `index.html` as `text/html`, and Helmet's `nosniff` made browsers refuse them — every public page rendered unstyled on all devices.
- **Async recipe generation retries transient model failures** (Backend #141 via #3049): the Pub/Sub worker was single-shot, so `gemini-3.1-pro-preview`'s intermittent truncated-JSON responses surfaced to users as "generation failed during async processing". Now retries up to `GENERATION_MAX_ATTEMPTS` (default 3) with real error messages. Backend submodule `b359743` → `ef594bf`.
- **Dynamic sitemap unshadowed** (#3041): removed the stale static `public/sitemap.xml` that `express.static` served ahead of the Flask proxy.

**Added:**
- **gcp-monitor MCP server over authenticated HTTP on Cloud Run** (#3051, #3052): keyless (`monitoring.viewer` SA via ADC), bearer token from Secret Manager, `?key=` query-param fallback; Dockerfile + `deploy_mcp_cloud_run.sh`. Registers as a Claude custom connector so cloud routines get monitoring tools first-class.
- **gcp-monitor cloud-session resilience** (#3043, #3044, #3046): prebuilt-venv cold-start path, PyPI timeout retries, pre-approved project MCP servers.

**Review findings addressed on this PR:**
- `starlette` pinned explicitly in `scripts/monitoring/requirements.txt` (#3056) — imported directly by `gcp_mcp_server.py` in HTTP mode, was only arriving transitively via `mcp`.
- Express catch-all leading-slash comment: false positive, rebutted inline with an empirical repro (`'{*path}'` matches `/` and all subpaths on this Express version; line is unchanged v0.3.1 code serving prod today).

**Changed:**
- **CI gate now runs on PRs targeting `dev`** (#3050), not just pushes.
- **`ci-cd-backend.yml` pytest job gets `PUBSUB_EMULATOR_HOST`** (#3055): the Backend #141 retry test imports `services/pubsub_service`, whose module-level Pub/Sub client needs ADC unless the emulator env is set. pr-gate.yml already had it; this workflow (which only fires on PRs to `main`) didn't — first red on this very PR, fixed and re-run green. Backend follow-up noted in #3055: lazy-init the client.
- GBrain docs/config refresh (#3042, #3045); `docs/MCP_GCP_MONITORING.md` § 4.5 for the connector setup.
- Version bump + CHANGELOG (#3053).

## Test Coverage

New `server/routes.test.ts` integration suite (route mounting via exported `app`/`ready`) covers the `/static/*` proxy fix. Backend retry fix covered by `tests/test_worker_generation_retry.py` (Backend #141). All other commits shipped with their own reviewed PRs into `dev`.

## Pre-Landing Review

All 13 commits landed via reviewed PRs into `dev` (Copilot review on #3047 addressed in #3048). Fresh diff review of the production-facing `server/index.ts` changes on this branch: no issues — listener guard only activates under `VITEST`/`NODE_ENV=test`; Cloud Run runs `NODE_ENV=production`.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

No plan file — this is a release promotion of already-planned work. Deploy checklist from CLAUDE.md verified: single Alembic head (`c60f6530f4ff`), Backend pointer at Backend `origin/dev` tip (`ef594bf`), no unreflected Backend commits.

## Verification Results (fresh, at release HEAD)

- Vitest: **51/51 passed** (4 files)
- ESLint: clean (`--max-warnings 0`)
- `tsc --noEmit`: clean (both tsconfigs)
- `ng build`: complete — pre-existing bundle-budget warning only (790 kB vs 500 kB, tracked)
- Backend pytest at `ef594bf`: **126 passed**

## Release mechanics

- ⚠️ **Merge with a MERGE COMMIT, never squash** — the v0.3.0 squash-merge broke `dev`/`main` shared history and forced a reconcile merge (#3040).
- On merge, `release.yml` reads `package.json` (0.3.2), pushes tag `v0.3.2`, and publishes the GitHub Release with the CHANGELOG section.
- The tag matches `^v[0-9]+\.[0-9]+\.[0-9]+$` → Cloud Build trigger (us-central1) builds both images, runs `flask-backend-migrate` (blocking), deploys `flask-backend` then `express-frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
