### PR TITLE
feat(publish): guest "Sign in to publish" affordance (T1, pairs with Backend #142)

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -384,9 +384,12 @@
                         ></span>
                       </button>
                     </div>
-                  } @else {
+                  } @else if (isSaved()) {
                     <!-- Guests can't publish: no accountable identity behind
-                         public pages. The server enforces this too. -->
+                         public pages. The server enforces this too. Gated on
+                         isSaved() so the CTA never sends a guest into the
+                         OAuth redirect with an unsaved, unrecoverable recipe
+                         still only in memory. -->
                     <button
                       type="button"
                       (click)="openAuthModal()"
@@ -396,7 +399,7 @@
                       Sign in to publish
                     </button>
                   }
-                  @if (r.is_public) {
+                  @if (canPublish() && r.is_public) {
                     <div class="flex items-center gap-2 ml-1 animate-[fadeIn_0.2s]">
                       <input
                         type="text"

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -360,29 +360,42 @@
 
                 <!-- v0.2 Anti-Recipe Distribution Controls -->
                 <div class="flex items-center gap-2 ml-2 pl-4 border-l border-stone-200">
-                  <div class="flex items-center gap-2">
-                    <span
-                      id="public-toggle-label"
-                      class="text-[10px] font-bold uppercase text-stone-400"
-                      >Public</span
-                    >
+                  @if (canPublish()) {
+                    <div class="flex items-center gap-2">
+                      <span
+                        id="public-toggle-label"
+                        class="text-[10px] font-bold uppercase text-stone-400"
+                        >Public</span
+                      >
+                      <button
+                        type="button"
+                        role="switch"
+                        [attr.aria-checked]="r.is_public"
+                        aria-labelledby="public-toggle-label"
+                        (click)="togglePublic(r)"
+                        class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
+                        [class.bg-green-600]="r.is_public"
+                        [class.bg-stone-300]="!r.is_public"
+                      >
+                        <span
+                          class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"
+                          [class.translate-x-5]="r.is_public"
+                          [class.translate-x-1]="!r.is_public"
+                        ></span>
+                      </button>
+                    </div>
+                  } @else {
+                    <!-- Guests can't publish: no accountable identity behind
+                         public pages. The server enforces this too. -->
                     <button
                       type="button"
-                      role="switch"
-                      [attr.aria-checked]="r.is_public"
-                      aria-labelledby="public-toggle-label"
-                      (click)="togglePublic(r)"
-                      class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
-                      [class.bg-green-600]="r.is_public"
-                      [class.bg-stone-300]="!r.is_public"
+                      (click)="openAuthModal()"
+                      class="text-[10px] font-bold uppercase text-stone-400 hover:text-green-600 underline underline-offset-2 transition-colors"
+                      aria-label="Sign in to publish this recipe"
                     >
-                      <span
-                        class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"
-                        [class.translate-x-5]="r.is_public"
-                        [class.translate-x-1]="!r.is_public"
-                      ></span>
+                      Sign in to publish
                     </button>
-                  </div>
+                  }
                   @if (r.is_public) {
                     <div class="flex items-center gap-2 ml-1 animate-[fadeIn_0.2s]">
                       <input

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -882,7 +882,19 @@ export class AppComponent {
 
   // ─── v0.2 Distribution Methods ────────────────────────────
 
+  /** Publishing is OAuth-gated: guests have no accountable identity, so the
+   *  server forces is_public=false for them — the UI must not pretend
+   *  otherwise. */
+  canPublish = computed(() => {
+    const user = this.authService.currentUser();
+    return !!user && !user.isGuest;
+  });
+
   async togglePublic(recipe: Recipe) {
+    if (!this.canPublish()) {
+      this.openAuthModal();
+      return;
+    }
     const nextState = !recipe.is_public;
     recipe.is_public = nextState;
 

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -887,7 +887,7 @@ export class AppComponent {
    *  otherwise. */
   canPublish = computed(() => {
     const user = this.authService.currentUser();
-    return !!user && !user.isGuest;
+    return !!user && user.isGuest === false;
   });
 
   async togglePublic(recipe: Recipe) {


### PR DESCRIPTION
## What

UI half of the publish accountability gate (T1 of the post-v0.3.2 plan, eng-review 3A):

- Guests no longer see the Public toggle — they get a **"Sign in to publish"** affordance that opens the auth modal. The server enforces the gate regardless (Backend #142); this keeps the UI honest instead of showing a switch that would silently revert.
- `togglePublic()` guards client-side via a new `canPublish()` computed (`currentUser` present and not `isGuest`).

## Depends on

- Backend PR adamtasteslikegood/tasteslikegood.com#142 (server-side gate + data migration). **The submodule bump to the merged Backend SHA will be pushed to this branch once #142 lands** — do not merge before that.
- Deploy note: set `GUEST_PUBLIC_REASSIGN_EMAIL` on the `flask-backend-migrate` job env before the next release if existing guest-owned public recipes should be reassigned (keeps indexed /r/* pages live) instead of unpublished. Inventory: `SELECT id, slug FROM recipe WHERE is_public AND user_id IS NULL;`

## Verification

- `npm run type-check` ✓, `npm run lint` ✓, `npm run build` ✓ (bundle-budget warning pre-existing)
- Server-side behavior covered by 11 pytest cases in #142; /qa E2E flow ("guest sees sign-in affordance; direct API attempt stays private") queued in the eng-review test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)












<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

