### PR TITLE
ci(claude-review): raise --max-turns 15 → 60

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -160,4 +160,4 @@ jobs:
                comment. This review is ADVISORY — never block the merge.
           claude_args: |
             --model ${{ steps.pick.outputs.model }}
-            --max-turns 15
+            --max-turns 60


### PR DESCRIPTION
Follow-up to #3128. Raises the independent Claude reviewer's turn cap from 15 → 60.

**Why:** the first authenticated run of the reviewer (on #3128) got all the way through OIDC auth → ran the review on `claude-opus-4-7` → but died with `error_max_turns` (Reached maximum number of turns (15)) before posting its comment. The full `/code-review --comment --fix` flow (inspect → reason → run skill → apply fixes → post inline comments → push → summary) needs more headroom than 15 on a non-trivial diff.

The 60 bump was authored after #3128 merged, so it needs its own PR to reach `dev`.

**Bonus:** opening this PR into `dev` should itself trigger the reviewer (now live on `dev`) against this one-line diff — a cheap end-to-end test that the 60-turn cap lets it run to completion and post its summary comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

