### PR TITLE
fix: declare starlette explicitly in gcp-monitor requirements

### DIFF
--- a/scripts/monitoring/requirements.txt
+++ b/scripts/monitoring/requirements.txt
@@ -6,6 +6,9 @@
 # releases but the pin is unified so both transports share one venv/image.
 mcp>=1.10.0
 google-cloud-monitoring>=2.21.0
-# Only used by the HTTP transport (_run_http); ships with mcp's server extra but
-# pinned explicitly so the Cloud Run image doesn't depend on that being present.
+# Only used by the HTTP transport (_run_http); both ship with mcp's server
+# extra, but gcp_mcp_server.py imports starlette directly and uvicorn is the
+# HTTP entrypoint, so both are pinned explicitly — the Cloud Run image must
+# not depend on mcp's dependency graph keeping them around.
+starlette>=0.40.0
 uvicorn>=0.30.0


### PR DESCRIPTION
## Summary

Review finding (Copilot + review bot) on release PR #3054: `scripts/monitoring/gcp_mcp_server.py` imports `starlette.responses` and `starlette.routing` directly in HTTP mode (`_run_http`, lines 755-756), but `requirements.txt` only got it transitively through `mcp`. If mcp ever restructures its deps, the Cloud Run connector image breaks.

One-line fix: pin `starlette>=0.40.0` alongside the existing explicit `uvicorn` pin, which exists for exactly the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

