### PR TITLE
ci: set PUBSUB_EMULATOR_HOST for the flask-backend pytest job

### DIFF
--- a/.github/workflows/ci-cd-backend.yml
+++ b/.github/workflows/ci-cd-backend.yml
@@ -30,4 +30,9 @@ jobs:
         run: uv sync
       - name: Run pytest
         working-directory: Backend
+        env:
+          # services/pubsub_service.py builds its Pub/Sub client at import
+          # time; without this the suite needs real ADC and dies with
+          # DefaultCredentialsError (same env as pr-gate.yml's pytest job).
+          PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest


### PR DESCRIPTION
## Summary

Release PR #3054 has one red check: `Install & pytest` (workflow `CI — Flask (flask-backend)`) fails on `tests/test_worker_generation_retry.py::test_worker_retries_transient_generation_failure` with `google.auth.exceptions.DefaultCredentialsError`.

**Root cause:** the test (new in Backend #141) patches `services.pubsub_service.publish_message`, which imports `services/pubsub_service.py` — and that module constructs its Pub/Sub client at import time, calling `google.auth.default()`. `pr-gate.yml`'s pytest job already sets `PUBSUB_EMULATOR_HOST: localhost:8085` (emulator mode needs no credentials), which is why `Backend — pytest` is green on the same commit. `ci-cd-backend.yml` ran bare `uv run pytest`, and it only triggers on PRs targeting `main` — so the gap stayed invisible until the release PR.

**Fix:** mirror the same `env:` into `ci-cd-backend.yml`.

**Verified locally** (ADC deliberately hidden):
- without the env: `1 failed, 9 passed` — reproduces CI exactly
- with `PUBSUB_EMULATOR_HOST=localhost:8085`: `10 passed`

Follow-up worth a ticket (Backend): lazy-init the Pub/Sub client in `services/pubsub_service.py` so importing the module never requires credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

