### PR TITLE
chore: automate session-start/end PM rituals via hooks

### DIFF
--- a/.claude/hooks/sessionend-session-log.sh
+++ b/.claude/hooks/sessionend-session-log.sh
@@ -85,6 +85,29 @@ if ! command -v claude >/dev/null 2>&1; then
   exit 0
 fi
 
+# --- cross-process dedup (two windows / resume racing the same session) -----
+# CLAUDE_PM_SESSION_LOG_ACTIVE only guards recursion *within* this process tree
+# (it's an exported env var the `claude -p` summarizer inherits) — it does NOT
+# coordinate across separate shells. If the same session_id ends in two
+# processes at once, both would otherwise publish a near-identical page.
+# Arbitrate with an ATOMIC mkdir claim keyed by session_id: exactly one process
+# wins the mkdir; the loser skips. A 10-minute stale window lets a much-later
+# resume of the same id log again (concurrent ends are always <10min apart, so
+# the prune never fires for them — mkdir stays the sole arbiter of the race).
+if [ -n "$SESSION_ID" ]; then
+  SAFE_ID=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+  CLAIM_ROOT="$MAIN_REPO/.claude/session-logs"
+  CLAIM="$CLAIM_ROOT/$SAFE_ID"
+  mkdir -p "$CLAIM_ROOT" 2>/dev/null || true
+  if [ -d "$CLAIM" ] && [ -n "$(find "$CLAIM" -maxdepth 0 -mmin +10 2>/dev/null)" ]; then
+    rm -rf "$CLAIM" 2>/dev/null || true
+  fi
+  if ! mkdir "$CLAIM" 2>/dev/null; then
+    echo "  skip: session ${SESSION_ID} already logged within 10 min (another window/process)" >>"$LOG"
+    exit 0
+  fi
+fi
+
 # --- detach: do the slow work without stalling teardown ---------------------
 (
   export CLAUDE_PM_SESSION_LOG_ACTIVE=1

--- a/.claude/hooks/sessionend-session-log.sh
+++ b/.claude/hooks/sessionend-session-log.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# SessionEnd hook — the session-log SAFETY NET for the paths PreCompact misses.
+#
+# precompact-session-log.sh only fires on /compact and auto-compact. It does NOT
+# fire on /clear or on a normal session exit — those drop context with no model
+# turn. This hook closes that gap: on SessionEnd it condenses the transcript,
+# hands it to Haiku for a summary, and publishes to Confluence under the Agent
+# Session Logs index — the same flow as the PreCompact hook.
+#
+# To avoid spamming Confluence with trivial exits, it applies a SUBSTANCE GATE:
+# sessions whose condensed digest is too small to be worth a page are skipped.
+#
+# Design rules (identical spirit to precompact-session-log.sh):
+#   * NEVER block session teardown. Every failure path exits 0.
+#   * Detach the slow work to the background; the transcript persists on disk, so
+#     the worker finishes after the parent process exits.
+#   * Recursion guard: the summarizer runs `claude -p`, which would re-enter this
+#     and the SessionStart hooks. The CLAUDE_PM_SESSION_LOG_ACTIVE flag stops it.
+#
+# SessionEnd stdin (JSON): session_id, transcript_path, cwd, hook_event_name,
+#                          reason ("clear"|"logout"|"prompt_input_exit"|"other").
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+# --- recursion guard -------------------------------------------------------
+if [ -n "${CLAUDE_PM_SESSION_LOG_ACTIVE:-}" ]; then
+  exit 0
+fi
+
+INPUT=$(cat 2>/dev/null || true)
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Resolve the primary checkout (venv + .env + scripts live there, not in worktrees).
+COMMON_GIT=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+if [ -n "$COMMON_GIT" ] && [ -d "$COMMON_GIT" ]; then
+  MAIN_REPO=$(dirname "$COMMON_GIT")
+else
+  MAIN_REPO="$PROJECT_DIR"
+fi
+
+LOG="$MAIN_REPO/.claude/session-log-hook.log"
+mkdir -p "$(dirname "$LOG")"
+
+_field() {
+  printf '%s' "$INPUT" | python3 -c "
+import json,sys
+try: print((json.load(sys.stdin) or {}).get('$1','') or '')
+except Exception: print('')
+" 2>/dev/null
+}
+
+TRANSCRIPT=$(_field transcript_path)
+SESSION_ID=$(_field session_id)
+REASON=$(_field reason)
+
+{
+  echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) SessionEnd reason=${REASON:-?} session=${SESSION_ID:-?}"
+} >>"$LOG" 2>&1
+
+# --- preconditions (all fail-open) -----------------------------------------
+if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
+  echo "  skip: no transcript at '${TRANSCRIPT:-<empty>}'" >>"$LOG"
+  exit 0
+fi
+
+# Mirror atlassian_pm_link.load_config(): env var wins over .env, all three of
+# URL/EMAIL/TOKEN required. Bail BEFORE spending a Haiku call if none configured.
+_has_cred() {
+  [ -n "$(printenv "$1" 2>/dev/null)" ] && return 0
+  grep -qs "^[[:space:]]*$1=[^[:space:]]" "$MAIN_REPO/.env"
+}
+
+MISSING=""
+for key in ATLASSIAN_URL ATLASSIAN_EMAIL ATLASSIAN_API_TOKEN; do
+  _has_cred "$key" || MISSING="$MISSING $key"
+done
+if [ -n "$MISSING" ]; then
+  echo "  skip: missing Atlassian credentials (env or $MAIN_REPO/.env):$MISSING" >>"$LOG"
+  exit 0
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "  skip: claude CLI not on PATH" >>"$LOG"
+  exit 0
+fi
+
+# --- detach: do the slow work without stalling teardown ---------------------
+(
+  export CLAUDE_PM_SESSION_LOG_ACTIVE=1
+  WORK=$(mktemp -d -t session-log-end-XXXXXX)
+  trap 'rm -rf "$WORK"' EXIT
+
+  DIGEST="$WORK/digest.txt"
+  SUMMARY="$WORK/summary.md"
+
+  DIGEST_PY="$PROJECT_DIR/scripts/pm/transcript_digest.py"
+  [ -f "$DIGEST_PY" ] || DIGEST_PY="$MAIN_REPO/scripts/pm/transcript_digest.py"
+
+  if ! python3 "$DIGEST_PY" \
+      --transcript "$TRANSCRIPT" --max-chars 40000 >"$DIGEST" 2>>"$LOG"; then
+    echo "  FAIL: transcript_digest.py ($DIGEST_PY)" >>"$LOG"
+    exit 0
+  fi
+
+  # SUBSTANCE GATE: SessionEnd fires on every exit, including greetings and
+  # aborted sessions. If the condensed digest is tiny, there is nothing worth a
+  # Confluence page — skip before spending a model call. PreCompact has no such
+  # gate because a session that filled its context is substantive by definition.
+  DIGEST_CHARS=$(wc -m <"$DIGEST" 2>/dev/null | tr -d ' ')
+  DIGEST_CHARS=${DIGEST_CHARS:-0}
+  if [ "$DIGEST_CHARS" -lt 800 ]; then
+    echo "  skip: digest too small ($DIGEST_CHARS chars < 800) — trivial session" >>"$LOG"
+    exit 0
+  fi
+
+  BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo unknown)
+  STAMP=$(date -u +%Y%m%d-%H%M%S)
+
+  PROMPT="You are writing a session log for an engineering team's Confluence.
+
+Below is a condensed transcript of a Claude Code session on branch \`$BRANCH\`.
+Write a session log in GitHub-flavored markdown with EXACTLY these sections:
+
+## Summary
+2-4 sentences. What was this session actually about, and what changed? Lead with
+the outcome, not the process.
+
+## Key decisions
+Bullets. Each is a decision made and WHY. If a decision reversed an earlier one,
+say so. If none were made, write 'None.'
+
+## Files changed
+Bullets of file paths. If none, write 'None.'
+
+## Follow-ups
+Bullets of work explicitly left undone, deferred, or flagged. If none, 'None.'
+
+## Gotchas
+Bullets of anything surprising, non-obvious, or that cost time — the things a
+future session would want to know. If none, 'None.'
+
+Rules: be concrete, name files and identifiers, no filler, no preamble. Do not
+invent anything not present in the transcript. Output ONLY the markdown.
+
+--- TRANSCRIPT DIGEST ---
+$(cat "$DIGEST")"
+
+  if command -v timeout >/dev/null 2>&1; then
+    RUNNER=(timeout 240)
+  elif command -v gtimeout >/dev/null 2>&1; then
+    RUNNER=(gtimeout 240)
+  else
+    RUNNER=()
+    echo "  note: no timeout(1) available; running summarizer unbounded (detached)" >>"$LOG"
+  fi
+
+  if ! "${RUNNER[@]}" claude -p "$PROMPT" \
+        --model claude-haiku-4-5-20251001 \
+        --allowedTools '' >"$SUMMARY" 2>>"$LOG"; then
+    echo "  FAIL: claude -p summarizer (timeout or error)" >>"$LOG"
+    exit 0
+  fi
+
+  if [ ! -s "$SUMMARY" ]; then
+    echo "  FAIL: summarizer produced empty output" >>"$LOG"
+    exit 0
+  fi
+
+  TITLED="$WORK/titled.md"
+  {
+    echo "# Session Log — $BRANCH — $STAMP"
+    echo
+    echo "> Auto-captured by the SessionEnd hook (reason: ${REASON:-unknown}). Summarized by Haiku from the session transcript."
+    echo "> Session ID: \`${SESSION_ID:-unknown}\`"
+    echo
+    cat "$SUMMARY"
+  } >"$TITLED"
+
+  if bash "$MAIN_REPO/scripts/pm/run_pm_script.sh" publish_session_log.py \
+      --file "$TITLED" \
+      --title "Session Log: session-end (${REASON:-exit}) — $BRANCH — $STAMP" >>"$LOG" 2>&1; then
+    echo "  OK: published session log for $BRANCH" >>"$LOG"
+  else
+    echo "  FAIL: publish_session_log.py (summary preserved below)" >>"$LOG"
+    cat "$TITLED" >>"$LOG"
+  fi
+) >/dev/null 2>&1 &
+
+disown 2>/dev/null || true
+exit 0

--- a/.claude/hooks/sessionstart-git-sync.sh
+++ b/.claude/hooks/sessionstart-git-sync.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SessionStart hook — automate CLAUDE.md "sync before you act" steps 1-2.
+#
+# Local checkouts on this machine routinely lag origin, and parallel agent
+# sessions may already be working the same area. This hook runs the READ-ONLY
+# half of the ritual on every session start — fetch origin for the parent repo
+# and the Backend submodule, then report ahead/behind for `dev` — and injects
+# the divergence summary into the session context so the agent starts informed.
+#
+# Deliberately NON-MUTATING: it never runs `submodule update`, `pull`, or checks
+# out anything. Moving the working tree or submodule pointer silently on every
+# session start would clobber in-progress work. When `dev` is behind, the
+# injected context tells the agent the exact `--ff-only` command to run.
+#
+# Design rules (mirrors precompact-session-log.sh):
+#   * Fail-open: never wedge session start. Every path exits 0.
+#   * Bounded: hook-level timeout in settings.json caps the network fetch.
+#   * Recursion guard: the PreCompact/SessionEnd summarizer spawns `claude -p`,
+#     which fires SessionStart again. Skip when that flag is set.
+#
+# SessionStart stdin (JSON): session_id, transcript_path, cwd, hook_event_name,
+#                            source ("startup"|"resume"|"clear"|"compact").
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+# The session-log summarizer runs `claude -p`, which re-enters this hook. Bail.
+if [ -n "${CLAUDE_PM_SESSION_LOG_ACTIVE:-}" ]; then
+  exit 0
+fi
+
+INPUT=$(cat 2>/dev/null || true)
+
+_field() {
+  printf '%s' "$INPUT" | python3 -c "
+import json,sys
+try: print((json.load(sys.stdin) or {}).get('$1','') or '')
+except Exception: print('')
+" 2>/dev/null
+}
+
+SOURCE=$(_field source)
+CWD=$(_field cwd)
+[ -n "$CWD" ] || CWD="$(pwd)"
+
+# Skip the mid-lifecycle re-entries: a compaction is not a fresh session, and a
+# fetch summary injected there is noise. Run on startup / resume / clear.
+if [ "$SOURCE" = "compact" ]; then
+  exit 0
+fi
+
+# Resolve the MAIN checkout. Worktree sessions live in .claude/worktrees/* where
+# the Backend submodule may be uninitialized; the shared .git of the main
+# checkout always has Backend and the right `dev` refs. --git-common-dir points
+# there from any linked worktree, and to the repo itself from the main checkout.
+COMMON_GIT=$(git -C "$CWD" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+if [ -n "$COMMON_GIT" ] && [ -d "$COMMON_GIT" ]; then
+  MAIN_REPO=$(dirname "$COMMON_GIT")
+else
+  MAIN_REPO="$CWD"
+fi
+
+# Not a git repo? Nothing to sync.
+git -C "$MAIN_REPO" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# --- ahead/behind for one repo against origin/<base>, fetch first -----------
+# Prints one summary line to stdout. Never fails the caller.
+_repo_divergence() {
+  local dir="$1" label="$2" base="${3:-dev}"
+  git -C "$dir" rev-parse --git-dir >/dev/null 2>&1 || return 0
+
+  # Fetch is best-effort; a network hiccup must not block the session. The
+  # hook-level timeout in settings.json bounds the total.
+  git -C "$dir" fetch origin --prune --quiet 2>/dev/null || true
+
+  # Need both local base and origin/base to compare.
+  git -C "$dir" rev-parse --verify --quiet "refs/heads/$base" >/dev/null 2>&1 || {
+    printf '%s: no local `%s` branch (skipped)\n' "$label" "$base"; return 0; }
+  git -C "$dir" rev-parse --verify --quiet "refs/remotes/origin/$base" >/dev/null 2>&1 || {
+    printf '%s: no origin/%s (skipped)\n' "$label" "$base"; return 0; }
+
+  local behind ahead
+  behind=$(git -C "$dir" rev-list --count "${base}..origin/${base}" 2>/dev/null || echo 0)
+  ahead=$(git -C "$dir" rev-list --count "origin/${base}..${base}" 2>/dev/null || echo 0)
+
+  if [ "$behind" -eq 0 ] && [ "$ahead" -eq 0 ]; then
+    printf '%s: `%s` up to date with origin/%s\n' "$label" "$base" "$base"
+  else
+    printf '%s: `%s` is %s behind / %s ahead of origin/%s\n' \
+      "$label" "$base" "$behind" "$ahead" "$base"
+  fi
+}
+
+CUR_BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null || echo "?")
+
+SUMMARY=$(
+  echo "Automated git sync (read-only fetch) at session start:"
+  _repo_divergence "$MAIN_REPO" "cookbook"
+  if [ -d "$MAIN_REPO/Backend/.git" ] || [ -f "$MAIN_REPO/Backend/.git" ]; then
+    _repo_divergence "$MAIN_REPO/Backend" "Backend"
+  else
+    echo "Backend: submodule not initialized in main checkout (skipped)"
+  fi
+  echo "This session's branch: \`$CUR_BRANCH\`."
+  echo "If \`dev\` is behind: \`git switch dev && git pull --ff-only\` (in the main checkout), then branch new work off \`origin/dev\`. This hook does NOT pull or update submodules for you."
+)
+
+# Emit as SessionStart additionalContext (JSON-encoded safely via python3).
+python3 -c "
+import json,sys
+ctx = sys.stdin.read()
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', 'additionalContext': ctx}}))
+" <<<"$SUMMARY" 2>/dev/null || true
+
+exit 0

--- a/.claude/hooks/sessionstart-pm-briefing.sh
+++ b/.claude/hooks/sessionstart-pm-briefing.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SessionStart hook — inject the PM briefing so every session opens briefed.
+#
+# Mirrors the pm-daemon `get_project_status` MCP tool EXACTLY, but as a plain
+# file read so it can't race the MCP server's startup: it reads
+# .agent-work/pm/PROJECT_PM_BRIEFING.md (first 12k chars) if present, else falls
+# back to the canonical specs/*.md planning files (first 1500 chars each). The
+# result is injected as SessionStart additionalContext.
+#
+# Doing this as a command hook (not an mcp_tool hook) is deliberate: the briefing
+# is a local file with no network dependency, and the pm-daemon stdio child may
+# not have finished connecting at the instant SessionStart fires. A file read is
+# deterministic and fast.
+#
+# Design rules: fail-open (always exit 0), bounded output, recursion-guarded.
+#
+# SessionStart stdin (JSON): session_id, transcript_path, cwd, hook_event_name,
+#                            source ("startup"|"resume"|"clear"|"compact").
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+# The session-log summarizer runs `claude -p`, which re-enters this hook. Bail.
+if [ -n "${CLAUDE_PM_SESSION_LOG_ACTIVE:-}" ]; then
+  exit 0
+fi
+
+INPUT=$(cat 2>/dev/null || true)
+
+_field() {
+  printf '%s' "$INPUT" | python3 -c "
+import json,sys
+try: print((json.load(sys.stdin) or {}).get('$1','') or '')
+except Exception: print('')
+" 2>/dev/null
+}
+
+SOURCE=$(_field source)
+CWD=$(_field cwd)
+[ -n "$CWD" ] || CWD="$(pwd)"
+
+# A compaction is not a fresh session; re-injecting the briefing there is noise.
+if [ "$SOURCE" = "compact" ]; then
+  exit 0
+fi
+
+# Resolve the main checkout: the gitignored briefing file lives in .agent-work/
+# which is NOT present in fresh worktrees, so prefer cwd but fall back to main.
+COMMON_GIT=$(git -C "$CWD" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+if [ -n "$COMMON_GIT" ] && [ -d "$COMMON_GIT" ]; then
+  MAIN_REPO=$(dirname "$COMMON_GIT")
+else
+  MAIN_REPO="$CWD"
+fi
+
+# Build the briefing text the same way get_project_status() does. Python keeps
+# the char caps and file list identical to the MCP tool and handles encoding.
+BRIEFING=$(CWD="$CWD" MAIN_REPO="$MAIN_REPO" python3 <<'PY' 2>/dev/null || true
+import os
+from pathlib import Path
+
+BRIEFING_FILE = Path(".agent-work/pm/PROJECT_PM_BRIEFING.md")
+CANONICAL = [
+    "specs/plan.md",
+    "specs/roadmap.md",
+    "specs/planning_notes.md",
+    "specs/design-plan.md",
+    "specs/SCRUM_BOOTSTRAP_AND_BOARD_PLAN.md",
+    "specs/SPRINT_0_PLAN.md",
+    "specs/ATLASSIAN_PM_LINK.md",
+]
+
+roots = []
+for r in (os.environ.get("CWD"), os.environ.get("MAIN_REPO")):
+    if r and r not in roots:
+        roots.append(Path(r))
+
+# Prefer the pre-baked briefing file from whichever root has it.
+for root in roots:
+    bp = root / BRIEFING_FILE
+    if bp.exists():
+        try:
+            c = bp.read_text(encoding="utf-8", errors="replace")
+            print("CURRENT PM BRIEFING:\n" + c[:12000] + ("..." if len(c) > 12000 else ""))
+            raise SystemExit(0)
+        except SystemExit:
+            raise
+        except Exception:
+            pass
+
+# Fall back to canonical planning files (cwd first, then main checkout).
+status = []
+seen = set()
+for root in roots:
+    for rel in CANONICAL:
+        fp = root / rel
+        if rel in seen or not fp.exists():
+            continue
+        try:
+            c = fp.read_text(encoding="utf-8", errors="replace")
+            status.append(f"--- {rel} ---\n{c[:1500]}" + ("..." if len(c) > 1500 else ""))
+            seen.add(rel)
+        except Exception:
+            pass
+
+if status:
+    print("CURRENT PM BRIEFING:\n" + "\n".join(status))
+PY
+)
+
+# Nothing to inject? Stay silent.
+[ -n "$BRIEFING" ] || exit 0
+
+python3 -c "
+import json,sys
+ctx = sys.stdin.read()
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', 'additionalContext': ctx}}))
+" <<<"$BRIEFING" 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,38 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sessionstart-git-sync.sh",
+            "timeout": 45,
+            "statusMessage": "Syncing git + checking divergence"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sessionstart-pm-briefing.sh",
+            "timeout": 15,
+            "statusMessage": "Loading PM briefing"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sessionend-session-log.sh",
+            "timeout": 15,
+            "statusMessage": "Capturing session log"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ scripts/pm/.venv/
 
 # PM daemon single-watcher election lock (runtime)
 .claude/pm-daemon-watcher.lock
+
+# Runtime session-log dedup markers (SessionEnd hook)
+.claude/session-logs/


### PR DESCRIPTION
## What

Wires three **fail-open** command hooks into the committed `.claude/settings.json` so the manual per-session ritual from `CLAUDE.md` runs itself. Configured via `/update-config`.

| Event | Script | Behavior |
|-------|--------|----------|
| `SessionStart` | `sessionstart-git-sync.sh` | Read-only `git fetch` (cookbook + Backend submodule) → injects an ahead/behind-vs-`origin/dev` summary into context. Automates CLAUDE.md "sync before you act" steps 1-2. **Non-mutating** — never runs `submodule update` or `pull`; surfaces the `--ff-only` command when `dev` is behind. |
| `SessionStart` | `sessionstart-pm-briefing.sh` | Injects the PM briefing, mirroring the pm-daemon `get_project_status` tool as a **plain file read** (briefing file → canonical `specs/*.md` fallback) so it can't race the MCP server's stdio startup. |
| `SessionEnd` | `sessionend-session-log.sh` | Extends the existing `PreCompact` logger to the `/clear` + exit paths it misses: digest → Haiku summary → publish to Confluence. Gated by a digest-size **substance check** so trivial sessions don't spam the Agent Session Logs index. |

Existing `PreToolUse` (gstack check) and `PreCompact` (session logger) hooks are left untouched.

## Design guarantees (all three)

- **Exit 0 on every path** — a broken hook must never wedge session start/teardown.
- **Recursion guard** — the SessionEnd/PreCompact summarizer spawns `claude -p`, which re-enters SessionStart; all three bail on `CLAUDE_PM_SESSION_LOG_ACTIVE`.
- **Worktree-aware** — resolve the main checkout via `--git-common-dir`, so worktree sessions read venv/.env/briefing from the right place and don't choke on an uninitialized Backend submodule.
- **Bounded** — per-hook timeouts (git-sync 45s, others 15s); PM briefing capped at 12k/1.5k chars exactly like the MCP tool.

## Verification

- `bash -n` clean on all three scripts.
- `jq -e` confirms hook nesting for `SessionStart` (2 hooks) + `SessionEnd` (1 hook); all four events present.
- Pipe-tested against synthesized stdin: git-sync emits valid `additionalContext` JSON (correctly reported `dev` 21 behind origin/dev, read-only); `source:"compact"` correctly stays silent; pm-briefing produced 8.2k chars from canonical specs; SessionEnd's no-transcript skip, recursion guard, and substance gate (40-char digest → SKIP) all fire; Atlassian creds confirmed present so real sessions will publish.
- Not proven firing in-turn: SessionStart/SessionEnd fire outside a turn, and these live in a worktree — they go live for the team after merge + pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

