### PR TITLE
fix(ci): harden claude-review.yml (injection sinks + action pinning)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # For pull_request events this is the PR branch, so --fix can push back.
           ref: ${{ github.head_ref }}
@@ -85,16 +85,24 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr checkout "${{ github.event.inputs.pr }}"
+          # Pass the untrusted dispatch input via env, never templated into the
+          # shell source — otherwise a crafted `pr` value is a command-injection
+          # sink (this job has contents/pull-requests/id-token: write).
+          PR_NUMBER: ${{ github.event.inputs.pr }}
+        run: gh pr checkout "$PR_NUMBER"
 
       - name: Pick a cost-optimized, independent review model
         id: pick
+        env:
+          # Via env, not templated into the shell source (same injection-safety
+          # rule as the dispatch input above; a stray quote/backtick in the var
+          # value would otherwise break or inject the script).
+          CLAUDE_REVIEW_MODEL: ${{ vars.CLAUDE_REVIEW_MODEL }}
         run: |
           # Deterministic, always-cheaper-than-author selection:
           #   default = highest Opus 4.x below 4.8 (cheaper than Opus 4.8 / Fable 5
           #   AND a different model, for genuinely independent perspective).
-          MODEL="${{ vars.CLAUDE_REVIEW_MODEL }}"
-          [ -z "$MODEL" ] && MODEL="claude-opus-4-7"
+          MODEL="${CLAUDE_REVIEW_MODEL:-claude-opus-4-7}"
           case "$MODEL" in
             claude-opus-4-8*|claude-fable-5*)
               echo "::warning::CLAUDE_REVIEW_MODEL=$MODEL is the authoring tier; using claude-opus-4-7 for a cheaper, independent review."
@@ -124,7 +132,7 @@ jobs:
 
       - name: Review + fix + comment
         if: steps.auth.outputs.present == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1
         with:
           # OAuth token (subscription) is primary; the action prefers it when set and
           # falls back to the API key when the OAuth secret is empty/unset.


### PR DESCRIPTION
Addresses the three workflow findings from the independent Claude review on #3132 (the file the reviewer runs from):

- **Script-injection sink (HIGH)** — the `workflow_dispatch` `pr` input was interpolated directly into the shell (`gh pr checkout "${{ github.event.inputs.pr }}"`). With `contents/pull-requests/id-token: write` in scope, a crafted `pr` value = arbitrary command execution on the runner. Now passed via an `env:` var and quoted (`"$PR_NUMBER"`), per [GitHub's intermediate-env-var guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).
- **Same pattern for `vars.CLAUDE_REVIEW_MODEL`** — moved to `env:`, defaulted with `${CLAUDE_REVIEW_MODEL:-claude-opus-4-7}`.
- **Unpinned actions** — pinned `actions/checkout` and `anthropics/claude-code-action` to commit SHAs (repo norm: `junie-review.yml` already pins). Matches the Backend copy.

No behavior change to the review itself; advisory/fail-open semantics untouched. The identical injection fix for the Backend copy is in a sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

