### PR TITLE
Reflect active work in Jira KAN

### DIFF
--- a/.pi/prompts/atlassian-session-log.md
+++ b/.pi/prompts/atlassian-session-log.md
@@ -15,7 +15,9 @@ Requirements:
 - Treat **Confluence** as durable planning/session truth
 - Keep the output non-destructive and handoff-friendly
 - Explicitly assess whether Atlassian is aligned, partially aligned, or drifting from the work done in this session
-- Include concrete branch / PR / Jira / Confluence refs when available
+- Include concrete branch / worktree / PR / Jira / Confluence refs when available
+- State the active KAN execution update needed: owner/status/blocker/handoff/next action
+- State the RCP delivery impact, or explicitly write that no delivery-scope update is required
 - Include PM sync health (`pm:start`, `pm:sync`, `pm:status`, daemon state) when known
 - Never include raw secrets, tokens, or `.env` values
 - Include concrete next actions for the next agent or teammate

--- a/.pi/prompts/atlassian-session-todo.md
+++ b/.pi/prompts/atlassian-session-todo.md
@@ -11,6 +11,8 @@ Focus override: $@
 
 Requirements:
 - Separate execution updates for **KAN** from delivery updates for **RCP**
+- For KAN, include branch/worktree, current status, blocker or handoff, next action, and PR/file refs
+- For RCP, create TODOs only for sprint, epic, release, acceptance, or scope changes; otherwise say no RCP update is required
 - Call out Confluence documentation follow-ups separately
 - Keep each TODO small, explicit, and branch/PR aware
 - Include branch / PR / Jira / session-log refs where available

--- a/.pi/skills/atlassian-session-log/references/SESSION_LOG_SCHEMA.md
+++ b/.pi/skills/atlassian-session-log/references/SESSION_LOG_SCHEMA.md
@@ -16,6 +16,7 @@ Use this markdown structure for every generated session log.
 ## Relevant Refs
 - Root PR:
 - Backend PR:
+- Branch / worktree:
 - KAN issue:
 - RCP issue:
 - Prior Confluence refs:
@@ -34,9 +35,9 @@ Short narrative of what happened in this session.
 
 ## Atlassian Alignment
 - Verdict: Aligned | Partially aligned | Drifting
-- KAN:
-- RCP:
-- Confluence:
+- KAN: active branch/work ownership, blockers, handoffs, and next action are visible or the missing update is named
+- RCP: delivery scope, epic, sprint, or acceptance impact is visible, or explicitly marked no delivery-scope change
+- Confluence: session log and relevant planning/docs update status
 - PM daemon / sync status:
 
 ## Atlassian Sync Status
@@ -59,16 +60,17 @@ Short narrative of what happened in this session.
 
 ## Artifacts Created
 - PRs
-- Jira updates
+- Jira/KAN updates
+- Jira/RCP updates
 - docs / scripts / extensions / skills
 - other durable outputs
 
 ## Recommended Updates
 ### Jira KAN
-- execution-side updates to make
+- execution-side updates to make: branch/work owner, current status, blocker/handoff, next action, PR/file refs
 
 ### Jira RCP
-- delivery-side updates to make
+- delivery-side updates to make only when sprint, epic, release, acceptance, or scope changed; otherwise write "No RCP update required"
 
 ### Confluence
 - durable context pages or docs to update

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Quick commands:
 ```sh
 npm run pm:start             # connectivity check + local PM briefing
 npm run pm:brief             # refresh local PM briefing
+npm run pm:reflect           # compare local git state to Jira/KAN linkage
 npm run pm:sync              # publish/update Confluence briefing
 npm run pm:status            # live Jira + PR + Confluence + prod snapshot
 npm run pm:daemon            # start daemon in background on this VM

--- a/docs/ATLASSIAN_PM_LINK.md
+++ b/docs/ATLASSIAN_PM_LINK.md
@@ -38,10 +38,15 @@ Verifies Jira and Confluence connectivity without writing files.
 
 ```sh
 npm run pm:brief
-npm run pm:reflect
 ```
 
 Fetches Jira issues and Confluence planning/session pages, then writes the local briefing, cache, and `.agent-work/pm/JIRA_KAN_WORK_REFLECTION.md`. The reflection file compares local git state to Jira refs so KAN can show the work actually happening on branches/worktrees. It also refreshes `jira_issues.txt` for older workflows when requested.
+
+```sh
+npm run pm:reflect
+```
+
+Standalone alternative that regenerates only the work reflection file without refreshing the full briefing or cache. `pm:brief` and `pm:sync` already write this file, so use `pm:reflect` when you want the reflection-only view without paying the cost of a full briefing.
 
 ```sh
 npm run pm:sync

--- a/docs/ATLASSIAN_PM_LINK.md
+++ b/docs/ATLASSIAN_PM_LINK.md
@@ -4,7 +4,8 @@ This repo has a lightweight PM/session bridge for Jira and Confluence. It is des
 
 ## Source Of Truth
 
-- Jira project: `KAN`
+- Jira execution project: `KAN`
+- Jira delivery project: `RCP`
 - Confluence space: `TLG`
 - Local briefing output: `.agent-work/pm/PROJECT_PM_BRIEFING.md`
 - Local JSON cache: `.agent-work/pm/atlassian-state.json`
@@ -18,6 +19,9 @@ ATLASSIAN_URL=tasteslikegood.atlassian.net
 # ATLASSIAN_EMAIL=your-atlassian-email@example.com
 # ATLASSIAN_API_TOKEN=your-atlassian-api-token
 ATLASSIAN_JIRA_PROJECT_KEY=KAN
+ATLASSIAN_JIRA_DELIVERY_PROJECT_KEY=RCP
+# Optional explicit project list for brief/status fetches:
+# JIRA_PROJECTS=KAN,RCP
 ATLASSIAN_CONFLUENCE_SPACE_KEY=TLG
 ATLASSIAN_CONFLUENCE_SPACE_ID=11042818
 ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID=11796481
@@ -34,9 +38,10 @@ Verifies Jira and Confluence connectivity without writing files.
 
 ```sh
 npm run pm:brief
+npm run pm:reflect
 ```
 
-Fetches Jira issues and Confluence planning/session pages, then writes the local briefing and cache. It also refreshes `jira_issues.txt` for older workflows.
+Fetches Jira issues and Confluence planning/session pages, then writes the local briefing, cache, and `.agent-work/pm/JIRA_KAN_WORK_REFLECTION.md`. The reflection file compares local git state to Jira refs so KAN can show the work actually happening on branches/worktrees. It also refreshes `jira_issues.txt` for older workflows when requested.
 
 ```sh
 npm run pm:sync
@@ -65,7 +70,8 @@ The daemon exposes:
 
 ## What The Briefing Contains
 
-- Jira status counts and issue type counts.
+- Jira status counts and issue type counts across KAN/RCP.
+- Current local branch/file-change reflection and whether a KAN execution link is missing.
 - Active work, blockers, high-priority backlog, recent updates, and open load by assignee.
 - Recent Confluence planning/session context from pages matching planning, status, roadmap, project, next steps, or previous session terms.
 - Local PM artifact summaries from `planning_notes.md`, `plan.md`, `roadmap.md`, and `design-plan.md`.

--- a/docs/PM_TOOLING.md
+++ b/docs/PM_TOOLING.md
@@ -38,10 +38,12 @@ The daemon watches `specs/` for changes to these files and auto-syncs them to Co
 ### 2. Session Logging (`log_agent_session`)
 
 Creates structured Confluence pages for each agent session with:
-- Session metadata (ID, agent, timestamp, duration)
+- Session metadata (ID, agent, timestamp, duration, branch)
 - Summary of work completed
 - Key decisions and trade-offs
 - Files changed
+- KAN execution refs/updates so active branch work is visible on the board
+- RCP delivery refs/updates when sprint, epic, release, acceptance, or scope changes
 - Follow-up TODOs
 - Links to related PRs/issues
 
@@ -65,7 +67,7 @@ cd scripts/pm && python sync_jira_confluence_status.py
 
 ### 4. Atlassian Link Utility (`scripts/pm/atlassian_pm_link.py`)
 
-Standalone utility for Atlassian API operations. Dependency-free (uses only the Python stdlib — `urllib`, no `requests`).
+Standalone utility for Atlassian API operations. Dependency-free (uses only the Python stdlib — `urllib`, no `requests`). The `brief`, `reflect`, and `sync` commands write `.agent-work/pm/JIRA_KAN_WORK_REFLECTION.md`, which compares local git state (branch, changed tracked files, recent issue keys) with fetched Jira state and names the KAN/RCP update needed before handoff. Use `npm run pm:reflect` when you only need the local work-to-board alignment check.
 
 ## Configuration
 
@@ -84,7 +86,9 @@ Standalone utility for Atlassian API operations. Dependency-free (uses only the 
 | `ATLASSIAN_CONFLUENCE_SPACE_ID` | `11042818` | Target Confluence space |
 | `ATLASSIAN_CONFLUENCE_PARENT_PAGE_ID` | `11796481` | Parent page for synced docs |
 | `ATLASSIAN_CONFLUENCE_SESSION_LOG_PARENT_PAGE_ID` | Same as parent | Parent page for session logs (alias: `CONFLUENCE_SESSION_LOGS_PARENT_ID`; the prefixed name wins if both are set) |
-| `ATLASSIAN_JIRA_PROJECT_KEY` | `KAN` | Default Jira project for epics |
+| `ATLASSIAN_JIRA_PROJECT_KEY` | `KAN` | Execution Jira project for active work |
+| `ATLASSIAN_JIRA_DELIVERY_PROJECT_KEY` | `RCP` | Delivery Jira project for epics/sprints/scope |
+| `JIRA_PROJECTS` | `KAN,RCP` | Optional explicit CSV of Jira projects to include in PM briefings |
 
 ## Skills
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "pm:start": "npm run pm:check && npm run pm:brief",
     "pm:check": "python3 scripts/pm/atlassian_pm_link.py check",
     "pm:brief": "python3 scripts/pm/atlassian_pm_link.py brief",
+    "pm:reflect": "python3 scripts/pm/atlassian_pm_link.py reflect",
     "pm:sync": "python3 scripts/pm/atlassian_pm_link.py sync",
     "pm:publish": "npm run pm:sync",
     "pm:status": "bash scripts/pm/run_pm_script.sh sync_jira_confluence_status.py",

--- a/scripts/pm/atlassian_pm_link.py
+++ b/scripts/pm/atlassian_pm_link.py
@@ -378,7 +378,18 @@ def run_git(args: list[str]) -> str:
 
 
 def current_branch() -> str:
-    return run_git(["branch", "--show-current"]) or "unknown"
+    # `git branch --show-current` prints the branch name on a normal checkout
+    # and an empty string on a detached HEAD. Fall back to a short SHA so the
+    # reflection can still identify what's checked out; reserve "unknown" for
+    # cases where git is genuinely unavailable (not a worktree, not installed,
+    # command timed out).
+    branch = run_git(["branch", "--show-current"])
+    if branch:
+        return branch
+    sha = run_git(["rev-parse", "--short", "HEAD"])
+    if sha:
+        return f"detached@{sha}"
+    return "unknown"
 
 
 def changed_files() -> list[str]:
@@ -447,8 +458,21 @@ def build_work_reflection(config: Config, issues: list[dict[str, Any]]) -> dict[
     issue_map = issue_lookup(issues)
     referenced_keys = extract_issue_keys(branch, "\n".join(commits), "\n".join(files))
     referenced_issues = [issue_summary(config, issue_map.get(key), key) for key in referenced_keys]
-    active_kan = [issue for issue in issues if str(issue.get("key", "")).startswith("KAN-") and not is_done(issue)]
-    active_rcp = [issue for issue in issues if str(issue.get("key", "")).startswith("RCP-") and not is_done(issue)]
+    # Derive execution/delivery project keys from config so counts don't
+    # silently break when a non-default project key is configured. The
+    # configured value is a CSV of project keys; by convention the first is
+    # execution (e.g. KAN) and the second, when present, is delivery (RCP).
+project_keys = [part.strip() for part in config.jira_project_key.split(",") if part.strip()]
+execution_key = (project_keys[0] if project_keys else "KAN").upper()
+delivery_key = (project_keys[1] if len(project_keys) > 1 else execution_key).upper()
+active_kan = [
+    issue for issue in issues
+    if str(issue.get("key", "")).upper().startswith(f"{execution_key}-") and not is_done(issue)
+]
+active_rcp = [
+    issue for issue in issues
+    if str(issue.get("key", "")).upper().startswith(f"{delivery_key}-") and not is_done(issue)
+]
     workstreams = Counter(infer_workstream_from_path(path) for path in files)
     git_unavailable = branch == "unknown" and not files and not commits
     untracked_refs = not referenced_keys and not git_unavailable and (branch != "dev" or files)
@@ -469,13 +493,13 @@ def build_work_reflection(config: Config, issues: list[dict[str, Any]]) -> dict[
         )
     elif untracked_refs:
         recommendations.append(
-            f"Create or update a KAN execution issue for branch `{branch}` with the changed-file summary and current next action."
+            f"Create or update a {execution_key} execution issue for branch `{branch}` with the changed-file summary and current next action."
         )
     if files:
-        recommendations.append("Add branch/PR/file refs to the active KAN issue before handoff.")
+        recommendations.append(f"Add branch/PR/file refs to the active {execution_key} issue before handoff.")
     if active_rcp and (referenced_keys or files):
         recommendations.append(
-            "If this work changes sprint, epic, release, or acceptance scope, update the relevant RCP issue; otherwise leave RCP unchanged."
+            f"If this work changes sprint, epic, release, or acceptance scope, update the relevant {delivery_key} issue; otherwise leave {delivery_key} unchanged."
         )
     if not recommendations:
         recommendations.append("No Jira update is required from local git state alone.")

--- a/scripts/pm/atlassian_pm_link.py
+++ b/scripts/pm/atlassian_pm_link.py
@@ -22,6 +22,7 @@ import textwrap
 import urllib.error
 import urllib.parse
 import urllib.request
+import subprocess
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,7 @@ from _jira_projects import resolve_jira_projects  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT = REPO_ROOT / ".agent-work" / "pm" / "PROJECT_PM_BRIEFING.md"
 DEFAULT_CACHE = REPO_ROOT / ".agent-work" / "pm" / "atlassian-state.json"
+DEFAULT_WORK_REFLECTION = REPO_ROOT / ".agent-work" / "pm" / "JIRA_KAN_WORK_REFLECTION.md"
 LOCAL_PM_FILES = [
     "specs/planning_notes.md",
     "specs/plan.md",
@@ -358,6 +360,176 @@ def summarize_local_pm_files() -> list[dict[str, str]]:
     return summaries
 
 
+
+def run_git(args: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def current_branch() -> str:
+    return run_git(["branch", "--show-current"]) or "unknown"
+
+
+def changed_files() -> list[str]:
+    output = run_git(["status", "--short", "--untracked-files=no"])
+    files: list[str] = []
+    for line in output.splitlines():
+        if not line.strip() or len(line) < 4:
+            continue
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.rsplit(" -> ", 1)[1]
+        files.append(path)
+    return files
+
+
+def recent_commits(limit: int = 10) -> list[str]:
+    output = run_git(["log", f"-n{limit}", "--pretty=format:%h %s"])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def extract_issue_keys(*values: str) -> list[str]:
+    seen: set[str] = set()
+    keys: list[str] = []
+    for value in values:
+        for key in re.findall(r"\b[A-Z][A-Z0-9]+-\d+\b", value or ""):
+            if key not in seen:
+                keys.append(key)
+                seen.add(key)
+    return keys
+
+
+def issue_lookup(issues: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(issue.get("key", "")): issue for issue in issues if issue.get("key")}
+
+
+def issue_summary(config: Config, issue: dict[str, Any] | None, key: str) -> str:
+    if issue:
+        fields = issue.get("fields", {})
+        return (
+            f"[{key}]({config.base_url}/browse/{key}) - {fields.get('summary', 'No summary')} "
+            f"[{issue_type(issue)}, {status_name(issue)}, {assignee_name(issue)}]"
+        )
+    return f"[{key}]({config.base_url}/browse/{key}) - referenced in git, not present in fetched Jira result set"
+
+
+def infer_workstream_from_path(path: str) -> str:
+    if path.startswith("scripts/pm/") or path.startswith(".pi/"):
+        return "PM/session automation"
+    if path.startswith("specs/") or path.startswith("docs/"):
+        return "planning/documentation"
+    if path.startswith("Backend/"):
+        return "Flask backend"
+    if path.startswith("server/"):
+        return "Express proxy"
+    if path.startswith("src/"):
+        return "Angular frontend"
+    if path.startswith(".github/"):
+        return "GitHub workflow"
+    return "repository maintenance"
+
+
+def build_work_reflection(config: Config, issues: list[dict[str, Any]]) -> dict[str, Any]:
+    branch = current_branch()
+    files = changed_files()
+    commits = recent_commits()
+    issue_map = issue_lookup(issues)
+    referenced_keys = extract_issue_keys(branch, "\n".join(commits), "\n".join(files))
+    referenced_issues = [issue_summary(config, issue_map.get(key), key) for key in referenced_keys]
+    active_kan = [issue for issue in issues if str(issue.get("key", "")).startswith("KAN-") and not is_done(issue)]
+    active_rcp = [issue for issue in issues if str(issue.get("key", "")).startswith("RCP-") and not is_done(issue)]
+    workstreams = Counter(infer_workstream_from_path(path) for path in files)
+    untracked_refs = not referenced_keys and (branch != "dev" or files)
+    jira_status = "Linked" if referenced_keys else "Needs KAN link" if files or branch != "dev" else "Clean no-op"
+
+    recommendations: list[str] = []
+    if untracked_refs:
+        recommendations.append(
+            f"Create or update a KAN execution issue for branch `{branch}` with the changed-file summary and current next action."
+        )
+    if files:
+        recommendations.append("Add branch/PR/file refs to the active KAN issue before handoff.")
+    if active_rcp and (referenced_keys or files):
+        recommendations.append("If this work changes sprint, epic, release, or acceptance scope, update the relevant RCP issue; otherwise leave RCP unchanged.")
+    if not recommendations:
+        recommendations.append("No Jira update is required from local git state alone.")
+
+    return {
+        "branch": branch,
+        "changed_files": files,
+        "recent_commits": commits,
+        "referenced_issue_keys": referenced_keys,
+        "referenced_issues": referenced_issues,
+        "active_kan_count": len(active_kan),
+        "active_rcp_count": len(active_rcp),
+        "workstreams": workstreams,
+        "jira_status": jira_status,
+        "recommendations": recommendations,
+    }
+
+
+def format_work_reflection(config: Config, reflection: dict[str, Any]) -> str:
+    generated = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    lines = [
+        "# Jira/KAN Work Reflection",
+        "",
+        f"Generated: {generated}",
+        f"Branch: `{reflection['branch']}`",
+        f"Jira linkage status: **{reflection['jira_status']}**",
+        "",
+        "## Local Git Signal",
+        "",
+    ]
+    files = reflection["changed_files"]
+    if files:
+        for path in files[:30]:
+            lines.append(f"- `{path}` ({infer_workstream_from_path(path)})")
+        if len(files) > 30:
+            lines.append(f"- …and {len(files) - 30} more changed files")
+    else:
+        lines.append("- No modified tracked files detected.")
+
+    lines.extend(["", "## Referenced Jira Issues", ""])
+    if reflection["referenced_issues"]:
+        lines.extend(f"- {item}" for item in reflection["referenced_issues"])
+    else:
+        lines.append("- No Jira issue key found in branch name, recent commit subjects, or changed tracked file paths.")
+
+    lines.extend(["", "## Workstream Signals", ""])
+    if reflection["workstreams"]:
+        for stream, count in reflection["workstreams"].most_common():
+            lines.append(f"- {stream}: {count} changed file(s)")
+    else:
+        lines.append("- No local file-change signal.")
+
+    lines.extend(["", "## Recommended Jira/KAN Updates", ""])
+    for item in reflection["recommendations"]:
+        lines.append(f"- {item}")
+
+    lines.extend(
+        [
+            "",
+            "## Board Role Reminder",
+            "",
+            "- KAN should reflect active branch/work ownership, blockers, handoffs, and immediate next actions.",
+            "- RCP should reflect delivery scope, epics, sprint commitments, and acceptance changes only when this work affects them.",
+            "- Confluence should receive the durable session narrative and PM drift notes.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
 def issue_line(config: Config, issue: dict[str, Any]) -> str:
     key = issue.get("key", issue.get("id", "UNKNOWN"))
     fields = issue.get("fields", {})
@@ -379,6 +551,7 @@ def build_markdown(config: Config, issues: list[dict[str, Any]], pages: list[dic
     active = [issue for issue in open_issues if status_name(issue).lower() in {"in progress", "in review", "review"}]
     recent = issues[:15]
     local_pm = summarize_local_pm_files()
+    work_reflection = build_work_reflection(config, issues)
 
     lines = [
         "# Project PM Briefing",
@@ -395,6 +568,14 @@ def build_markdown(config: Config, issues: list[dict[str, Any]], pages: list[dic
         f"- Active issues: {len(active)}",
         f"- Blockers or critical items: {len(blockers)}",
         f"- Confluence planning/session pages fetched: {len(pages)}",
+        f"- Local git/Jira linkage: {work_reflection['jira_status']}",
+        "",
+        "## Current Work Reflection",
+        "",
+        f"- Branch: `{work_reflection['branch']}`",
+        f"- Changed tracked files: {len(work_reflection['changed_files'])}",
+        f"- Referenced Jira issues: {', '.join(work_reflection['referenced_issue_keys']) if work_reflection['referenced_issue_keys'] else 'None detected'}",
+        "- Recommended board action: " + work_reflection['recommendations'][0],
         "",
         "## Status Counts",
         "",
@@ -605,13 +786,36 @@ def run_brief(args: argparse.Namespace) -> int:
         "jira_issues": issues,
         "confluence_pages": pages,
     }
+    reflection = build_work_reflection(config, issues)
+    reflection_body = format_work_reflection(config, reflection)
+    state["work_reflection"] = {**reflection, "workstreams": dict(reflection["workstreams"])}
     write_outputs(markdown_body, state, Path(args.output), Path(args.cache))
+    reflection_path = Path(args.work_reflection_output)
+    reflection_path.parent.mkdir(parents=True, exist_ok=True)
+    reflection_path.write_text(reflection_body, encoding="utf-8")
     if args.update_legacy_files:
         update_legacy_jira_issues(config, issues)
     print(f"Wrote PM briefing: {Path(args.output)}")
+    print(f"Wrote work reflection: {reflection_path}")
     print(f"Wrote Atlassian cache: {Path(args.cache)}")
     return 0
 
+
+
+def run_reflect(args: argparse.Namespace) -> int:
+    config = load_config()
+    client = AtlassianClient(config)
+    issues = client.fetch_jira_issues(args.max_issues)
+    reflection = build_work_reflection(config, issues)
+    reflection_body = format_work_reflection(config, reflection)
+    reflection_path = Path(args.work_reflection_output)
+    reflection_path.parent.mkdir(parents=True, exist_ok=True)
+    reflection_path.write_text(reflection_body, encoding="utf-8")
+    print(f"Wrote work reflection: {reflection_path}")
+    print(f"Jira/KAN linkage: {reflection['jira_status']}")
+    for item in reflection["recommendations"]:
+        print(f"- {item}")
+    return 0
 
 def run_sync(args: argparse.Namespace) -> int:
     config = load_config()
@@ -628,11 +832,18 @@ def run_sync(args: argparse.Namespace) -> int:
         "jira_issues": issues,
         "confluence_pages": pages,
     }
+    reflection = build_work_reflection(config, issues)
+    reflection_body = format_work_reflection(config, reflection)
+    state["work_reflection"] = {**reflection, "workstreams": dict(reflection["workstreams"])}
     write_outputs(markdown_body, state, Path(args.output), Path(args.cache))
+    reflection_path = Path(args.work_reflection_output)
+    reflection_path.parent.mkdir(parents=True, exist_ok=True)
+    reflection_path.write_text(reflection_body, encoding="utf-8")
     if args.update_legacy_files:
         update_legacy_jira_issues(config, issues)
     result = client.publish_confluence_page(markdown_body)
     print(f"Wrote PM briefing: {Path(args.output)}")
+    print(f"Wrote work reflection: {reflection_path}")
     print(f"Wrote Atlassian cache: {Path(args.cache)}")
     print(f"Confluence sync: {result}")
     return 0
@@ -660,6 +871,11 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="Markdown briefing output path.")
         subparser.add_argument("--cache", default=str(DEFAULT_CACHE), help="JSON cache output path.")
         subparser.add_argument(
+            "--work-reflection-output",
+            default=str(DEFAULT_WORK_REFLECTION),
+            help="Markdown output path for local git-to-Jira/KAN reflection.",
+        )
+        subparser.add_argument(
             "--update-legacy-files",
             action="store_true",
             help="Also refresh legacy jira_issues.txt for older workflows.",
@@ -672,6 +888,10 @@ def build_parser() -> argparse.ArgumentParser:
     sync = subparsers.add_parser("sync", help="Write a local briefing and publish/update it in Confluence.")
     add_common(sync)
     sync.set_defaults(func=run_sync)
+
+    reflect = subparsers.add_parser("reflect", help="Write the local git-to-Jira/KAN work reflection without Confluence sync.")
+    add_common(reflect)
+    reflect.set_defaults(func=run_reflect)
 
     check = subparsers.add_parser("check", help="Verify Jira and Confluence connectivity without writing files.")
     check.set_defaults(func=run_check)

--- a/scripts/pm/atlassian_pm_link.py
+++ b/scripts/pm/atlassian_pm_link.py
@@ -450,18 +450,33 @@ def build_work_reflection(config: Config, issues: list[dict[str, Any]]) -> dict[
     active_kan = [issue for issue in issues if str(issue.get("key", "")).startswith("KAN-") and not is_done(issue)]
     active_rcp = [issue for issue in issues if str(issue.get("key", "")).startswith("RCP-") and not is_done(issue)]
     workstreams = Counter(infer_workstream_from_path(path) for path in files)
-    untracked_refs = not referenced_keys and (branch != "dev" or files)
-    jira_status = "Linked" if referenced_keys else "Needs KAN link" if files or branch != "dev" else "Clean no-op"
+    git_unavailable = branch == "unknown" and not files and not commits
+    untracked_refs = not referenced_keys and not git_unavailable and (branch != "dev" or files)
+    jira_status = (
+        "Git unavailable"
+        if git_unavailable
+        else "Linked"
+        if referenced_keys
+        else "Needs KAN link"
+        if files or branch != "dev"
+        else "Clean no-op"
+    )
 
     recommendations: list[str] = []
-    if untracked_refs:
+    if git_unavailable:
+        recommendations.append(
+            "Git state unavailable (not a git worktree or git not installed); cannot infer KAN linkage from local changes."
+        )
+    elif untracked_refs:
         recommendations.append(
             f"Create or update a KAN execution issue for branch `{branch}` with the changed-file summary and current next action."
         )
     if files:
         recommendations.append("Add branch/PR/file refs to the active KAN issue before handoff.")
     if active_rcp and (referenced_keys or files):
-        recommendations.append("If this work changes sprint, epic, release, or acceptance scope, update the relevant RCP issue; otherwise leave RCP unchanged.")
+        recommendations.append(
+            "If this work changes sprint, epic, release, or acceptance scope, update the relevant RCP issue; otherwise leave RCP unchanged."
+        )
     if not recommendations:
         recommendations.append("No Jira update is required from local git state alone.")
 

--- a/scripts/pm/atlassian_pm_link.py
+++ b/scripts/pm/atlassian_pm_link.py
@@ -462,17 +462,17 @@ def build_work_reflection(config: Config, issues: list[dict[str, Any]]) -> dict[
     # silently break when a non-default project key is configured. The
     # configured value is a CSV of project keys; by convention the first is
     # execution (e.g. KAN) and the second, when present, is delivery (RCP).
-project_keys = [part.strip() for part in config.jira_project_key.split(",") if part.strip()]
-execution_key = (project_keys[0] if project_keys else "KAN").upper()
-delivery_key = (project_keys[1] if len(project_keys) > 1 else execution_key).upper()
-active_kan = [
-    issue for issue in issues
-    if str(issue.get("key", "")).upper().startswith(f"{execution_key}-") and not is_done(issue)
-]
-active_rcp = [
-    issue for issue in issues
-    if str(issue.get("key", "")).upper().startswith(f"{delivery_key}-") and not is_done(issue)
-]
+    project_keys = [part.strip() for part in config.jira_project_key.split(",") if part.strip()]
+    execution_key = (project_keys[0] if project_keys else "KAN").upper()
+    delivery_key = (project_keys[1] if len(project_keys) > 1 else execution_key).upper()
+    active_kan = [
+        issue for issue in issues
+        if str(issue.get("key", "")).upper().startswith(f"{execution_key}-") and not is_done(issue)
+    ]
+    active_rcp = [
+        issue for issue in issues
+        if str(issue.get("key", "")).upper().startswith(f"{delivery_key}-") and not is_done(issue)
+    ]
     workstreams = Counter(infer_workstream_from_path(path) for path in files)
     git_unavailable = branch == "unknown" and not files and not commits
     untracked_refs = not referenced_keys and not git_unavailable and (branch != "dev" or files)

--- a/scripts/pm/atlassian_pm_link.py
+++ b/scripts/pm/atlassian_pm_link.py
@@ -421,7 +421,7 @@ def issue_summary(config: Config, issue: dict[str, Any] | None, key: str) -> str
             f"[{key}]({config.base_url}/browse/{key}) - {fields.get('summary', 'No summary')} "
             f"[{issue_type(issue)}, {status_name(issue)}, {assignee_name(issue)}]"
         )
-    return f"[{key}]({config.base_url}/browse/{key}) - referenced in git, not present in fetched Jira result set"
+    return f"[{key}]({config.base_url}/browse/{key}) - referenced in git, not present in fetched Jira results (may be outside --max-issues); verify in Jira or rerun with a higher --max-issues"
 
 
 def infer_workstream_from_path(path: str) -> str:

--- a/scripts/pm/pm_daemon.py
+++ b/scripts/pm/pm_daemon.py
@@ -335,6 +335,12 @@ def _render_session_log_html(
     follow_up_items: list[str],
     pr_links: list[str] | None = None,
     duration_minutes: int | None = None,
+    branch: str = "",
+    kan_issue: str = "",
+    rcp_issue: str = "",
+    atlassian_alignment: str = "",
+    jira_updates: list[str] | None = None,
+    kan_updates: list[str] | None = None,
 ) -> str:
     """Render an agent session log as Confluence storage-format HTML."""
     from datetime import datetime, timezone
@@ -352,6 +358,12 @@ def _render_session_log_html(
     files_html = "".join(f"<li><code>{html.escape(f)}</code></li>" for f in files_changed) if files_changed else "<li>None</li>"
     followups_html = "".join(f"<li>{html.escape(item)}</li>" for item in follow_up_items) if follow_up_items else "<li>None</li>"
     links_html = "".join(f"<li><a href=\"{html.escape(link, quote=True)}\">{html.escape(link)}</a></li>" for link in (pr_links or []))
+    jira_updates_html = "".join(f"<li>{html.escape(item)}</li>" for item in (jira_updates or [])) or "<li>No Jira/RCP delivery updates recorded.</li>"
+    kan_updates_html = "".join(f"<li>{html.escape(item)}</li>" for item in (kan_updates or [])) or "<li>No KAN execution updates recorded.</li>"
+    branch = html.escape(branch or "—")
+    kan_issue = html.escape(kan_issue or "—")
+    rcp_issue = html.escape(rcp_issue or "—")
+    alignment = html.escape(atlassian_alignment or "Not assessed")
 
     return f"""
 <ac:structured-macro ac:name="info"><ac:rich-text-body>
@@ -363,7 +375,13 @@ def _render_session_log_html(
 <tr><th>Agent</th><td>{agent_name}</td></tr>
 <tr><th>Timestamp</th><td>{timestamp}</td></tr>
 <tr><th>Duration</th><td>{duration_str}</td></tr>
+<tr><th>Branch</th><td>{branch}</td></tr>
+<tr><th>KAN issue</th><td>{kan_issue}</td></tr>
+<tr><th>RCP issue</th><td>{rcp_issue}</td></tr>
 </table>
+
+<h2>Atlassian Alignment</h2>
+<p>{alignment}</p>
 
 <h2>Summary</h2>
 <p>{summary}</p>
@@ -373,6 +391,12 @@ def _render_session_log_html(
 
 <h2>Files Changed</h2>
 <ul>{files_html}</ul>
+
+<h2>KAN Execution Updates</h2>
+<ul>{kan_updates_html}</ul>
+
+<h2>RCP / Delivery Updates</h2>
+<ul>{jira_updates_html}</ul>
 
 <h2>Follow-up TODOs</h2>
 <ul>{followups_html}</ul>
@@ -391,6 +415,12 @@ def log_agent_session(
     follow_up_items: list[str] | None = None,
     pr_links: list[str] | None = None,
     duration_minutes: int | None = None,
+    branch: str = "",
+    kan_issue: str = "",
+    rcp_issue: str = "",
+    atlassian_alignment: str = "",
+    jira_updates: list[str] | None = None,
+    kan_updates: list[str] | None = None,
 ) -> str:
     """Log an agent session to Confluence as a structured page.
 
@@ -417,6 +447,12 @@ def log_agent_session(
         follow_up_items=follow_up_items or [],
         pr_links=pr_links,
         duration_minutes=duration_minutes,
+        branch=branch,
+        kan_issue=kan_issue,
+        rcp_issue=rcp_issue,
+        atlassian_alignment=atlassian_alignment,
+        jira_updates=jira_updates,
+        kan_updates=kan_updates,
     )
 
     payload = {

--- a/scripts/pm/templates/session_log.md
+++ b/scripts/pm/templates/session_log.md
@@ -13,6 +13,9 @@
 | **Agent** | {agent_name} |
 | **Timestamp** | {timestamp} |
 | **Duration** | {duration} |
+| **Branch** | `{branch}` |
+| **KAN Issue** | {kan_issue} |
+| **RCP Issue** | {rcp_issue} |
 
 ## Summary
 
@@ -27,6 +30,23 @@
 
 - `{file_1}`
 - `{file_2}`
+
+## Atlassian Alignment
+
+- Verdict: {aligned_partially_aligned_or_drifting}
+- KAN: {execution_state_visible_or_missing}
+- RCP: {delivery_scope_impact_or_none}
+- Confluence: {session_log_and_docs_status}
+
+## KAN Execution Updates
+
+- {branch_owner_status_blocker_or_next_action_update}
+- {kan_issue_to_create_or_update_if_work_is_active}
+
+## RCP Delivery Updates
+
+- {epic_sprint_acceptance_or_scope_update}
+- {write_no_delivery_scope_change_if_not_applicable}
 
 ## Follow-up TODOs
 

--- a/specs/ATLASSIAN_PM_LINK.md
+++ b/specs/ATLASSIAN_PM_LINK.md
@@ -83,6 +83,7 @@ Run:
 
 ```bash
 npm run pm:brief
+npm run pm:reflect
 npm run pm:sync
 npm run pm:status
 ```
@@ -109,6 +110,7 @@ It exists to:
 ```bash
 npm run pm:start             # check connectivity + build local briefing
 npm run pm:brief             # rebuild local PM briefing
+npm run pm:reflect           # write local git-to-Jira/KAN reflection
 npm run pm:sync              # rebuild briefing + publish/update Confluence briefing
 npm run pm:publish           # alias for pm:sync
 npm run pm:status            # live Jira + PR + Confluence + prod snapshot

--- a/specs/ATLASSIAN_PM_LINK.md
+++ b/specs/ATLASSIAN_PM_LINK.md
@@ -83,10 +83,11 @@ Run:
 
 ```bash
 npm run pm:brief
-npm run pm:reflect
 npm run pm:sync
 npm run pm:status
 ```
+
+`pm:brief` and `pm:sync` both write `.agent-work/pm/JIRA_KAN_WORK_REFLECTION.md`, so the default handoff flow does not need a separate `pm:reflect` step. Run `npm run pm:reflect` on its own only when you want the reflection report without the full briefing/sync round-trip.
 
 That ensures:
 


### PR DESCRIPTION
This pull request introduces a comprehensive "work reflection" feature that compares the current local git state to Jira/KAN linkage, improving visibility into work alignment and required project management updates. It also enhances documentation, configuration, and session logging to support this workflow, and adds a new `pm:reflect` command for targeted alignment checks.

The most important changes are:

**Work Reflection Feature:**
* Added a new work reflection mechanism in `scripts/pm/atlassian_pm_link.py` that analyzes the current git branch, changed files, recent commits, and referenced Jira issues, then generates a detailed reflection report and recommendations for KAN/RCP updates. This is written to `.agent-work/pm/JIRA_KAN_WORK_REFLECTION.md` and surfaced in the PM briefing. [[1]](diffhunk://#diff-b86b20fe6afe8fffe6638aaf2689ca3f1991571869743c4d8e8b43c7ceaae2a5R363-R532) [[2]](diffhunk://#diff-b86b20fe6afe8fffe6638aaf2689ca3f1991571869743c4d8e8b43c7ceaae2a5R554) [[3]](diffhunk://#diff-b86b20fe6afe8fffe6638aaf2689ca3f1991571869743c4d8e8b43c7ceaae2a5R571-R578) [[4]](diffhunk://#diff-b86b20fe6afe8fffe6638aaf2689ca3f1991571869743c4d8e8b43c7ceaae2a5R789-R819)
* Introduced a new CLI command `pm:reflect` in `package.json` and supporting logic to generate the work reflection report independently. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114)

**Documentation and Schema Updates:**
* Updated documentation (`docs/ATLASSIAN_PM_LINK.md`, `docs/PM_TOOLING.md`) to describe the work reflection feature, new configuration options for KAN/RCP, and the new `pm:reflect` workflow. Also clarified the distinction between execution (KAN) and delivery (RCP) Jira projects. [[1]](diffhunk://#diff-1415deee55f8bf7c1bf10905b784f5bc25bcf2171dc83c8b890d292360d13341L7-R8) [[2]](diffhunk://#diff-1415deee55f8bf7c1bf10905b784f5bc25bcf2171dc83c8b890d292360d13341R22-R24) [[3]](diffhunk://#diff-1415deee55f8bf7c1bf10905b784f5bc25bcf2171dc83c8b890d292360d13341R41-R44) [[4]](diffhunk://#diff-1415deee55f8bf7c1bf10905b784f5bc25bcf2171dc83c8b890d292360d13341L68-R74) [[5]](diffhunk://#diff-d9459e7a53d0d48c1df3593de3342a84b8ac67b20c162ffafb1dfbd32b13ca3eL41-R46) [[6]](diffhunk://#diff-d9459e7a53d0d48c1df3593de3342a84b8ac67b20c162ffafb1dfbd32b13ca3eL68-R70) [[7]](diffhunk://#diff-d9459e7a53d0d48c1df3593de3342a84b8ac67b20c162ffafb1dfbd32b13ca3eL87-R91)
* Extended the session log and TODO schemas to explicitly require branch/worktree refs, KAN execution updates, and clear RCP delivery impact statements. [[1]](diffhunk://#diff-b87d756ef68a47ff07ab9aab829ed915f30214a6ed31eca892bb48617b6fb9e6L18-R20) [[2]](diffhunk://#diff-3fb81873291f3cbfa0de4efb86c00279ad489e1afd7aad69a12d698a064f691cR14-R15) [[3]](diffhunk://#diff-ec1fc4044f164f1b89ef06a40d00f32d73b1037e1be327b3ecd80f1198d0c48aR19) [[4]](diffhunk://#diff-ec1fc4044f164f1b89ef06a40d00f32d73b1037e1be327b3ecd80f1198d0c48aL37-R40) [[5]](diffhunk://#diff-ec1fc4044f164f1b89ef06a40d00f32d73b1037e1be327b3ecd80f1198d0c48aL62-R73)

**Session Logging Improvements:**
* Enhanced session logs to include branch information and explicit KAN/RCP update requirements, ensuring session artifacts are more actionable and board-aligned.

**Codebase Enhancements:**
* Added new helper functions for git operations, issue key extraction, and workstream inference in `scripts/pm/atlassian_pm_link.py` to support the reflection logic.
* Updated the PM briefing to include a summary of local git/Jira linkage and recommended board actions. [[1]](diffhunk://#diff-b86b20fe6afe8fffe6638aaf2689ca3f1991571869743c4d8e8b43c7ceaae2a5R554) [[2]](diffhunk://#diff-b86b20fe6afe8fffe6638aaf2689ca3f1991571869743c4d8e8b43c7ceaae2a5R571-R578)

These changes provide better traceability between local development and Jira/Confluence, improve session and PM artifact quality, and make it easier to keep KAN and RCP boards up to date.## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issues

<!--
  Link issues this PR closes or relates to.
  GitHub only auto-closes issues when this PR is merged if you use a closing
  keyword such as Closes, Fixes, or Resolves.
  Use "Relates to" to link an issue without closing it.

  Examples:
    Closes #123
    Fixes #456
    Resolves #789
    Relates to #101
-->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Tests pass locally (`npm run test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Code is formatted (`npm run format`)
- [ ] Build succeeds (`npm run build`)
- [ ] Type checking passes (`npm run type-check`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->



















<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

