### PR TITLE
chore: release v0.3.3 - bump version + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-11
+
+Stability and automation release. Fixes cookbook editing regressions, makes authenticated publishing explicit, hardens the hosted GCP monitoring connector, and repairs the repository's agentic workflows.
+
+### Fixed
+
+- **Recipe editing no longer loses ingredient data** ([#3057](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3057)): the wizard preserves ingredient groups while editing, cookbook creation rejects blank names, and modal controls now have accessible labels.
+- **Publishing is limited to signed-in users** ([#3066](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3066), Backend [#142](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/142)): guests see a clear "Sign in to publish" action instead of a control that cannot complete, while the backend rejects guest publishing and migrates previously guest-published rows safely.
+- **Hosted gcp-monitor connector reliability** ([#3058](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3058), [#3060](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3060), [#3078](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3078)): secret-path routing now works with connector registration, reverse-proxy host validation no longer rejects Cloud Run traffic, and `metric_pb2` is imported consistently.
+- **PM session-log configuration matches the documented environment variables** ([#3065](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3065), [#3079](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3079)): session logs target the Agent Session Logs index and receive the expected label.
+- **Agentic workflows compile and run again** ([#3077](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3077), [#3091](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3091), [#3093](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3093)): Daily Repo Status uses the current gh-aw runtime, and Issue Arborist now uses the built-in GitHub token with a regenerated lock file whose frontmatter hash matches its source.
+- **Backend operational endpoints are safer and accurate** (Backend [#147](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/147)): `/api/migrate` requires an admin token and `/api/status` performs a working database health probe.
+
+### Added
+
+- **Issue Arborist automation** ([#3089](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3089), [#3093](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3093)): periodically groups strongly related GitHub issues into parent/sub-issue relationships, with compiler-generated maintenance for expiring safe outputs.
+- **Reverse-engineered product reference** ([#3082](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3082)): documents current pages, API inventory, data model, enums, and platform behavior under `prd/`.
+
+### Changed
+
+- Angular 22.0.5 -> 22.0.6, `@google/genai` 2.10 -> 2.11, Vite 8.0.16 -> 8.1.4, Node types 25 -> 26, plus testing and linting patch updates ([#3000](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3000), [#3071](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3071), [#3073](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3073), [#3074](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3074), [#3075](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3075), [#3076](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3076)).
+- Backend submodule `ef594bf` -> `3883f00`, adding authenticated publishing enforcement and the operational endpoint fixes above. Alembic remains on one head (`e91b47a2c5d3`).
+- Repository and agent-tooling pointers were refreshed, runtime artifacts were explicitly parked/ignored, and session-start synchronization guidance was tightened ([#3068](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3068), [#3085](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3085)).
+
 ## [0.3.2] - 2026-07-05
 
 Regression-fix release for v0.3.1: restores styling on the server-rendered public pages, makes async recipe generation retry transient model failures, and un-shadows the dynamic sitemap. Also brings the GCP monitoring MCP server to Cloud Run as an authenticated Claude connector and gates PRs targeting `dev` with the full CI suite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@angular/build": "22.0.6",
         "@angular/cli": "22.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
## Summary

Release prep for **v0.3.3**. Bumps `package.json` and `package-lock.json`, and documents all 24 commits promoted from `dev` since v0.3.2.

## Release highlights

- fixes recipe-wizard ingredient preservation, cookbook-name validation, and modal accessibility (#3057)
- makes recipe publishing authenticated-only with a clear guest sign-in path (#3066, Backend #142)
- repairs hosted gcp-monitor routing, proxy compatibility, and metric imports (#3058, #3060, #3078)
- adds Issue Arborist and repairs both gh-aw workflows (#3077, #3089, #3091, #3093)
- advances Backend `ef594bf` to `3883f00`, including the protected migrate endpoint and working status DB probe (Backend #147)
- includes Angular 22.0.6 and the current testing, linting, Vite, Node types, and GenAI dependency patches

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run type-check`
- `npm test -- --run`: **51/51 passed**
- `npm run build`: complete, with the existing bundle-budget warning (792.11 kB vs 500 kB)
- `FRONTEND_URL=http://localhost uv run pytest -q` in Backend: **142/142 passed**
- `uv run flask db heads`: single head `e91b47a2c5d3`
- `gh aw compile --strict --validate --no-emit`: 2 workflows, 0 errors, 0 warnings
- Issue Arborist dispatch: all jobs passed in run https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/actions/runs/29154891862
- `dev` CI at `598bdb5`: green

After this lands on `dev`, promote `dev` to `main` with a **merge commit, never squash**, so the shared branch history remains intact and `release.yml` can tag v0.3.3.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

