### PR TITLE
feat(pm): apply agent-session-log label; point session-log parent at Agent Session Logs index

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,11 @@ ATLASSIAN_JIRA_DELIVERY_PROJECT_KEY=RCP
 ATLASSIAN_CONFLUENCE_SPACE_KEY=TLG
 ATLASSIAN_CONFLUENCE_SPACE_ID=11042818
 ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID=11796481
-# Optional: separate parent for per-session Confluence log pages created by pi session-log tooling.
+# Optional: separate parent for per-session Confluence log pages created by the
+# session-log tooling (pm_daemon log_agent_session; publish_session_log.py, used
+# by the pi agent and other coding agents).
 # Defaults to ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID when unset.
+# Alias: CONFLUENCE_SESSION_LOGS_PARENT_ID (the prefixed name wins if both are set).
 # 34635777 = "Agent Session Logs" index page in the TLG space (coding-agent
 # logs; the separate "AI Session Logs" page 29884418 is for Rovo sessions).
 # ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID=34635777

--- a/.env.example
+++ b/.env.example
@@ -54,8 +54,9 @@ ATLASSIAN_CONFLUENCE_SPACE_ID=11042818
 ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID=11796481
 # Optional: separate parent for per-session Confluence log pages created by pi session-log tooling.
 # Defaults to ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID when unset.
-# 29884418 = "AI Session Logs" index page in the TLG space.
-# ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID=29884418
+# 34635777 = "Agent Session Logs" index page in the TLG space (coding-agent
+# logs; the separate "AI Session Logs" page 29884418 is for Rovo sessions).
+# ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID=34635777
 ATLASSIAN_CONFLUENCE_BRIEFING_TITLE=Project PM Briefing - Live State
 
 # GCP monitoring MCP server (scripts/monitoring/gcp_mcp_server.py)

--- a/docs/PM_TOOLING.md
+++ b/docs/PM_TOOLING.md
@@ -47,7 +47,9 @@ Creates structured Confluence pages for each agent session with:
 
 **Template:** See `scripts/pm/templates/session_log.md`
 
-**Confluence location:** Pages are created under the Session Logs parent page (configured via `ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID` env var, or its alias `CONFLUENCE_SESSION_LOGS_PARENT_ID`; defaults to the Project Documentation parent).
+**Confluence location:** Pages are created under the Session Logs parent page (configured via `ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID` env var, or its alias `CONFLUENCE_SESSION_LOGS_PARENT_ID`; defaults to the Project Documentation parent). Point it at the "Agent Session Logs" index page (`34635777` in the TLG space) — the separate "AI Session Logs" page is reserved for conversational Rovo sessions.
+
+**Label:** Both `log_agent_session` and `publish_session_log.py` automatically apply the `agent-session-log` label to each page, per the Agent Session Logs index conventions. Filter with CQL: `type = page AND label = "agent-session-log"`.
 
 ### 3. Jira/Confluence Status (`scripts/pm/sync_jira_confluence_status.py`)
 

--- a/scripts/pm/atlassian_pm_link.py
+++ b/scripts/pm/atlassian_pm_link.py
@@ -80,7 +80,8 @@ class AtlassianClient:
         path: str,
         *,
         query: dict[str, Any] | None = None,
-        payload: dict[str, Any] | None = None,
+        # list payloads: some v1 endpoints (e.g. content labels) take a JSON array
+        payload: dict[str, Any] | list[Any] | None = None,
     ) -> dict[str, Any]:
         url = self.config.base_url + path
         if query:

--- a/scripts/pm/pm_daemon.py
+++ b/scripts/pm/pm_daemon.py
@@ -441,7 +441,22 @@ def log_agent_session(
                 page_url = f"https://{URL_BASE}/wiki{webui_path}" if webui_path.startswith("/spaces") else f"https://{URL_BASE}{webui_path}"
             else:
                 page_url = f"https://{URL_BASE}/wiki/pages/viewpage.action?pageId={page_id}"
-            return f"Session logged successfully: {title}\nConfluence URL: {page_url}"
+            # The Agent Session Logs index requires every entry to carry this
+            # label for CQL filtering. Labels aren't supported on the v2 page
+            # create payload, so apply via the v1 API; best-effort only.
+            label_note = ""
+            try:
+                label_resp = requests.post(
+                    f"https://{URL_BASE}/wiki/rest/api/content/{page_id}/label",
+                    headers=HEADERS,
+                    json=[{"prefix": "global", "name": "agent-session-log"}],
+                    timeout=TIMEOUT,
+                )
+                if label_resp.status_code not in [200, 201]:
+                    label_note = f"\nWarning: agent-session-log label not applied: {label_resp.status_code}"
+            except Exception as e:
+                label_note = f"\nWarning: agent-session-log label not applied: {e}"
+            return f"Session logged successfully: {title}\nConfluence URL: {page_url}{label_note}"
         else:
             return f"Failed to log session: {response.status_code} {response.text}"
     except Exception as e:

--- a/scripts/pm/pm_daemon.py
+++ b/scripts/pm/pm_daemon.py
@@ -453,7 +453,7 @@ def log_agent_session(
                     timeout=TIMEOUT,
                 )
                 if label_resp.status_code not in [200, 201]:
-                    label_note = f"\nWarning: agent-session-log label not applied: {label_resp.status_code}"
+                    label_note = f"\nWarning: agent-session-log label not applied: {label_resp.status_code} {label_resp.text[:200]}"
             except Exception as e:
                 label_note = f"\nWarning: agent-session-log label not applied: {e}"
             return f"Session logged successfully: {title}\nConfluence URL: {page_url}{label_note}"

--- a/scripts/pm/publish_session_log.py
+++ b/scripts/pm/publish_session_log.py
@@ -55,6 +55,19 @@ def main() -> None:
     print(f"Created Confluence session log page {page_id}: {title}")
     print(f"URL: {config.base_url}/wiki/spaces/{config.confluence_space_key}/pages/{page_id}")
 
+    # The Agent Session Logs index requires the agent-session-log label on
+    # every entry (CQL filtering). Labels can't ride on the v2 create payload,
+    # so apply via the v1 API; a label failure shouldn't fail the publish.
+    try:
+        client.request_json(
+            "POST",
+            f"/wiki/rest/api/content/{page_id}/label",
+            payload=[{"prefix": "global", "name": "agent-session-log"}],
+        )
+        print("Label: agent-session-log")
+    except AtlassianError as exc:
+        print(f"Warning: agent-session-log label not applied: {exc}")
+
 
 if __name__ == "__main__":
     try:

--- a/scripts/pm/publish_session_log.py
+++ b/scripts/pm/publish_session_log.py
@@ -36,6 +36,7 @@ def main() -> None:
     parent_id = (
         args.parent_id
         or os.environ.get("ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID")
+        or os.environ.get("CONFLUENCE_SESSION_LOGS_PARENT_ID")
         or config.confluence_parent_page_id
     )
     title = args.title or default_title(markdown_path)


### PR DESCRIPTION
## Description

Follow-up to #3065 and #3067, closing the remaining gaps between the session-log tooling and the "Agent Session Logs" Confluence index (`34635777`, TLG space):

- **`agent-session-log` label**: the index requires every entry to carry this label for CQL filtering (`type = page AND label = "agent-session-log"`), but neither `log_agent_session` (pm daemon) nor `publish_session_log.py` applied any label. Both now add it after page creation via the v1 content-label API — labels can't ride on the v2 create payload. A label failure is surfaced as a warning and never fails the publish. (`atlassian_pm_link.request_json` payload type hint loosened to accept the JSON-array body the label endpoint takes.)
- **`.env.example` parent correction**: the example pointed `ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID` at the "AI Session Logs" page (`29884418`), which that page reserves for conversational Rovo sessions. Coding-agent logs belong under "Agent Session Logs" (`34635777`) — the page the live `.env` already targets per #3067.
- **`docs/PM_TOOLING.md`**: documents the intended parent page and the automatic label.

Title formats are **intentionally unchanged**: the Agent Session Logs index documents the scripts' existing patterns (`Session Log: {agent} — {YYYYMMDD-HHMMSS}` automated, `Session Log - YYYY-MM-DD - {branch} - {description}` manual) as the convention; the `AI Session Log — …` pattern belongs to the Rovo index.

## Related Issues

Relates to #3065, #3067

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes

## Testing

Python-only change to PM scripts; the npm suites don't cover them.

- [x] `python3 -m py_compile scripts/pm/pm_daemon.py scripts/pm/publish_session_log.py` passes
- [x] `atlassian_pm_link.py` fails `py_compile` on Python 3.11 identically before and after this change (pre-existing 3.12+ f-string syntax; my edit there is a type hint only)
- [x] Verified conventions against the live "Agent Session Logs" Confluence page (`34635777`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

Label application is best-effort by design: a page that publishes but misses its label is recoverable by hand; failing the whole publish over a label is not worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWSJdj9xyEZzNSUghQMotU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWSJdj9xyEZzNSUghQMotU)_









<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

