### PR TITLE
docs(skills): qualify .deps-installed stamp path in run-pm-daemon skill

### DIFF
--- a/.claude/skills/run-pm-daemon/SKILL.md
+++ b/.claude/skills/run-pm-daemon/SKILL.md
@@ -133,7 +133,7 @@ Live smoke checks: `driver.py list` (exit 0, 5 tools) and
   (pip install) hadn't finished. Re-run with `--timeout 600`, or pre-warm:
   `bash scripts/pm/run_pm_script.sh atlassian_pm_link.py check`. The retry is
   safe — the launchers re-run pip until an install completes once
-  (`.venv/.deps-installed` stamp).
+  (`scripts/pm/.venv/.deps-installed` stamp).
 - **`Failed to create the PM scripts virtualenv`**: missing venv module —
   install your distro's python3-venv package.
 - **`WARNING: Atlassian credentials missing from .env`** in stderr/log:


### PR DESCRIPTION
## Summary

One-line doc fix in `.claude/skills/run-pm-daemon/SKILL.md` (added in #3105): the Troubleshooting section referenced the venv bootstrap stamp as `.venv/.deps-installed`, but the skill's preamble promises all paths are written relative to the repo root. The launchers (`scripts/pm/run_pm_daemon.sh`, `scripts/pm/run_pm_script.sh`) actually write the stamp to `scripts/pm/.venv/.deps-installed` — the doc now says so.

Found while smoke-testing the skill for the first time: a pre-flight `ls scripts/pm/.venv/.deps-installed` reported the stamp missing (the venv predated the stamp mechanism), and the ambiguous doc path made that harder to interpret than it should have been.

## Verification

- `grep -n deps_stamp scripts/pm/run_pm_daemon.sh scripts/pm/run_pm_script.sh` confirms both launchers use `$venv_dir/.deps-installed` with `venv_dir=scripts/pm/.venv`
- Docs-only change; no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmcRwW9eLzjX5NcNQVu85f
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

