### PR TITLE
fix: move metric_pb2 import to module top-level in gcp_mcp_server.py

### DIFF
--- a/scripts/monitoring/gcp_mcp_server.py
+++ b/scripts/monitoring/gcp_mcp_server.py
@@ -71,6 +71,7 @@ import threading
 from pathlib import Path
 from typing import Optional
 
+from google.api import metric_pb2
 from mcp.server.fastmcp import FastMCP
 
 _RESOLVED = Path(__file__).resolve()
@@ -614,8 +615,6 @@ def list_available_metrics(prefix: str, limit: int = 50) -> str:
                 "filter": f'metric.type = starts_with("{prefix.replace(chr(34), "")}")',
             }
         )
-        from google.api import metric_pb2
-
         lines = []
         for descriptor in descriptors:
             # MetricDescriptor is a raw protobuf message (google.api), so the


### PR DESCRIPTION
## Summary
Moves `from google.api import metric_pb2` from inside `list_available_metrics()` to the module's top-level imports in `scripts/monitoring/gcp_mcp_server.py`, following standard Python convention and avoiding repeated import lookups on every function call.

## Verification
- Parsed the file with `ast.parse` — syntax valid.
- Imported `metric_pb2` and the full module via the project's `scripts/monitoring/.venv` — both succeed with no side effects or circular import issues.

Fixes #3025






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

