### PR TITLE
fix(pm): honor documented ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,8 @@ ATLASSIAN_CONFLUENCE_SPACE_ID=11042818
 ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID=11796481
 # Optional: separate parent for per-session Confluence log pages created by pi session-log tooling.
 # Defaults to ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID when unset.
-# ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID=11796481
+# 29884418 = "AI Session Logs" index page in the TLG space.
+# ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID=29884418
 ATLASSIAN_CONFLUENCE_BRIEFING_TITLE=Project PM Briefing - Live State
 
 # GCP monitoring MCP server (scripts/monitoring/gcp_mcp_server.py)

--- a/scripts/pm/pm_daemon.py
+++ b/scripts/pm/pm_daemon.py
@@ -323,7 +323,7 @@ def create_epic_from_roadmap(epic_name: str, description: str, project_key: str 
     except Exception as e:
         return f"Error creating Epic: {e}"
 
-# Parent page ID for session logs (created under Project Documentation)
+# Parent page ID for session logs; falls back to the Project Documentation parent when unset
 SESSION_LOGS_PARENT_ID = os.environ.get('ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID') or os.environ.get('CONFLUENCE_SESSION_LOGS_PARENT_ID', PARENT_PAGE_ID)
 
 def _render_session_log_html(

--- a/scripts/pm/pm_daemon.py
+++ b/scripts/pm/pm_daemon.py
@@ -324,7 +324,7 @@ def create_epic_from_roadmap(epic_name: str, description: str, project_key: str 
         return f"Error creating Epic: {e}"
 
 # Parent page ID for session logs (created under Project Documentation)
-SESSION_LOGS_PARENT_ID = os.environ.get('CONFLUENCE_SESSION_LOGS_PARENT_ID', PARENT_PAGE_ID)
+SESSION_LOGS_PARENT_ID = os.environ.get('ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID') or os.environ.get('CONFLUENCE_SESSION_LOGS_PARENT_ID', PARENT_PAGE_ID)
 
 def _render_session_log_html(
     session_id: str,


### PR DESCRIPTION
## Description

`pm_daemon.py`'s session-log parent page ID still read the legacy `CONFLUENCE_SESSION_LOGS_PARENT_ID` env var, while `docs/PM_TOOLING.md`, `.env.example`, and `scripts/pm/publish_session_log.py` all document `ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID`. Setting the documented var was silently ignored, so `log_agent_session` filed pages under the general Project Documentation parent instead of the Session Logs parent.

This one-liner makes the daemon prefer the documented name with the legacy one as a fallback — the same pattern `ebace0e` applied to the space and parent-page vars but missed for the session-logs parent. `d3df2c7` had already switched the docs to the new name, so docs and code now finally agree.

## Related Issues

Follow-up to the PM tooling shipped via #3030 / #3039 (originally scaffolded in #2955).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes

## Testing

Python-only change to an MCP daemon script; the npm suites don't cover it.

- [x] `python3 -m py_compile scripts/pm/pm_daemon.py` passes
- [x] Verified `publish_session_log.py`, `docs/PM_TOOLING.md`, and `.env.example` all use the now-honored var name

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (docs already used the new name — no change needed)
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

Behavior is unchanged for anyone using the legacy var or no var at all (falls back to `PARENT_PAGE_ID` as before). Note the site defaults already point at `tasteslikegood.atlassian.net` — the sunset `-dev` site is not referenced anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWSJdj9xyEZzNSUghQMotU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWSJdj9xyEZzNSUghQMotU)_






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

