### PR TITLE
fix(gcp-monitor): disable DNS-rebinding Host allowlist so the hosted connector works behind a proxy

### DIFF
--- a/docs/MCP_GCP_MONITORING.md
+++ b/docs/MCP_GCP_MONITORING.md
@@ -363,6 +363,13 @@ suggestions.
 
 ## Troubleshooting
 
+- **Hosted connector returns 421 / logs `Invalid Host header`** — the MCP SDK's
+  DNS-rebinding protection defaults to a localhost-only Host allowlist, so behind
+  a TLS proxy (Railway/Cloud Run) it rejects the proxied Host. The server
+  disables that protection by default in HTTP mode, so this only appears if
+  you've set `MCP_ALLOWED_HOSTS` and the incoming Host isn't in it — add the
+  proxy's public hostname (e.g. `myapp.up.railway.app`) to the list, or unset
+  the var to accept any Host (the secret URL path is the access control).
 - **Tools never register on the very first session** — the cold-start pip
   install can exceed the MCP client's startup timeout, so the server gets
   killed mid-bootstrap and no tools appear. Run

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -50,7 +50,15 @@ HTTP-transport-only configuration:
                                     can't send headers and treats a 401 as an
                                     OAuth prompt (see _run_http docstring).
     PORT                            listen port in HTTP mode (default 8080;
-                                    Cloud Run injects this).
+                                    Cloud Run / Railway inject this).
+    MCP_ALLOWED_HOSTS               optional comma-separated Host allowlist. When
+                                    set, the SDK's DNS-rebinding protection is
+                                    enabled and only these Hosts are accepted.
+                                    When unset (default), that protection is off
+                                    so the connector works behind any TLS proxy —
+                                    otherwise the SDK's localhost-only default
+                                    rejects the proxied Host ("Invalid Host
+                                    header", seen by the client as 421).
 """
 
 import base64
@@ -730,10 +738,33 @@ def _run_http() -> None:
     import uvicorn
     from starlette.responses import PlainTextResponse
     from starlette.routing import Route
+    from mcp.server.transport_security import TransportSecuritySettings
 
     async def _healthz(_request):
         # Unauthenticated liveness probe — deliberately reveals nothing.
         return PlainTextResponse("ok")
+
+    # The MCP SDK's DNS-rebinding guard defaults to a localhost-only Host
+    # allowlist, so behind a TLS proxy (Railway/Cloud Run) it rejects every
+    # request with "Invalid Host header" (surfaces to the client as 421). That
+    # guard exists to protect browser-reachable *localhost* servers from
+    # malicious web pages — not the threat model for a public server whose
+    # access control is the secret URL path. Disable it by default so the
+    # connector works behind any proxy; an operator who wants it on can pin the
+    # host(s) with MCP_ALLOWED_HOSTS (comma-separated).
+    allowed_hosts = [
+        h.strip() for h in os.environ.get("MCP_ALLOWED_HOSTS", "").split(",") if h.strip()
+    ]
+    if allowed_hosts:
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=[f"https://{h}" for h in allowed_hosts],
+        )
+    else:
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=False,
+        )
 
     # Mount the MCP endpoint under the secret path. Knowing the path is the
     # credential; the app carries no separate auth gate, so it never emits a 401

--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -50,7 +50,7 @@ HTTP-transport-only configuration:
                                     can't send headers and treats a 401 as an
                                     OAuth prompt (see _run_http docstring).
     PORT                            listen port in HTTP mode (default 8080;
-                                    Cloud Run / Railway inject this).
+                                    Cloud Run / Railway injects this).
     MCP_ALLOWED_HOSTS               optional comma-separated Host allowlist. When
                                     set, the SDK's DNS-rebinding protection is
                                     enabled and only these Hosts are accepted.
@@ -756,10 +756,30 @@ def _run_http() -> None:
         h.strip() for h in os.environ.get("MCP_ALLOWED_HOSTS", "").split(",") if h.strip()
     ]
     if allowed_hosts:
+        # A proxied Host header may or may not carry an explicit port
+        # (`app.example.com` vs `app.example.com:443`), and the SDK matches
+        # allowed_hosts by exact string or a `host:*` any-port pattern. Expand
+        # each entry so the operator doesn't have to guess what the proxy sends:
+        # a bare host also allows `host:*`, and a `host:port` entry also allows
+        # the bare host.
+        expanded_hosts: list[str] = []
+        bare_hosts: list[str] = []
+        for h in allowed_hosts:
+            bare = h.split(":", 1)[0]
+            bare_hosts.append(bare)
+            expanded_hosts.append(h)
+            expanded_hosts.append(bare if ":" in h else f"{h}:*")
+        expanded_hosts = list(dict.fromkeys(expanded_hosts))
+        origins = list(
+            dict.fromkeys(
+                [f"https://{b}" for b in bare_hosts]
+                + [f"https://{b}:*" for b in bare_hosts]
+            )
+        )
         mcp.settings.transport_security = TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
-            allowed_hosts=allowed_hosts,
-            allowed_origins=[f"https://{h}" for h in allowed_hosts],
+            allowed_hosts=expanded_hosts,
+            allowed_origins=origins,
         )
     else:
         mcp.settings.transport_security = TransportSecuritySettings(


### PR DESCRIPTION
## Description

Follow-up to #3058. With the secret-path connector deployed to Railway, registration/health checks failed — the Railway logs showed **`Invalid Host header: <app>.up.railway.app`**, surfaced to the client as HTTP **421**.

Root cause: the MCP SDK's `TransportSecuritySettings` enables **DNS-rebinding protection** with a **localhost-only Host allowlist by default**, so behind a TLS proxy (Railway/Cloud Run) it rejects every proxied request. It worked in local testing only because the Host there was `127.0.0.1`.

That guard exists to protect browser-reachable *localhost* MCP servers from malicious web pages — it's not the threat model for a **public** server whose access control is the **secret URL path**. So in HTTP mode the server now sets `enable_dns_rebinding_protection=False` by default, and it works behind any TLS proxy. Operators who want the protection on can pin the public host(s) with **`MCP_ALLOWED_HOSTS`** (comma-separated), which re-enables it with that allowlist.

- `gcp_mcp_server.py`: `_run_http()` sets `mcp.settings.transport_security` before building the app — off by default, or an allowlist from `MCP_ALLOWED_HOSTS`. Docstring documents the new var.
- `docs/MCP_GCP_MONITORING.md`: troubleshooting entry for the 421 / `Invalid Host header`.

## Related Issues

Relates to #3058

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

Verified against `mcp 1.28.1`, spoofing the real Railway Host header on `POST /<token>/mcp` initialize:

- [x] default (no `MCP_ALLOWED_HOSTS`) → `200`
- [x] `MCP_ALLOWED_HOSTS=<that host>` → `200`
- [x] `MCP_ALLOWED_HOSTS=other.example.com` → `421` (correctly rejected)
- [x] `py_compile` clean

Node checklist items N/A — Python + docs only.

- [ ] Tests pass locally (`npm run test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Code is formatted (`npm run format`)
- [ ] Build succeeds (`npm run build`)
- [ ] Type checking passes (`npm run type-check`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This is the last blocker for the Railway-hosted connector: once deployed, `POST /<token>/mcp` returns `200` behind the proxy and the connector registers cleanly (no OAuth prompt, no Host rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3QhyMrJ9vfDPUVtpvi55m

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3QhyMrJ9vfDPUVtpvi55m)_



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

