### PR TITLE
chore: add gbrain nightly maintenance Railway cron service

### DIFF
--- a/scripts/gbrain-maintenance/Dockerfile
+++ b/scripts/gbrain-maintenance/Dockerfile
@@ -1,0 +1,25 @@
+# Nightly gbrain maintenance cron service (Railway).
+# Runs `gbrain dream` + `gbrain extract --stale` against the shared Railway
+# Postgres brain, then exits (Railway cron requires the process to exit).
+#
+# gbrain is NOT on npm (the npm "gbrain" package is an unrelated GPU library).
+# It is built from source and pinned by commit SHA so this service never runs
+# schema migrations the owner's local gbrain hasn't seen. Bump GBRAIN_COMMIT
+# in lockstep with local gbrain upgrades (locally: git -C ~/gbrain rev-parse HEAD).
+FROM oven/bun:1.3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# 646179047a8e4ad9c462d83ce9a67a50ba076de8 = v0.42.56.0
+ARG GBRAIN_COMMIT=646179047a8e4ad9c462d83ce9a67a50ba076de8
+RUN git clone https://github.com/garrytan/gbrain.git /opt/gbrain \
+    && git -C /opt/gbrain checkout "$GBRAIN_COMMIT" \
+    && cd /opt/gbrain \
+    && bun install
+
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+CMD ["/run.sh"]

--- a/scripts/gbrain-maintenance/README.md
+++ b/scripts/gbrain-maintenance/README.md
@@ -1,0 +1,48 @@
+# gbrain nightly maintenance (Railway cron service)
+
+Runs `gbrain dream` (call-graph edge resolution) + `gbrain extract --stale`
+nightly against the shared gbrain Postgres, then exits. Deployed as a Railway
+**cron service** in the same Railway project as the Postgres so it needs no
+special egress (Claude Code cloud routines can't reach the DB — their sandbox
+egress is HTTP-proxy-only and Railway's TCP proxy on :34400 is raw Postgres;
+that dead end is why this service exists).
+
+Code sync stays on the dev machine (`/sync-gbrain` or `gbrain autopilot`);
+this service never syncs code, so there is exactly one writer per concern.
+
+## Deploy (one-time)
+
+```bash
+cd scripts/gbrain-maintenance
+railway login
+railway link          # pick the Railway project that hosts the gbrain Postgres
+railway add --service gbrain-maintenance
+railway up --service gbrain-maintenance
+```
+
+Then set service variables (Dashboard → gbrain-maintenance → Variables):
+
+- `GBRAIN_DATABASE_URL` — the gbrain DB URL. From inside the same Railway
+  project you can use the private endpoint
+  (`postgresql://postgres:<pw>@<postgres>.railway.internal:5432/gbrain`,
+  IPv6 private network) or simply reuse the public proxy URL
+  (`...@switchback.proxy.rlwy.net:34400/gbrain`) — egress from Railway to its
+  own proxy is unrestricted.
+- `OPENAI_API_KEY` — gbrain embeds with `text-embedding-3-large` and uses
+  `gpt-5.2` for expansion; the dream cycle's embed phase fails without it.
+- `GBRAIN_DREAM_SOURCE` (optional) — defaults to
+  `gstack-code-575c47df-9dc431`, the owner's worktree-scoped code source.
+
+The cron schedule (`0 9 * * *` UTC = 2am PT) lives in `railway.json`.
+Railway cron requires the container to exit when done; `run.sh` does.
+
+## Version pinning
+
+The Dockerfile pins gbrain to commit
+`646179047a8e4ad9c462d83ce9a67a50ba076de8` (v0.42.56.0) — the same version as
+the owner's local install — so this service can never run schema migrations
+the local CLI hasn't seen. gbrain is NOT on npm (the npm `gbrain` package is
+an unrelated GPU library); it builds from `github.com/garrytan/gbrain`.
+
+**When local gbrain upgrades:** update `GBRAIN_COMMIT` in the Dockerfile to
+`git -C ~/gbrain rev-parse HEAD` and redeploy (`railway up`).

--- a/scripts/gbrain-maintenance/railway.json
+++ b/scripts/gbrain-maintenance/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "cronSchedule": "0 9 * * *",
+    "restartPolicyType": "NEVER"
+  }
+}

--- a/scripts/gbrain-maintenance/run.sh
+++ b/scripts/gbrain-maintenance/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Entry point for the gbrain maintenance cron service.
+# Writes gbrain config from env vars, runs dream + extract --stale, exits.
+set -euo pipefail
+
+: "${GBRAIN_DATABASE_URL:?GBRAIN_DATABASE_URL is required (Railway service variable)}"
+: "${OPENAI_API_KEY:?OPENAI_API_KEY is required (Railway service variable)}"
+
+# The code source to run the dream cycle against. Matches the owner's
+# worktree-scoped source pin (.gbrain-source on the dev machine).
+GBRAIN_DREAM_SOURCE="${GBRAIN_DREAM_SOURCE:-gstack-code-575c47df-9dc431}"
+
+umask 077
+mkdir -p ~/.gbrain
+cat > ~/.gbrain/config.json <<EOF
+{
+  "engine": "postgres",
+  "database_url": "${GBRAIN_DATABASE_URL}",
+  "embedding_model": "openai:text-embedding-3-large",
+  "embedding_dimensions": 1536,
+  "expansion_model": "openai:gpt-5.2",
+  "chat_model": "openai:gpt-5.2",
+  "schema_pack": "gbrain-base-v2",
+  "mcp": {"publish_skills": false},
+  "self_upgrade": {"mode": "notify", "mode_prompted": true}
+}
+EOF
+
+gbrain() { (cd /opt/gbrain && bun src/cli.ts "$@"); }
+
+echo "[gbrain-maintenance] $(date -u +%FT%TZ) version: $(gbrain --version)"
+
+echo "[gbrain-maintenance] dream --source ${GBRAIN_DREAM_SOURCE}"
+gbrain dream --source "${GBRAIN_DREAM_SOURCE}"
+
+echo "[gbrain-maintenance] extract --stale"
+gbrain extract --stale
+
+echo "[gbrain-maintenance] status snapshot"
+gbrain status || true
+
+echo "[gbrain-maintenance] $(date -u +%FT%TZ) done"


### PR DESCRIPTION
## Summary
- Adds `scripts/gbrain-maintenance/`: a Railway **cron service** (Dockerfile + `run.sh` + `railway.json`) that runs `gbrain dream` + `gbrain extract --stale` nightly (09:00 UTC / 2am PT) against the shared gbrain Postgres, then exits.
- gbrain builds from source (`github.com/garrytan/gbrain`) pinned to commit `6461790` (v0.42.56.0, matching the local install) — gbrain is NOT on npm; the npm `gbrain` package is an unrelated GPU library.
- README documents deploy steps, required service variables (`GBRAIN_DATABASE_URL`, `OPENAI_API_KEY`), and the version-pin bump procedure.

## Why
Claude Code cloud routines can't reach the brain database: the sandbox's egress is HTTP-proxy-only, and Railway's Postgres proxy is raw TCP on :34400 (confirmed by two failed routine runs — TCP probe timeout). A cron service colocated with the Postgres in the same Railway project has no egress problem and doesn't need an LLM for a mechanical job. The Claude routine `trig_01SE21E24QTErnyR1Zp7f52r` has been disabled in favor of this.

Code sync stays local (`/sync-gbrain` / autopilot) — one writer per concern, since gbrain has no cross-machine locking.

## Test plan
- [x] Files reviewed; `run.sh` fails fast on missing env vars, writes config with `umask 077`, exits when done (Railway cron requirement)
- [ ] `railway up` deploy + manual trigger of the service verifies dream/extract against the real DB (post-merge, needs Railway login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV6Ty2dNPMCXGcCvmHs4tM
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

