### PR TITLE
docs(prd): add reverse-engineered PRD for the full stack

### DIFF
--- a/prd/README.md
+++ b/prd/README.md
@@ -1,0 +1,76 @@
+# VeganGenius Chef — Product Requirements Document
+
+> Reverse-engineered from the codebase on 2026-07-10 (app version 0.3.2).
+> Repos: `tasteslikegoodtheangularsvegancookbook` (frontend + Express) and the `Backend/` submodule (`tasteslikegood.com`, Flask).
+> Production: https://www.tasteslikegood.org
+
+## System Overview
+
+**VeganGenius Chef** is an AI-powered vegan recipe generator and personal cookbook. A visitor types what they're craving; Google Gemini generates a complete, schema-validated vegan recipe, and Imagen generates a professional food photo for it. Recipes are saved into a personal "Kitchen" that can be organized into named cookbooks, edited, imported/exported as JSON, and — for signed-in users — published as server-rendered public pages with full SEO markup.
+
+The product is deliberately **guest-first**: everything except publishing works without an account. Guest data is stored in browser localStorage for instant UI and simultaneously in the backend database, scoped to an anonymous server session. Signing in with Google merges the guest's recipes and cookbooks into the account, making them available across devices. Publishing is reserved for authenticated users because a public page needs an accountable identity behind it.
+
+Architecturally it is a three-tier system: an Angular 22 SPA (Signals, zoneless, **no router** — two views switched by signal + history state), a Node/Express reverse proxy that is the only public service (static hosting, rate limiting, security headers, streaming proxy), and a private Flask API (OAuth, recipe/cookbook CRUD, AI generation orchestrated asynchronously through Pub/Sub push workers). PostgreSQL (Cloud SQL) is authoritative; images live in Google Cloud Storage.
+
+## Module Overview
+
+| Module | Pages / Surfaces | Core Functionality |
+|--------|------------------|--------------------|
+| Recipe Generation | Generator view | Prompt → async Gemini recipe (202 + status polling) → auto Imagen photo; scaling, notes editing, export |
+| Cookbook Management | My Kitchen view | Saved-recipe grid, cookbooks (collections), manual 3-step recipe wizard, JSON import/export, client-side recycle bin |
+| Distribution | `/r/<slug>`, `/browse`, `/sitemap.xml` | Publish toggle + slug, SSR pages with schema.org Recipe JSON-LD, save-to-cookbook CTA back into the SPA |
+| Identity | Auth modal, profile card | Google OAuth (PKCE) with guest fallback; guest-data merge on login |
+| Platform | Express layer | Single-origin proxy, rate limiting (Valkey-distributed), Helmet, Cloud Run deploy with blocking migration job |
+
+## Page Inventory
+
+| # | Page | Route | Module | Doc |
+|---|------|-------|--------|-----|
+| 1 | Recipe Generator / Recipe Detail | `/` | Recipe Generation | [→](pages/01-recipe-generator.md) |
+| 2 | My Kitchen | `/#kitchen` | Cookbook Management | [→](pages/02-my-kitchen.md) |
+| 3 | Public Recipe Pages (SSR) | `/r/<slug>`, `/browse`, `/sitemap.xml` | Distribution | [→](pages/03-public-recipe-pages.md) |
+
+Modals (Auth, Create Cookbook, Manual Entry wizard, Add to Cookbook, Delete/Empty-Bin confirmations) are documented inside their triggering page's file.
+
+## Appendices
+
+| Doc | Contents |
+|-----|----------|
+| [api-inventory.md](appendix/api-inventory.md) | Every endpoint (live, worker, admin, legacy) with params, errors, and business rules |
+| [data-model.md](appendix/data-model.md) | DB tables, recipe JSON schema, localStorage shape, image storage strategy |
+| [enum-dictionary.md](appendix/enum-dictionary.md) | All statuses, model names, limits, units, infrastructure names |
+| [page-relationships.md](appendix/page-relationships.md) | Navigation graph, SSR⇄SPA flows, data coupling |
+| [platform-behavior.md](appendix/platform-behavior.md) | Express routes, security, rate limiting, proxy, deployment pipeline |
+
+## Global Notes
+
+### Permission model
+
+There are exactly three actor levels — there is no role system:
+
+1. **Guest** (default) — full generate/save/organize capability, scoped to an anonymous server session + localStorage. Cannot publish (enforced in UI, repository layer, and by data migration).
+2. **Authenticated user** (Google OAuth) — everything guests have, plus cross-device sync and publishing. Login merges guest data into the account.
+3. **Machine actors** — Pub/Sub workers (OIDC-verified service account) and admin image-maintenance endpoints (`Bearer $ADMIN_API_TOKEN`).
+
+### Common interaction patterns
+
+- **localStorage-first writes:** every mutation updates local state before the API call; the UI never blocks on the network. API failures are logged, rarely surfaced.
+- **Async AI with polling:** generation endpoints return 202 immediately; the client polls `/api/recipes/<id>/status` every 2 s. Recipe generation retries up to 3× server-side; image generation does not retry.
+- **Idempotent saves:** recipe POST is an upsert for the same owner; a 409/duplicate is treated as success client-side.
+- **Destructive actions confirm first:** recipe delete (modal, soft), cookbook delete (native confirm), cookbook-membership removal (inline confirm), empty recycle bin (modal, permanent).
+- **Soft delete is client-side only:** the recycle bin lives in localStorage; the server hard-deletes immediately and restore re-creates the row.
+
+### Known gaps & stale-doc corrections (found during analysis)
+
+- `server/validation.ts` **does not exist**; `express-validator` is an unused dependency. Project docs claiming Express-layer validation are stale. All validation is Flask-side (and recipe blobs from clients are stored unvalidated).
+- Flask's "Valkey cache" (`extensions.cache`) is a **no-op stub** — docstrings claim 24 h caching that doesn't happen. Only Express uses Valkey (rate limiting).
+- `PUT /api/recipes/<id>` never updates the `slug`/`is_public`/`status` columns; publishing works only because the SPA saves via POST-upsert.
+- `POST /api/migrate` (legacy file migration) is unauthenticated and reachable through the proxy — hardening gap.
+- With the in-memory rate-limit fallback (Valkey down), limits multiply per Cloud Run instance (GH #163/#162, KAN-16/17).
+- Legacy surfaces still registered in Flask: redirect-based `/auth/*` (sets `user_id` to an email string, never touches the DB) and the file-based recipe/SSR stack. Treat both as deprecated; they are not reachable through Express except via `/api/*` legacy endpoints.
+- `/api/status`'s DB probe likely always reports `error` under SQLAlchemy 2.x (raw-string `SELECT 1`) `[TBC]`.
+- Frontend "Export All" exports all recipes regardless of the selected cookbook `[TBC: possibly unintended]`.
+
+### Reconstruction guidance
+
+An engineer or agent rebuilding this product should read the three page docs for exact fields and interaction contracts, `api-inventory.md` + `data-model.md` for the backend contract (including the ownership-scoping and publish-gating invariants), and `platform-behavior.md` for the proxy/rate-limit/deploy envelope. The recipe JSON schema in `data-model.md` is the single source of truth for generated-recipe shape.

--- a/prd/appendix/api-inventory.md
+++ b/prd/appendix/api-inventory.md
@@ -1,0 +1,95 @@
+# API Inventory
+
+> **Source:** `Backend/blueprints/*.py`, `Backend/auth.py`, `server/index.ts`
+> **Generated:** 2026-07-10
+
+All browser traffic goes through Express (single origin). Express answers `/api/health` itself and proxies every other `/api/*` path to Flask unmodified. "Guest OK" means no login is required — requests are scoped to the authenticated `user_id` when present, otherwise to an auto-created guest `session_id` cookie (every non-static request gets one).
+
+## Production API surface (used by the SPA)
+
+### Auth — `/api/auth/*`
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/auth/login` | none | Returns `{authorization_url, state}` for Google OAuth (PKCE; scopes openid/email/profile). 500 if OAuth env vars unset. |
+| GET | `/api/auth/callback` | OAuth state cookie | Exchanges the code, upserts the User row (by google_id, then email), sets `session[user_id]` (DB int), **merges guest data** (recipes/cookbooks with the pre-login guest session id are reassigned to the user), then script-redirects to `FRONTEND_URL?auth=success`. Errors: 400 state-missing / email-required; 500 otherwise. |
+| GET | `/api/auth/check` | none | Always 200: `{authenticated, user_id, email, name, picture}` or `{authenticated: false, user_id: null}`. |
+| GET | `/api/auth/me` | session required | 401 without a session; 200 user info from DB (falls back to session data on DB failure). |
+| POST | `/api/auth/logout` | none | Clears the whole session — **including the guest id**, so prior guest data is orphaned. Always 200. |
+
+### AI generation
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/api/generate` | guest OK | Body `{prompt (10–500 chars required), model (default gemini-3.1-pro-preview)}`. Creates a pending recipe row (`status="generating"`, name "Generating..."), publishes to Pub/Sub topic `recipe-generation`, returns **202** `{recipe_id, status: "generating"}`. 400 on prompt validation; 500 on DB/publish failure (status set to `error`). Express rate-limits to 20/hr/IP. |
+| POST | `/api/generate_image` | guest OK | Body `{recipe_id (required), force_regenerate (default false)}`. Returns 200 `{image_url}` if the image already exists and not forcing, else publishes to topic `image-generation` and returns **202** `{status: "generating_image"}`. 404 if the recipe isn't owner-visible. 20/hr/IP. |
+| GET | `/api/recipes/<id>/status` | guest OK (owner-scoped) | Polling target: `{status: generating\|ready\|error, recipe: <data blob>}`. |
+| GET | `/api/recipes/<id>/image` | public if recipe is public; else owner-scoped | Serves PNG (`Cache-Control: public, max-age=86400`). Source order: cache (currently a no-op stub) → GCS `images/<id>.png` → legacy base64 in the blob. Exempt from Express rate limiting. |
+| GET | `/api/recipes/missing-images` | guest OK (owner-scoped) | `{recipes: [{id, name, ai_image_url}], count}` for recipes lacking image data. |
+
+### Recipes CRUD — `/api/recipes`
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/recipes` | guest OK | Owner's recipes, newest first: `{recipes: [{id, name, data, created_at, updated_at}], count, ...}`. |
+| POST | `/api/recipes` | guest OK | Create or same-owner **upsert** (client-supplied UUID). Only `name` is required — client blobs are stored **without JSON-Schema validation**. This is the only path that writes the `slug` and `is_public` columns. Guests get `is_public` forced to false. Cross-owner ID collision → 500. 201 on success. |
+| GET | `/api/recipes/<id>` | guest OK (owner-scoped) | Single recipe. 404 if not owned. |
+| PUT | `/api/recipes/<id>` | guest OK (owner-scoped) | Updates `name` + the whole data blob. Does **not** update `slug`/`is_public`/`status` columns. (The SPA does not use PUT.) |
+| DELETE | `/api/recipes/<id>` | guest OK (owner-scoped) | Hard delete. 404 if not owned. |
+| GET | `/api/recipes/stats` | guest OK | `{total_recipes, ...}`. |
+| GET | `/api/recipes/public/<slug>` | none | Public recipe JSON for the save-from-SSR flow; 404 unless `is_public`. |
+
+### Collections (cookbooks) — `/api/collections`
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/collections` | guest OK | Owner's cookbooks, newest first. |
+| POST | `/api/collections` | guest OK | Body `{name (required), description, id (optional uuid), coverImage, recipeIds}`. 201. No validation that recipeIds reference real recipes. |
+| GET | `/api/collections/<id>` | guest OK (owner-scoped) | Single cookbook. |
+| DELETE | `/api/collections/<id>` | guest OK (owner-scoped) | Delete cookbook (recipes untouched). |
+| POST | `/api/collections/<id>/recipes` | guest OK (owner-scoped) | Body `{recipe_id}`; appends if absent (idempotent). No existence/ownership check on the recipe id. |
+| DELETE | `/api/collections/<id>/recipes/<rid>` | guest OK (owner-scoped) | Removes the id (idempotent). |
+
+### Platform & misc
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/health` | none | **Answered by Express**, never proxied: `{status, timestamp, rateLimitStore}`. |
+| GET | `/api/status` | none | Flask health: `{status, api_key_loaded, default_model, database}`. The DB probe uses a raw-string `execute("SELECT 1")` — likely always reports `error` under SQLAlchemy 2.x `[TBC]`. |
+| GET | `/api/models` | none | Curated cached model list (gemini/gemma only, excludes embedding/imagen/veo/tts/etc., max 10, preferred-first). |
+| POST | `/api/models/refresh` | dual-auth | Refreshes the model cache (session credentials → server API key fallback; 401 if neither). Cache file is per-instance/ephemeral. |
+| GET | `/api/admin/image-audit` | `Bearer $ADMIN_API_TOKEN` | Audit image storage across **all** recipes. 403 without token (or when the env var is unset). |
+| POST | `/api/admin/migrate-images` | admin bearer token | Migrates base64-in-DB images to GCS in batches of 100; fixes legacy URLs. |
+
+### Async workers (Pub/Sub push targets — not browser-callable)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/api/worker/recipe` | Pub/Sub OIDC JWT (`email == PUBSUB_INVOKER_SA`, verified; `PUBSUB_AUTH_OPTIONAL=1` bypass for dev) | Generates recipe text: rebuilds the schema prompt, calls Gemini (server API key; temperature 0.7, JSON mime type), normalizes units, validates against the Draft-7 recipe schema, retries up to `GENERATION_MAX_ATTEMPTS` (default 3) in-process. Success → `status="ready"` + auto-queues image generation. Exhausted → `status="error"`. **Processing errors return 200** so Pub/Sub never redelivers a poison message. |
+| POST | `/api/worker/image` | Pub/Sub OIDC | Generates the food photo with `imagen-4.0-generate-001` (prompt from name + image_keywords, "professional food photography… overhead shot"). GCS-first storage (`gs://$GCS_BUCKET_NAME/images/<id>.png`), base64-in-DB fallback when no bucket. Sets `ai_image_url=/api/recipes/<id>/image`. No retry; failures recorded in `ai_metadata.image_generation`. |
+
+## SSR routes (proxied by Express; see [Public Recipe Pages](../pages/03-public-recipe-pages.md))
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/r/<slug>` | Public recipe HTML (404 unless published). |
+| GET | `/browse` | Paginated public index (20/page). |
+| GET | `/sitemap.xml` | Dynamic sitemap. |
+| GET | `/static/*` | Flask template stylesheets (proxied after Angular assets). |
+| GET | `/privacy-policy` | Static HTML served by Express itself. |
+
+## Legacy / deprecated endpoints (registered in Flask but not reachable through Express, or superseded)
+
+- `/auth/login|callback|profile|logout` — old redirect-based OAuth; sets `session[user_id]` to the **email string** (type mismatch with the DB-int convention), never creates DB users or merges guest data. Superseded by `/api/auth/*`.
+- `/` , `/recipe/<filename>`, `/recipe/<filename>/json`, `/generate_recipe` — file-based SSR stack operating on the `recipes/` directory (ephemeral on Cloud Run).
+- `/api/generate_image/<filename>`, `/api/regenerate_image/<filename>` — legacy synchronous file-based image generation to `static/images/`.
+- `/api/report_recipe/<filename>` — appends to `user_reports.json` (file-based, not durable).
+- `/api/migrate` — **unauthenticated** file-recipe migration endpoint (reachable through the Express `/api` proxy — flagged as a hardening gap).
+- `/api/jokes` — returns jokes from a bundled CSV.
+
+## Cross-cutting API rules
+
+- **Ownership scoping:** authenticated → rows where `user_id` matches; guest → rows where `user_id IS NULL AND guest_session_id` matches. There is no admin override on the CRUD paths.
+- **Sessions are client-side signed cookies** (`FLASK_SECRET_KEY`; Secure/SameSite=Lax/HttpOnly in production, shared across apex+www via `SESSION_COOKIE_DOMAIN`). A server-side session table was introduced and later dropped. OAuth tokens live inside the cookie, with `client_secret` deliberately excluded and re-injected from env at use time.
+- **Rate limiting lives only in Express** (300/15 min general; 20/hr AI); Flask has none of its own.
+- **No Express-layer request validation** — `server/validation.ts` does not exist; `express-validator` is an unused dependency. Flask validates AI prompts (10–500 chars) and requires `name` on recipe/cookbook creation; everything else in client blobs is stored as-is.

--- a/prd/appendix/data-model.md
+++ b/prd/appendix/data-model.md
@@ -1,0 +1,92 @@
+# Data Model
+
+> **Source:** `Backend/models/*.py`, `Backend/migrations/versions/*.py`, `Backend/recipe_schema.json`, `src/recipe.types.ts`, `src/auth.types.ts`
+> **Generated:** 2026-07-10
+
+PostgreSQL (Cloud SQL) in production, SQLite locally. Three tables. Recipes store their full content as a JSON blob in a single column; cookbooks reference recipes by ID array (no join table, no FK).
+
+## `user`
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| id | Integer | PK, autoincrement |
+| email | String(120) | UNIQUE, NOT NULL |
+| name | String(100) | nullable |
+| google_id | String(100) | UNIQUE, nullable |
+| created_at | DateTime | NOT NULL, default now (UTC) |
+
+Users exist only via Google OAuth — there is no password column and no local registration. Guests have **no** user row; their data hangs off a session id.
+
+## `recipe`
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| id | String(36) | PK — client- or server-generated UUID4 |
+| user_id | Integer | FK → user.id, nullable (**NULL = guest-owned**) |
+| guest_session_id | String(64) | nullable, indexed |
+| name | String(200) | NOT NULL |
+| status | String(20) | NOT NULL, default `ready` — values: `ready` / `generating` / `error` |
+| slug | String(255) | nullable, **UNIQUE index** — public URL path segment |
+| is_public | Boolean | NOT NULL, default false — gates `/r/<slug>`, `/browse`, sitemap |
+| data | JSON (MutableDict) | NOT NULL — the full recipe blob (below) |
+| created_at / updated_at | DateTime | NOT NULL, UTC defaults; updated_at auto-bumps |
+
+**Ownership invariant:** exactly one of (`user_id`, `guest_session_id`) identifies the owner. On login, guest rows are migrated (`user_id` set, `guest_session_id` cleared). **Publish invariant:** `is_public` may only be true when `user_id` is non-NULL (repository-enforced; historical violations cleaned by migration `e91b47a2c5d3`).
+
+## `cookbook` (API name: "collections")
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| id | String(36) | PK (UUID string) |
+| user_id | Integer | FK → user.id, nullable |
+| guest_session_id | String(64) | nullable, indexed |
+| name | String(200) | NOT NULL |
+| description | String(500) | nullable, default `""` |
+| cover_image | String(500) | nullable |
+| recipe_ids | JSON | NOT NULL, default `[]` — plain array of recipe UUIDs, no referential integrity |
+| created_at / updated_at | DateTime | NOT NULL |
+
+API serialization uses camelCase: `coverImage`, `recipeIds`.
+
+## Recipe `data` blob — JSON Schema (Draft-07, `recipe_schema.json`)
+
+AI-generated recipes are validated against this schema before being marked ready. Client-saved recipes (manual entry, import, edits) are **not** validated server-side.
+
+**Required:** `name` (string), `prepTime` (int, minutes), `cookTime` (int), `servings` (int), `ingredients`, `instructions`.
+
+| Field | Type | Rules |
+|-------|------|-------|
+| ingredients | object of groups | Required groups `wet` and `dry`; optional `other`; arbitrary extra group names allowed. |
+| ingredients.<group>[] | ingredient object | `name` (req), `amount` (number **or** number[] for ranges, req), `units` (string, req), `notes` (opt). |
+| instructions | array | Each item: plain string OR `{step?: int ≥ 1, description: string}` (no extra keys). |
+| description, notes | string | Optional. |
+| tags | string[] | Optional. |
+| image_keywords | string[] | Optional, 1–5 items — stock-photo search terms the generator must include. |
+| stock_image_url, ai_image_url, image | uri or null | Optional. |
+| user_id | string | Optional (legacy). |
+| ai_metadata | object | `recipe_generation` (model, prompt, timestamp, success, user identity), `image_generation` (nullable; `{success: false, error, timestamp}` on failure), `stock_image_generation` (nullable), legacy `model`/`timestamp`/`prompt`, `images_working`. |
+
+**Backend-written fields outside the schema** (top-level `additionalProperties` is open, so they pass): `id`, `ai_image_gcs` (GCS object name), `ai_image_data` (legacy base64 PNG), `stock_image_attribution`, `slug`, `is_public`.
+
+## Frontend types (localStorage session record)
+
+The Angular `User` object cached under localStorage key `vegan_genius_session`:
+
+| Field | Notes |
+|-------|-------|
+| id | DB user id (authenticated) or client UUID (guest) |
+| email, name, picture | From Google profile; guest name is "Guest Chef" |
+| isGuest, authProvider | `google` \| `guest` |
+| savedRecipes | Recipe[] — base64 `data:` image URLs stripped before write (5 MB quota) |
+| cookbooks | `{id, name, description, recipeIds, coverImage?}` |
+| deletedRecipes | `{recipe, deletedAt (ISO), cookbookIds?}[]` — the recycle bin, **client-side only** |
+
+## Image storage strategy
+
+1. **GCS (production):** `gs://$GCS_BUCKET_NAME/images/<recipe_id>.png` (prod bucket `tasteslikegood-recipe-images`); blob carries `ai_image_gcs` and `ai_image_url = /api/recipes/<id>/image`.
+2. **Base64-in-DB (legacy/local):** `ai_image_data` in the blob when no bucket is configured. An admin endpoint migrates these to GCS.
+3. Raw image bytes are stripped from API list/read responses and never stored in browser localStorage; clients always reference the serving endpoint.
+
+## Sessions
+
+Client-side signed cookies only (Flask default, `FLASK_SECRET_KEY`). Keys: `session_id` (guest identity, auto-created on every non-static request), `state` + `code_verifier` (OAuth/PKCE), `credentials` (OAuth tokens, minus client_secret), `user_info`, `user_id` (DB int), `db_user`. A `flask_sessions` server-side table was created (migration `e5a1b3c7d9f2`) and later dropped (`03da1e46c9a5`) — do not document server-side sessions as current behavior.

--- a/prd/appendix/enum-dictionary.md
+++ b/prd/appendix/enum-dictionary.md
@@ -1,0 +1,88 @@
+# Enum & Constant Dictionary
+
+> **Generated:** 2026-07-10
+
+## Recipe status (`recipe.status`, String(20) — no DB enum)
+
+| Value | Meaning | Set by |
+|-------|---------|--------|
+| `ready` | Recipe content is complete (default) | Worker on successful generation; default for client-saved recipes |
+| `generating` | Async Gemini generation queued/in progress | `POST /api/generate` |
+| `error` | Generation failed after all retries (or queueing failed) | Worker / generate endpoint |
+
+## Auth providers (frontend `AuthProvider`)
+
+| Value | Meaning |
+|-------|---------|
+| `google` | Google OAuth via Flask |
+| `guest` | Local guest session ("Guest Chef") |
+
+## Ingredient groups
+
+`wet`, `dry` (required by the AI schema), `other` (optional). The manual-entry wizard offers exactly these three. Extra group names are schema-legal but never produced by the UI.
+
+## Ingredient types in manual entry
+
+`wet` | `dry` | `other` — default `dry`.
+
+## Canonical ingredient units (normalization, fuzzy-match cutoff 0.8; missing unit → `qty`)
+
+`cup, tsp, Tbsp, oz, g, kg, ml, l, lb, pinch, qty, to taste`
+
+## Amount display fractions (frontend)
+
+0.25 → `1/4`, 0.33 → `1/3`, 0.5 → `1/2`, 0.66 → `2/3`, 0.75 → `3/4` (±0.01 tolerance); array amounts render as `a - b`.
+
+## Portion multipliers
+
+`0.5x`, `1x` (default), `2x` — display-only scaling.
+
+## AI models
+
+| Constant | Value | Used by |
+|----------|-------|---------|
+| Default text model | `gemini-3.1-pro-preview` (no `models/` prefix) | `POST /api/generate` |
+| Legacy form default | `models/gemini-2.5-flash` | Legacy `/generate_recipe` |
+| Image model | `imagen-4.0-generate-001` | Image worker + legacy image endpoints |
+| Preferred-model sort order | `models/gemini-2.5-pro`, `models/gemini-2.5-flash`, `models/gemini-2.0-flash`, `models/gemini-2.0-flash-exp`, `models/gemini-3-pro-preview`, `models/gemini-2.0-flash-lite`, `models/gemini-exp-1206`, `models/gemini-pro-latest`, `models/gemini-flash-latest` | `/api/models` |
+| Model filter | only `gemini`/`gemma`; excludes names containing `embedding, imagen, veo, live, tts, audio, robotics, aqa`; max **10** returned | `/api/models` |
+
+## Limits & thresholds
+
+| Limit | Value | Where |
+|-------|-------|-------|
+| Prompt length | 10–500 chars | Flask `/api/generate` (and legacy form) |
+| General API rate limit | 300 req / 15 min / IP | Express, `/api/*` |
+| AI rate limit | 20 req / hour / IP | Express, `/api/generate*` (shared bucket with Valkey; separate with in-memory fallback) |
+| Generation retries | `GENERATION_MAX_ATTEMPTS`, default 3 | Recipe worker (in-process) |
+| Generation temperature | 0.7 | Gemini calls |
+| Images per generation | 1 | Imagen |
+| Image polling interval | 2 s | Frontend status polling |
+| Hydration retries | 2 (1 s apart) | Frontend `loadFromApi` |
+| Browse page size | 20 | `/browse` |
+| Admin image migration batch | 100 | `/api/admin/migrate-images` |
+| Image cache header | `public, max-age=86400` | `/api/recipes/<id>/image` |
+| Express JSON body limit | 50 KB (post-proxy routes only) | Express |
+| localStorage quota strategy | base64 `data:` URLs stripped before write | Frontend |
+| Report reason | truncated to 500 chars | Legacy `/api/report_recipe` |
+| Column lengths | user.email 120, user.name 100, google_id 100; recipe.name 200, status 20, slug 255, guest_session_id 64; cookbook.name 200, description 500, cover_image 500 | DB |
+
+## Session keys (Flask signed cookie)
+
+`session_id` (guest identity), `state`, `code_verifier` (OAuth PKCE), `credentials` (tokens, minus client_secret), `user_info`, `user_id` (DB int), `db_user`.
+
+## Infrastructure names
+
+| Item | Value |
+|------|-------|
+| Pub/Sub topics | `recipe-generation`, `image-generation` |
+| GCS objects | `images/<recipe_id>.png`; prod bucket `tasteslikegood-recipe-images` |
+| Cloud Run services | `express-frontend` (public, :8080), `flask-backend` (private), `flask-backend-migrate` (job) |
+| Rate-limit key prefixes | `rl:api:`, `rl:expensive:` (Valkey) |
+| Cache key scheme (currently no-op) | `vgc:{u:<uid>\|g:<sid>}:r:<rid>`, `...:rstats`, `...:colls`, `...:c:<cid>`, `vgc:img:<rid>` |
+| localStorage key | `vegan_genius_session` |
+| Deploy tag pattern | `^v[0-9]+\.[0-9]+\.[0-9]+$` (pre-release/metadata tags do not deploy) |
+
+## OAuth scopes
+
+`openid`, `https://www.googleapis.com/auth/userinfo.email`, `https://www.googleapis.com/auth/userinfo.profile`

--- a/prd/appendix/page-relationships.md
+++ b/prd/appendix/page-relationships.md
@@ -1,0 +1,56 @@
+# Page Relationships & Navigation Map
+
+> **Generated:** 2026-07-10
+
+## Navigation graph
+
+```
+                    ┌──────────────────────┐
+                    │  Recipe Generator /  │◄──────── logo click, tab,
+                    │  Recipe Detail ( / ) │          browser Back
+                    └───────┬──────────────┘
+        tab / empty-state   │  ▲ card click (view recipe)
+        CTA / auto after    ▼  │
+        ?save flow    ┌──────────────────┐
+                      │ My Kitchen       │◄──── #kitchen hash deep-link
+                      │ (/#kitchen)      │      (from SSR pages)
+                      └──────────────────┘
+                               ▲
+        ?save=<slug> ──────────┘
+             │
+   ┌─────────┴────────────┐    "View public page" link ┌───────────────┐
+   │ Public recipe page   │◄───(new tab, from detail)──│ slug field on │
+   │ /r/<slug>  (SSR)     │                            │ detail view   │
+   └─────────┬────────────┘                            └───────────────┘
+             │ listed on
+             ▼
+   ┌──────────────────────┐        ┌──────────────────┐
+   │ Browse index /browse │        │ /sitemap.xml     │──► search engines
+   │ (SSR)                │        └──────────────────┘
+   └──────────────────────┘
+   ┌──────────────────────┐
+   │ /privacy-policy      │◄── footer link (static HTML, Express-served)
+   └──────────────────────┘
+```
+
+## SPA view switching (no router)
+
+The Angular app has **no Angular Router** — it switches between two views via a signal (`activeView`), synchronized with browser history:
+
+- Entering My Kitchen pushes `{view: 'kitchen'}` history state; opening a recipe from the kitchen pushes `{view: 'recipe-detail'}`; the browser Back button walks these states (popstate handler).
+- The `#kitchen` hash is honored only as an initial-entry deep-link (SSR pages link to `/#kitchen`); it is cleared when returning to the Generator so it can't hijack later back/forward navigation.
+
+## Cross-boundary flows (SSR ⇄ SPA)
+
+| Flow | Parameters | Behavior |
+|------|-----------|----------|
+| SSR "Save to Cookbook" CTA → SPA | `/?save=<slug>` | The SPA strips the param (so refresh doesn't re-trigger), validates the slug against `^[a-z0-9-]+$` (after trim+lowercase; prevents client-side request forgery), waits for the startup auth check, ensures a session, fetches `GET /api/recipes/public/<slug>`, saves a **copy with a fresh ID** into the cookbook (reusing the source ID would 409-collide and never persist), then navigates to My Kitchen. |
+| SPA publish → SSR | slug on the recipe | Public toggle + slug field on the detail view produce `/r/<slug>`; the link opens in a new tab. |
+| OAuth round-trip | `/?auth=success` | Google redirects back with this param; the SPA confirms the session via `/api/auth/check` and strips the param. |
+
+## Data coupling
+
+- **Generator ⇄ Kitchen:** both views render from the same signals (`currentUser().savedRecipes` / `.cookbooks`); any save, delete, publish, or cookbook change is visible in both instantly, including the header's saved-recipe badge.
+- **localStorage ⇄ API:** every mutation writes localStorage first, then syncs to Flask. A one-time-per-session hydration merges API data into local state after the auth check (guests included — guest data is scoped by a server-issued guest session cookie).
+- **Login merge:** on Google sign-in, existing guest recipes/cookbooks are retained in the new authenticated session and pushed to the account through the normal save flow.
+- **SSR pages read the same database:** publishing in the SPA makes the recipe appear at `/r/<slug>`, on `/browse`, and in `/sitemap.xml` (once public and, for guests, never — publishing is OAuth-gated).

--- a/prd/appendix/platform-behavior.md
+++ b/prd/appendix/platform-behavior.md
@@ -1,0 +1,67 @@
+# Platform Behavior — Express Layer, Security, Deployment
+
+> **Source:** `server/index.ts`, `server/proxy.ts`, `server/security.ts`, `server/valkey.ts`, `Dockerfile`, `cloudbuild.yaml`
+> **Generated:** 2026-07-10
+
+Everything the browser touches goes through a single public Express service. It serves the Angular SPA, proxies all `/api/*` traffic to the private Flask backend, proxies the server-rendered public pages, and enforces rate limits and security headers. No business logic lives here.
+
+## Route map (mount order matters)
+
+| # | Route | Handled by | Purpose |
+|---|-------|-----------|---------|
+| 1 | `GET /api/health` | Express itself | `{status, timestamp, rateLimitStore: 'valkey'\|'memory'}` — health + rate-limit-store diagnostic. Never proxied. |
+| 2 | `/api/*` | Rate limiter | General: 300 req / 15 min / IP. |
+| 3 | `/api/generate`, `/api/generate_image` | Rate limiter | AI tier: 20 req / hour / IP. With Valkey both endpoints share one bucket per IP (same key prefix); with the in-memory fallback they count separately. |
+| 4 | (all) | Helmet + X-Robots-Tag | Security headers (see below). |
+| 5 | `/api/*` | **Flask proxy** | Mounted **before** `express.json()` so request bodies stream raw to Flask (Flask parses its own bodies). |
+| 6 | (all) | `express.json({limit: '50kb'})` | Defense-in-depth only — no Express route after the proxy reads a body. |
+| 7 | static | Angular `dist/` | SPA assets. |
+| 8 | `GET /privacy-policy` | Static file | `server/public/privacy-policy.html`; mounted before the SPA fallback. |
+| 9 | `GET /r/*`, `GET /browse`, `GET /sitemap.xml`, `GET /static/*` | Flask SSR proxy | Server-rendered public recipe pages, browse index, sitemap, and Flask template stylesheets. `/static/*` proxying was added after a real incident (v0.3.1): without it, stylesheets fell through to the SPA fallback as `text/html` and `nosniff` left public pages unstyled. GET-only by design. |
+| 10 | `GET *` | SPA fallback | `dist/index.html`. Rate-limited 300/15 min. |
+| 11 | (errors) | Error handler | Logs details server-side; returns generic `{error: 'An unexpected error occurred on the server.'}`. |
+
+`trust proxy: 1` is set so rate limiting keys on the real client IP behind Cloud Run.
+
+## Security
+
+- **Helmet with CSP explicitly disabled** — Angular's build output relies on inline styles/handlers and dynamic script loading; the code comments delegate CSP to CDN/proxy level `[TBC: nothing in this repo configures that]`. All other Helmet defaults active (nosniff, X-Frame-Options, HSTS, Referrer-Policy).
+- **`X-Robots-Tag: index, follow`** on HTML responses only when `NODE_ENV=production` — preview deploys are not indexable.
+- **Rate limit exemptions:** `/api/health` and recipe-image serving (`/api/recipes/<id>/image`) are exempt from the general limiter so image-heavy pages don't burn quota.
+- **429 responses:** general — "Too many requests, please try again later."; AI — "Rate limit exceeded for this operation. Please try again later." RFC `RateLimit-*` headers enabled.
+- **Request logging:** one line per request (timestamp, method, path, status, duration). No bodies or PII.
+- **No Express-layer input validation.** `express-validator` is a declared dependency but is imported nowhere; `server/validation.ts` does not exist (project docs describing it are stale). All input validation is Flask's responsibility.
+
+## Distributed rate limiting (Valkey)
+
+- When `VALKEY_HOST` is set and reachable, limits are shared across all Express replicas via Valkey (Redis-compatible), using GCP IAM tokens as passwords when `VALKEY_AUTH_MODE=iam` (auto-refreshed every 45 min), with TLS via a Google-managed CA cert (`VALKEY_CA_CERT`).
+- If Valkey is absent or down, limiters **silently fall back to per-instance in-memory stores** — a scaled-out deployment effectively multiplies the quota. Known edge cases tracked in GH #163/#162 (KAN-16/17). `/api/health` reports which store is live.
+
+## Proxy behavior
+
+- Dependency-free streaming proxy (Node `http`/`https`). Target: `FLASK_BACKEND_URL` (default `http://localhost:5000`), read once at startup.
+- Forwards method, full URL, and all headers; rewrites `Host` to the Flask target and sets `X-Forwarded-Host` (browser's original host) + `X-Forwarded-Proto` so Flask's `ProxyFix` generates correct external URLs (OAuth redirects).
+- Fully streaming both directions — no buffering, no explicit timeout (long AI generations rely on this).
+- Flask unreachable → **502** `{error: 'Backend service unavailable', ...}`; mid-stream failures cut the response off.
+
+## Startup / shutdown
+
+- Port `PORT` (default **8080**). Startup: connect Valkey (or fall back) → mount routes → listen; fatal errors exit(1).
+- Graceful shutdown on SIGTERM/SIGINT: drain HTTP, stop IAM-token refresh, quit Valkey with a 3 s force-disconnect fallback (fits Cloud Run's 10 s window).
+- Dev mode bypasses Express entirely: Angular dev server on :3000 with `proxy.conf.json` forwarding only `/api/auth`, `/api/recipes`, `/api/collections` to Flask `[TBC: /api/generate* is not in the dev proxy config — dev AI calls appear to require the full Express path or fail]`.
+
+## Deployment (Cloud Run, us-central1)
+
+Pipeline (`cloudbuild.yaml`), triggered by version tags matching `^v[0-9]+\.[0-9]+\.[0-9]+$`:
+
+1. Init Backend submodule; build + push both Docker images (`$SHORT_SHA` + version tag).
+2. **Run `flask-backend-migrate` Cloud Run Job** (`flask db upgrade`, blocking, 600 s timeout). Failure aborts the deploy; the old revision keeps serving.
+3. Deploy `flask-backend` — private (`--no-allow-unauthenticated`), min 1 instance, VPC-attached (Cloud SQL private IP, Valkey at 10.128.0.11), secrets from Secret Manager (`GOOGLE_API_KEY`, `FLASK_SECRET_KEY`, `GOOGLE_CLIENT_SECRET`, `DATABASE_URL`). `FRONTEND_URL=https://www.tasteslikegood.org`, `SESSION_COOKIE_DOMAIN=.tasteslikegood.org`.
+4. Deploy `express-frontend` — the only public service, min 0 instances, secrets `GEMINI_API_KEY`, `VALKEY_CA_CERT`. Deployed after Flask so a new frontend never serves against an old API. Its env vars (e.g. `FLASK_BACKEND_URL`) persist from prior revision settings, configured out-of-band `[TBC]`.
+
+## Test-only elements (not product behavior)
+
+- The HTTP listener is skipped under `VITEST`/`NODE_ENV=test`; tests boot the app themselves.
+- `server/routes.test.ts` uses a stub Flask server; `server/server.test.ts` mocks ioredis/google-auth.
+- `createAuthProxy()` is an unused backward-compat alias.
+- Most of `server/types.ts` (`SecurityConfig`, `ValidationError`) is unreferenced scaffolding for a validation layer that was never built.

--- a/prd/pages/01-recipe-generator.md
+++ b/prd/pages/01-recipe-generator.md
@@ -1,0 +1,174 @@
+# Recipe Generator (Home)
+
+> **Route:** `/` (SPA default view; `activeView = 'generator'`)
+> **Module:** Recipe Generation
+> **Source:** `src/app.component.ts`, `src/app.component.html` (lines 194–760), `src/services/gemini.service.ts`
+> **Generated:** 2026-07-10
+
+## Overview
+
+The Generator is the landing experience of VeganGenius Chef. A visitor types what they're craving into a single prompt box, and the system generates a complete vegan recipe (name, description, timing, grouped ingredients, step-by-step method, chef's notes, tags) using Google Gemini, followed by an AI-generated food photo via Imagen. No account is required — a guest session is created automatically on first generation.
+
+The generated-recipe display doubles as the **recipe detail view**: opening a saved recipe from My Kitchen renders it in this same layout.
+
+## Layout
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Header: logo/title (click → generator) | Generator/Kitchen │
+│         tabs | Sign In button OR user profile chip         │
+├────────────────────────────────────────────────────────────┤
+│ Prompt input ........................... [Generate button] │
+│ (error banner appears below on failure)                    │
+├──────────────────────────┬─────────────────────────────────┤
+│ Recipe header:           │ Image area (4:3):               │
+│  "Vegan Recipe" badge    │  AI photo + "AI Generated" tag  │
+│  Save / Add to Cookbook /│  or "Styling your dish..."      │
+│  Download JSON buttons   │  spinner, or "Image not         │
+│  Public toggle + slug    │  available" placeholder.        │
+│  Title, description, tags│  Hover: Regenerate button       │
+│  Prep/Cook/Servings grid │                                 │
+│  Scale: 0.5x / 1x / 2x   │                                 │
+├──────────────────────────┼─────────────────────────────────┤
+│ Ingredients card         │ Method (numbered steps)         │
+│ (sticky; Wet/Dry/Other   │ Chef's Notes card (yellow,      │
+│  groups)                 │  hover-to-edit)                 │
+└──────────────────────────┴─────────────────────────────────┘
+│ Footer: © Tasteslikegood.org | Privacy Policy link         │
+```
+
+## Fields
+
+### Prompt Area
+
+| Field | Type | Required | Default | Validation | Notes |
+|-------|------|----------|---------|------------|-------|
+| Craving prompt | Text input | Yes | empty | Non-blank (trimmed) to enable Generate | Placeholder: "What are you craving? (e.g., 'spicy lentil tacos' or 'avocado chocolate mousse')". Enter key also submits. No Express-layer validation exists (see api-inventory appendix); Flask validates server-side. |
+
+### Recipe Display (read-only fields)
+
+| Field | Format | Notes |
+|-------|--------|-------|
+| Name | Large serif heading | `recipe.name` |
+| Description | Italic paragraph | |
+| Tags | `#tag` pills | Optional array |
+| Prep Time / Cook Time | `{n} min` | Static — not affected by scaling |
+| Servings | Integer | **Scaled**: `round(servings × multiplier)` |
+| Ingredients | Grouped lists: Wet, Dry, Other | Each row: amount + units (bold green, right-aligned), name, optional `(notes)` in italic. A group is hidden when empty. |
+| Ingredient amount | Fraction-friendly | Amounts 0.25/0.33/0.5/0.66/0.75 display as 1/4, 1/3, 1/2, 2/3, 3/4. Range amounts (`number[]`) display as `a - b`. |
+| Instructions | Numbered steps | Accepts plain strings or `{step, description}` objects (renders `description`). |
+| Chef's Notes | Yellow card, pre-wrap text | Shows "No notes added yet." when empty. |
+| Image | 4:3 cover photo | From `ai_image_url`; "AI Generated" badge overlaid. |
+
+The recipe article carries `itemscope itemtype="https://schema.org/Recipe"` microdata for SEO.
+
+### Action Buttons (recipe header)
+
+| Button | Visibility | Behavior |
+|--------|-----------|----------|
+| Save / Saved | Always (disabled once saved) | Persists recipe to cookbook (localStorage + API). Turns green "Saved" with checkmark. |
+| Add to Cookbook | Always | Opens Add to Cookbook modal (see below). |
+| Download (JSON) | Always | Client-side download of the single recipe as `<Recipe_Name>.json`. |
+| Public toggle | Signed-in (non-guest) users only | Publishes/unpublishes the recipe (see Publishing). |
+| "Sign in to publish" link | Guests, only after the recipe is saved | Opens the Auth modal. Gated on saved-state so a guest is never sent into the OAuth redirect with an unsaved in-memory recipe. |
+| Slug input + open-in-new-tab link | Signed-in AND recipe is public | Edit the public URL slug; link opens `/r/<slug>`. |
+| Regenerate image | On image hover, when not loading | Re-runs image generation with `force_regenerate: true`. |
+| Scale 0.5x / 1x / 2x | Always | Multiplies all ingredient amounts and servings; amounts rounded to 2 decimals. Default 1x; resets to 1x on each new generation. |
+| Edit notes (pencil) | On Chef's Notes hover | Inline textarea with Save/Cancel; Save persists the whole recipe. |
+
+## Interactions
+
+### Page Load
+
+- App bootstraps zoneless Angular; startup auth check runs (`GET /api/auth/check`) — see [Auth & Sessions](../appendix/page-relationships.md).
+- View resolves from URL: `#kitchen` hash → My Kitchen; otherwise Generator. A `?save=<slug>` query param triggers the save-from-SSR flow (see Page Relationships).
+- No recipe is shown until one is generated or opened from My Kitchen.
+
+### Generate a recipe
+
+- **Trigger:** Click Generate or press Enter in the prompt (no-op if prompt is blank; button disabled while loading).
+- **Behavior:**
+  1. A guest session is ensured (created in localStorage if no session exists).
+  2. UI resets: clears previous recipe/image/error, resets scale to 1x, shows "Cooking..." spinner on the button.
+  3. `POST /api/generate {prompt}` — Flask generates via Gemini **and saves the recipe to the database** during generation.
+  4. If the response is `status: "generating"` (async path), the client polls `GET /api/recipes/<id>/status` every 2 s until `status: "ready"` (resolve) or `"error"` (reject).
+  5. On success the recipe renders, is marked Saved immediately (backend already persisted it), and is also written into local state via an idempotent save (a 409 duplicate from the API is treated as success).
+  6. Image generation starts automatically (below).
+- **Failure:** Red error banner under the prompt with the API's `error` message, or "Failed to generate recipe. Please try again."
+
+### Image generation (automatic after recipe, or manual regenerate)
+
+- **Trigger:** Automatic after a successful generation; manual via the hover Regenerate button (adds `force_regenerate: true`).
+- **Behavior:** `POST /api/generate_image {recipe_id, force_regenerate}` shows "Styling your dish..." spinner. If the response is `status: "generating_image"` (async Pub/Sub path), polls `GET /api/recipes/<id>/status` every 2 s until `ai_image_url` appears (resolve) or `ai_metadata.image_generation.success === false` (reject).
+- **Race guard:** the recipe ID is captured before the request; if the user has navigated to a different recipe by the time the image arrives, the UI is not updated (but localStorage still records the URL for the original recipe).
+- **Persistence rule:** on completion only the `ai_image_url` field is patched into localStorage — a full recipe re-save is deliberately avoided because API responses strip the raw image data, and re-POSTing the recipe would erase the stored image server-side.
+- **Failure:** logged to console only; the placeholder "Image not available" remains. No user-facing error.
+
+### Save
+
+- **Trigger:** Save button (disabled when already saved).
+- **Behavior:** writes localStorage first (instant UI), then `POST /api/recipes` (409 ignored). Button flips to green "Saved".
+
+### Add to Cookbook (modal)
+
+- **Trigger:** "Add to Cookbook" button here, or the hover "+" button on kitchen cards.
+- **Modal content:** list of the user's cookbooks as toggle buttons (green ring when selected), pre-checked with the recipe's current memberships; "+ New" opens the Create Cookbook modal layered on top (z-60), and a cookbook created that way is auto-selected on return. Empty state: "No cookbooks yet. Create one!"
+- **Confirm:** computes adds and removes vs. current membership. If any cookbook would lose the recipe, an inline amber confirmation lists them ("This recipe will be removed from: …") with Go Back / Yes, Remove. Applying changes calls the collections API per add/remove and marks the recipe Saved if it's the one on screen.
+
+### Publish / unpublish (signed-in only)
+
+- **Trigger:** Public toggle switch.
+- **Behavior:** flips `is_public` optimistically. When publishing a recipe with no slug, one is derived from the name (lowercase, spaces/underscores → hyphens, punctuation stripped). Saves via `POST /api/recipes`; on failure the toggle reverts. When public, the slug field and a link to the public page `/r/<slug>` appear.
+- **Guest rule:** guests cannot publish — the server forces `is_public=false` for guest sessions, and the UI shows "Sign in to publish" instead of the toggle. See [Business Rules](#business-rules).
+
+### Edit slug
+
+- **Trigger:** blur of the slug input (visible only while public).
+- **Behavior:** normalizes (lowercase, whitespace/underscores → hyphens, invalid chars stripped) and re-saves the recipe. Empty slug is ignored.
+
+### Edit Chef's Notes
+
+- **Trigger:** pencil icon (appears on card hover).
+- **Behavior:** textarea prefilled with current notes; Save persists the full recipe with the new notes; Cancel discards.
+
+### Sign in (Auth modal)
+
+- **Trigger:** "Sign In" header button, "Sign in to publish", or any publish attempt while guest.
+- **Modal content:** brand header, error banner (if the login start fails), a "Sign in with Google" button (spinner + "Connecting..." while the OAuth start request runs), and guest guidance: "No account needed to generate recipes! Close this dialog to continue as a guest. Your recipes will be stored locally in this browser."
+- **Behavior:** `GET /api/auth/login` returns an `authorization_url`; the browser redirects to Google's consent screen. On return, the app detects `?auth=success`, confirms the session via `/api/auth/check`, merges guest localStorage data into the account, and hydrates recipes/cookbooks from the API.
+
+### Header / profile
+
+- Signed-in users see a profile chip (avatar or initial, first name). Clicking opens a dropdown card: avatar, name, masked email (`ad***@gmail.com`), Saved Recipes count, Cookbooks count, and Log Out.
+- Log Out calls `POST /api/auth/logout`, clears local session, clears the on-screen recipe and prompt, and returns to the Generator. Local state is cleared even if the server is unreachable.
+- The "My Kitchen" tab shows a green badge with the saved-recipe count when non-zero.
+- While the startup auth check runs, the auth area shows a pulsing placeholder instead of the Sign In button.
+
+## API Dependencies
+
+| API | Method | Path | Trigger | Notes |
+|-----|--------|------|---------|-------|
+| Generate recipe | POST | `/api/generate` | Generate button | Body `{prompt}`. Rate-limited (AI tier). Saves to DB server-side. |
+| Generate image | POST | `/api/generate_image` | Auto after generate; Regenerate | Body `{recipe_id, force_regenerate}`. |
+| Recipe status | GET | `/api/recipes/<id>/status` | 2 s polling during async generation | Returns `{status, recipe}`. |
+| Save recipe | POST | `/api/recipes` | Save, notes, slug, publish toggle | Idempotent; 409 treated as success. |
+| Auth check | GET | `/api/auth/check` | App startup | `{authenticated, email, name, picture, user_id}`. |
+| Start login | GET | `/api/auth/login` | Google sign-in button | Returns `{authorization_url}`. |
+| Logout | POST | `/api/auth/logout` | Log Out | |
+| Cookbook membership | POST/DELETE | `/api/collections/<id>/recipes[/<rid>]` | Add to Cookbook confirm | |
+| List recipes/collections | GET | `/api/recipes`, `/api/collections` | Once per session after auth resolves | Hydrates local state; retried up to 2× at 1 s intervals. |
+
+## Page Relationships
+
+- **To My Kitchen:** header tab or logo; saved recipes appear there.
+- **From My Kitchen:** clicking a recipe card opens it in this view (marked Saved, image loaded, history entry pushed so browser Back returns to the kitchen).
+- **To public page:** `/r/<slug>` link next to the slug field (new tab).
+- **From SSR public pages:** `?save=<slug>` deep-link saves the public recipe into the visitor's cookbook and lands on My Kitchen (see [Public Recipe Pages](03-public-recipe-pages.md)).
+
+## Business Rules
+
+- **Guest-first:** all generation and saving works without an account; data lives in browser localStorage and in the Flask DB scoped to a server-issued guest session.
+- **Generation implies save:** a generated recipe is already persisted server-side; the Save button exists for local-state consistency and for manually-opened recipes.
+- **Publishing requires identity:** only Google-authenticated users can make recipes public. The UI hides the toggle for guests and the server independently enforces it.
+- **Scaling is display-only:** the 0.5x/2x multiplier never mutates the stored recipe.
+- **Image data never round-trips through the client:** recipes carry a URL (`/api/recipes/<id>/image` or a GCS/stock URL); base64 payloads are stripped before localStorage writes (5 MB quota) and on export/import.

--- a/prd/pages/02-my-kitchen.md
+++ b/prd/pages/02-my-kitchen.md
@@ -1,0 +1,183 @@
+# My Kitchen (Cookbook Manager)
+
+> **Route:** `/#kitchen` (SPA view; `activeView = 'kitchen'`; deep-linkable via the `#kitchen` hash)
+> **Module:** Cookbook & Recipe Management
+> **Source:** `src/app.component.ts`, `src/app.component.html` (lines 762–1933), `src/services/persistence.service.ts`, `src/services/auth.service.ts`
+> **Generated:** 2026-07-10
+
+## Overview
+
+My Kitchen is the user's personal cookbook: a grid of saved recipe cards organized into named cookbooks (collections), with manual recipe authoring, JSON import/export, and a recycle bin for soft-deleted recipes. It works identically for guests (localStorage + guest-scoped API) and signed-in users (API-backed, synced across devices).
+
+Entering the kitchen always ensures a session exists (creating a guest session for first-time visitors), because every kitchen action needs somewhere to persist.
+
+## Layout
+
+```
+┌──────────────┬─────────────────────────────────────────────┐
+│ Sidebar      │ Main content                                │
+│  [New        │  Header: cookbook name (or "All Recipes")   │
+│   Cookbook]  │          + description | Export All /       │
+│  [Write      │          Import JSON buttons                │
+│   Recipe]    │  Recipe card grid (1–3 columns):            │
+│  All Recipes │   photo, name, total time, servings;        │
+│   (count)    │   hover: Add-to-Cookbook + Delete buttons   │
+│  <cookbook>  │  Empty state: "No recipes yet" + CTA        │
+│   (count, 🗑) │                                             │
+│  ──────────  │  — or, when Recycle Bin is open —           │
+│  Recycle Bin │  Bin header + "Empty Recycle Bin"; cards    │
+│   (count)    │  with grayscale photo, deleted date,        │
+│              │  Restore / Delete buttons                   │
+└──────────────┴─────────────────────────────────────────────┘
+```
+
+## Fields
+
+### Sidebar
+
+| Element | Type | Notes |
+|---------|------|-------|
+| New Cookbook | Button | Opens Create Cookbook modal. |
+| Write Recipe | Button | Opens the 3-step Manual Entry wizard. |
+| All Recipes | Nav item | Default selection (`activeCookbookId = null`); badge shows total saved-recipe count. |
+| Cookbook rows | Nav items | Name (truncated), recipe-count badge, hover-revealed delete (trash) button. Keyboard-accessible (Enter/Space). |
+| Recycle Bin | Nav item | Only rendered when the bin is non-empty; red styling; count badge. Selecting it deselects any cookbook. |
+
+### Recipe Card (grid)
+
+| Element | Format | Notes |
+|---------|--------|-------|
+| Photo | 4:3-ish cover, hover zoom | `ai_image_url`; gray placeholder icon when absent. |
+| Name | Bold, clamped to 2 lines | |
+| Total time | `{prepTime + cookTime}m` | Clock icon. |
+| Servings | Integer | People icon. |
+| Add to Cookbook (+) | Hover overlay button | Opens Add to Cookbook modal for that card's recipe. |
+| Delete (trash) | Hover overlay button | Opens Delete confirmation modal. |
+| Card click | — | Opens the recipe in the Generator/detail view (browser Back returns here). |
+
+### Create Cookbook Modal
+
+| Field | Type | Required | Default | Validation | Notes |
+|-------|------|----------|---------|------------|-------|
+| Cookbook Name | Text input | Yes | empty | Non-blank (trimmed); Create button disabled otherwise | Placeholder "Cookbook Name (e.g. Desserts)" |
+| Description | Text input | No | empty | — | Placeholder "Description (Optional)" |
+
+### Manual Entry Wizard ("Write Recipe") — 3 steps
+
+**Step 1 — Basics**
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| Recipe Name | Text | Yes (gates final Save) | empty | |
+| Description | Textarea | No | empty | |
+| Prep (min) | Number | No | 15 | |
+| Cook (min) | Number | No | 30 | |
+| Servings | Number | No | 4 | |
+| Tags | Text | No | empty | Comma-separated; split and trimmed on save. |
+
+**Step 2 — Ingredients** (add-row + list)
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| Type | Select | — | Dry | Options: Wet / Dry / Other — determines ingredient grouping. |
+| Name | Text | Yes (row is ignored if blank) | empty | |
+| Qty | Number | No | 1 | |
+| Unit | Text | No | empty | Free text. |
+
+Added rows list with a type badge and a remove (×) button.
+
+**Step 3 — Instructions**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Step description | Textarea + Add button | Appends a numbered step; rows have hover-remove buttons. |
+| Chef's Notes | Textarea | Optional; saved on the recipe. |
+
+Footer: Back (steps 2–3), Next (steps 1–2), Save Recipe (step 3; disabled until Name is set).
+
+## Interactions
+
+### Entering the kitchen
+
+- **Triggers:** "My Kitchen" header tab, `#kitchen` hash on load (SSR deep-link), browser back/forward to a kitchen history entry, or the `?save=<slug>` flow.
+- **Behavior:** ensures a session (restores an existing localStorage session or creates a fresh "Guest Chef"), then shows All Recipes. History state is pushed so Back returns to the Generator. Leaving the kitchen clears a lingering `#kitchen` hash so back/forward stays consistent.
+- **Data:** the grid is a pure view over local state; a one-time-per-session API hydration (`GET /api/recipes` + `GET /api/collections`) merges server data into local state once the auth check settles (retried up to 2×). Local-only recipes and locally-known image URLs survive the merge.
+
+### Selecting a cookbook
+
+- **Trigger:** click a sidebar cookbook (or All Recipes).
+- **Behavior:** grid filters to recipes whose IDs are in the cookbook's `recipeIds`; header shows the cookbook name and description. Closes the recycle-bin view if open.
+
+### Create cookbook
+
+- **Trigger:** New Cookbook button (sidebar) or "+ New" inside the Add to Cookbook modal (layered on top, z-60).
+- **Behavior:** `POST /api/collections {id, name, description}` (client-generated UUID). On success the server's copy is merged into local state; **on API failure it silently falls back to a localStorage-only cookbook** so the UI keeps working. When launched from the Add-to-Cookbook flow, the new cookbook is auto-selected in that modal on return.
+
+### Delete cookbook
+
+- **Trigger:** hover trash button on a sidebar cookbook row.
+- **Behavior:** native browser `confirm()`: "Are you sure you want to delete this cookbook? Recipes will remain in \"All Saved\"." On confirm: removed locally, `DELETE /api/collections/<id>`, and if it was the active cookbook the view falls back to All Recipes. Recipes themselves are never deleted by this action.
+
+### Write recipe (manual entry)
+
+- **Trigger:** Write Recipe button.
+- **Behavior:** wizard resets to step 1 with defaults each time it opens. Moving from step 2 to 3, and final Save, auto-commit any typed-but-unadded ingredient/instruction row so no input is silently lost. Save assembles a `Recipe` (client UUID; ingredients grouped wet/dry/other; `image_keywords = [name, 'homemade']`), persists via localStorage + `POST /api/recipes`, and closes the wizard. No AI image is generated for manual recipes at save time.
+- **Validation:** only Name is required; there is no numeric-range validation on times/servings/quantity `[TBC: negative or zero values are accepted client-side]`.
+
+### Import JSON
+
+- **Trigger:** Import JSON label-button (hidden file input, `.json` only).
+- **Behavior:** parses a single recipe object or an array. Recipes must have `name`, `ingredients`, and `instructions` to count; invalid entries are skipped. Missing IDs get fresh UUIDs; duplicates (by ID) are not re-added. Inline base64 image data (`ai_image_data`) is stripped. If a cookbook is currently selected, imports are also added to it (and may set its cover image). Each valid recipe is synced via `POST /api/recipes`.
+- **Post-import image backfill:** recipes with no usable image URL get AI images generated sequentially in the background; an alert reports "Imported N recipes! Generating images for M recipe(s)..." (or a plain success alert when none need images).
+- **Failure:** parse errors alert "Failed to parse recipe file. Please ensure it is valid JSON."
+
+### Export
+
+- **Export All** (kitchen header): downloads every saved recipe as `my_vegan_cookbook.json`. Note: exports **all** saved recipes regardless of the selected cookbook `[TBC: possibly unintended — the button sits under the cookbook header]`.
+- **Export single** (recipe detail view): downloads `<Recipe_Name>.json`.
+
+### Delete recipe (soft delete)
+
+- **Trigger:** hover trash on a card → Delete confirmation modal ("*<name>* will be moved to the Recycle Bin.").
+- **Behavior:** locally the recipe moves to the recycle bin (remembering which cookbooks it was in) and is removed from all cookbooks; the server is asked to `DELETE /api/recipes/<id>` immediately — **the recycle bin is client-side only; the server hard-deletes**. If the deleted recipe was open in the detail view, that view is cleared.
+
+### Recycle Bin
+
+- **Trigger:** sidebar Recycle Bin entry (visible only when non-empty).
+- **View:** grayscale cards with "Deleted {date}" timestamps.
+- **Restore:** re-adds the recipe to saved recipes and its former cookbooks locally, and re-creates it server-side via `POST /api/recipes`.
+- **Delete (single):** removes it from the bin permanently (no server call — it was already hard-deleted).
+- **Empty Recycle Bin:** confirmation modal ("This will permanently delete N recipe(s). This cannot be undone.") then clears the bin locally.
+- The bin lives in localStorage as part of the session record, so it does not sync across devices and is lost if browser storage is cleared.
+
+### Add to Cookbook (from a card)
+
+Same modal and rules as on the Generator page — see [Recipe Generator § Add to Cookbook](01-recipe-generator.md#add-to-cookbook-modal).
+
+## API Dependencies
+
+| API | Method | Path | Trigger | Notes |
+|-----|--------|------|---------|-------|
+| List recipes | GET | `/api/recipes` | Session hydration | Response `{recipes: [{id, data}]}`; client uses `data`. |
+| List collections | GET | `/api/collections` | Session hydration | Mapped to Cookbook shape. |
+| Save recipe | POST | `/api/recipes` | Manual save, import, restore, edits | Idempotent (409 ignored). |
+| Delete recipe | DELETE | `/api/recipes/<id>` | Soft-delete confirm | Server-side hard delete. |
+| Create collection | POST | `/api/collections` | Create Cookbook | Falls back to local-only on failure. |
+| Delete collection | DELETE | `/api/collections/<id>` | Delete cookbook | |
+| Add recipe to collection | POST | `/api/collections/<id>/recipes` | Add-to-Cookbook apply | Body `{recipe_id}`; recipe is re-saved first to guarantee it exists in the DB. |
+| Remove recipe from collection | DELETE | `/api/collections/<id>/recipes/<rid>` | Add-to-Cookbook apply | |
+| Generate image | POST | `/api/generate_image` | Import backfill | Sequential, background, per recipe missing an image. |
+
+## Page Relationships
+
+- **From Generator:** header tab; also auto-navigated here after the `?save=<slug>` SSR save flow completes.
+- **To Generator/detail:** card click opens the recipe in the detail layout; "Go to Generator" CTA on the empty state; browser Back returns here (history state).
+- **Data coupling:** saving/publishing/deleting in the detail view immediately updates kitchen counts and grids (shared signals). The header's My Kitchen badge mirrors the saved-recipe count.
+
+## Business Rules
+
+- **localStorage-first writes:** every mutation updates local state before the API call, so the UI never waits on the network; API failures are logged, not surfaced (except cookbook creation's silent local fallback).
+- **Guest data merges on login:** a guest's locally saved recipes/cookbooks are carried into the authenticated session and pushed to the account via the normal save flow.
+- **Recycle bin ≠ server state:** restore re-creates the recipe server-side; permanent delete is local-only bookkeeping.
+- **Base64 images are never stored client-side:** stripped before localStorage writes (quota) and on import.
+- **Cookbook cover image:** first recipe added with an image becomes the cover unless one is already set (currently not rendered anywhere in the UI `[TBC: coverImage is stored but unused visually]`).

--- a/prd/pages/03-public-recipe-pages.md
+++ b/prd/pages/03-public-recipe-pages.md
@@ -1,0 +1,69 @@
+# Public Recipe Pages (SSR)
+
+> **Routes:** `/r/<slug>`, `/browse`, `/sitemap.xml` (+ JSON companion `/api/recipes/public/<slug>`)
+> **Module:** Recipe Distribution (v0.2 "anti-recipe-site" pages)
+> **Source:** `Backend/blueprints/public_bp.py`, `Backend/templates/public/`; proxied by Express (`server/index.ts` SSR routes)
+> **Generated:** 2026-07-10
+
+## Overview
+
+Published recipes get real server-rendered HTML pages so search engines, social cards, and no-JS visitors see full content instead of the empty SPA shell. Express proxies `GET /r/*`, `/browse`, `/sitemap.xml`, and `/static/*` (template stylesheets) to Flask; everything else falls through to the SPA. Only recipes explicitly published by a **signed-in** owner appear here.
+
+## Pages
+
+### Recipe page — `GET /r/<slug>`
+
+- Renders the recipe where `slug` matches AND `is_public` is true; anything else is a 404 (unpublished, guest-owned, unknown slug).
+- Content: recipe name, description, hero image, timing/servings, ingredients formatted as `amount units name (notes)` (ranges as `a–b`), numbered instructions, tags.
+- Image selection order: `ai_image_url` → the image-serving endpoint (when GCS/base64 data exists) → `stock_image_url`; all made absolute against `FRONTEND_URL`.
+- SEO: canonical URL, meta description, and **schema.org Recipe JSON-LD** — name, description, author (user's name, else Organization "TastesLikeGood"), datePublished/Modified, prep/cook/total time as ISO-8601 durations, recipeYield, recipeIngredient, recipeInstructions (HowToStep list), keywords from tags, `recipeCategory: "Vegan"`. Empty/null fields are stripped.
+- Sharing: Pinterest share link.
+- CTAs into the SPA: "Save to Cookbook" → `/?save=<slug>#kitchen` (triggers the SPA save flow — see [Page Relationships](../appendix/page-relationships.md)), plus deep-links to the generator/kitchen.
+
+### Companion JSON — `GET /api/recipes/public/<slug>`
+
+Powers the SPA's save-from-SSR flow. Returns `{id, name, description, prepTime, cookTime, servings, ingredients, instructions, notes, tags, stock_image_url, ai_image_url, image, slug, is_public}`; 404 when not found or not public. The SPA saves a **copy under a fresh ID** — the visitor's cookbook entry is independent of the source recipe.
+
+### Browse index — `GET /browse`
+
+Paginated list of all public recipes, newest first, **20 per page**, `?page=n` (out-of-range values clamped). Each entry links to its `/r/<slug>` page. Canonical URL in meta.
+
+### Sitemap — `GET /sitemap.xml`
+
+Dynamic XML sitemap: `/` (priority 1.0, daily), `/browse` (0.9, daily), and every public recipe with a slug as `/r/<slug>` (0.8, weekly) with `lastmod` from the recipe's update date.
+
+## Interactions
+
+### Publishing lifecycle (cross-page)
+
+1. A signed-in user flips the Public toggle in the SPA detail view; the frontend generates a slug from the recipe name if none exists (lowercase, hyphenated, punctuation stripped) and saves via `POST /api/recipes` (upsert).
+2. The POST-upsert path is the **only** API path that writes the `slug` and `is_public` database columns (PUT updates only the JSON blob). Since the SPA always saves recipes via POST, publish/unpublish works; an API client using PUT could not change publish state `[TBC: likely unintentional asymmetry]`.
+3. Slug uniqueness is enforced by a unique index; the SPA does not currently surface a duplicate-slug error specially (the save fails, is logged to console, and the toggle reverts).
+4. Once public: the page is live at `/r/<slug>`, listed on `/browse`, included in `/sitemap.xml`, and its image endpoint becomes publicly readable (ownership check skipped for public recipes so crawlers can load images).
+5. Unpublishing (toggle off + POST) returns the page to 404.
+
+### Guest gating
+
+Guests can never publish. Enforced at three layers:
+
+- **UI:** guests see "Sign in to publish" instead of the toggle (shown only after the recipe is saved, so an OAuth redirect never strands an unsaved recipe).
+- **API:** the repository forces `is_public=false` on create and update for any request without an authenticated `user_id` (logged as a warning).
+- **Data migration:** pre-gate guest-published rows were reassigned to a designated account (`GUEST_PUBLIC_REASSIGN_EMAIL`, keeping indexed URLs alive) or unpublished; an unmatched email aborts the deploy.
+
+Rationale: a public page needs an accountable identity behind it for moderation.
+
+## Robots / indexability
+
+Express adds `X-Robots-Tag: index, follow` to HTML responses only in production, so staging deploys aren't indexed.
+
+## Page Relationships
+
+- **From SPA:** the slug field's open-in-new-tab link on the recipe detail view.
+- **To SPA:** "Save to Cookbook" CTA (`/?save=<slug>#kitchen`) and nav links; the SPA validates the slug (`^[a-z0-9-]+$` after normalization), fetches the public JSON, saves a copy, and lands on My Kitchen.
+- **To each other:** `/browse` → `/r/<slug>`; `/sitemap.xml` → both.
+
+## Business Rules
+
+- Public pages are read-only; there is no commenting, rating, or forking beyond "save a copy".
+- `recipeCategory` is always "Vegan" — the product's core promise is baked into structured data.
+- Legacy file-based SSR routes (`/`, `/recipe/<filename>`, `/generate_recipe` on Flask) still exist but are **not reachable through Express in production** (Express serves the SPA at `/` and only proxies `/r/*`, `/browse`, `/sitemap.xml`, `/static/*`); they operate on an ephemeral `recipes/` directory and predate the database. Treat them as deprecated.


### PR DESCRIPTION
## Description

Adds a complete reverse-engineered Product Requirements Document under `prd/` — 9 documents (~900 lines) covering the system as actually built, derived from the Angular SPA, Express proxy, and Flask backend (including its migrations).

```
prd/
├── README.md                        # System overview, modules, permission model, known gaps
├── pages/
│   ├── 01-recipe-generator.md       # Prompt→Gemini flow, async polling, image-gen race guards,
│   │                                #   publish/slug rules, scaling, notes, header/auth UI
│   ├── 02-my-kitchen.md             # Cookbooks, manual 3-step wizard, import/export,
│   │                                #   recycle-bin semantics, all modals
│   └── 03-public-recipe-pages.md    # /r/<slug>, /browse, sitemap, JSON-LD, guest gating
└── appendix/
    ├── api-inventory.md             # All ~45 endpoints: live SPA API, Pub/Sub workers, admin, legacy
    ├── data-model.md                # 3 tables + full recipe JSON Schema + localStorage shape
    ├── enum-dictionary.md           # Statuses, model names, limits, units, infra names
    ├── page-relationships.md        # Navigation graph, SSR⇄SPA flows (?save=, ?auth=success)
    └── platform-behavior.md         # Express route order, rate limits, Valkey, deploy pipeline
```

### Known gaps surfaced while reverse-engineering (recorded in the PRD, not papered over)

- **Stale docs:** CLAUDE.md describes `server/validation.ts` — the file doesn't exist and `express-validator` is imported nowhere. There is zero Express-layer input validation; Flask's 10–500-char prompt check is the only gate.
- **No-op cache:** Flask's `extensions.cache` is a stub — docstrings claim 24h Valkey caching that never happens (Valkey only backs Express rate limiting).
- **Publish asymmetry:** `PUT /api/recipes/<id>` never writes the `slug`/`is_public` columns; publishing works only because the SPA saves via POST-upsert. An API client using PUT could not publish/unpublish.
- **Hardening gap:** legacy `POST /api/migrate` is unauthenticated and reachable through the proxy, unlike the token-gated `/api/admin/*` routes.
- **Likely-broken probe:** `/api/status`'s DB check uses a raw-string `SELECT 1` that raises under SQLAlchemy 2.x, so it probably always reports `database: error`.

Genuinely undeterminable items are marked `[TBC]` per the code-to-prd skill's no-guessing rule. These gaps are candidates for follow-up issues/Jira tickets — happy to file them if wanted.

## Related Issues

None — documentation generated from the codebase; the gaps above may warrant new issues.

## Type of Change

- [x] Documentation update

## Testing

Docs-only change — no runtime surface.

- [x] Linting passes (`npm run lint`) — n/a, markdown only
- [x] Build succeeds — n/a, no source touched

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

## Additional Notes

Scope is strictly the new `prd/` directory — no source, config, or `.claude/` changes included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kc81qmLi3GYQU2SAsQVnb7
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

