### PR TITLE
chore: bump Backend to 1baa118 — Pinterest broken-pin guard (Backend #200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pinterest "Save to Pinterest" button no longer creates broken pins**: the
+  button on a public recipe page now renders only when the recipe has a
+  genuinely fetchable image, so a recipe whose image is missing (a row with an
+  `ai_image_url` but no stored bytes) no longer offers a pin whose media 404s.
+  A run of broken pins to a fresh domain is exactly what trips Pinterest's
+  new-account spam heuristics. Also adds an inert `p:domain_verify` placeholder
+  in the public `<head>` for domain claiming (unlocks Rich Pins). Ships via the
+  Backend submodule pointer bump to `1baa118` (Backend #200).
+
 ## [0.3.6] - 2026-07-15
 
 Login fix release. Restores Google OAuth sign-in, which regressed under the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   button on a public recipe page now renders only when the recipe has a
   genuinely fetchable image, so a recipe whose image is missing (a row with an
   `ai_image_url` but no stored bytes) no longer offers a pin whose media 404s.
-  A run of broken pins to a fresh domain is exactly what trips Pinterest's
-  new-account spam heuristics. Also adds an inert `p:domain_verify` placeholder
-  in the public `<head>` for domain claiming (unlocks Rich Pins). Ships via the
-  Backend submodule pointer bump to `1baa118` (Backend #200).
+  A run of broken pins to a fresh domain can trigger Pinterest's new-account spam
+  heuristics. Also adds an inert `p:domain_verify` placeholder in the public
+  `<head>` for domain claiming (unlocks Rich Pins). Ships via the Backend
+  submodule pointer bump to `1baa118` (Backend [#200](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/200)).
 
 ## [0.3.6] - 2026-07-15
 


### PR DESCRIPTION
Ships **Backend #200** (Pinterest hardening) to production by advancing the `Backend/` submodule pointer `1077e42` → `1baa118`.

## What ships to the runtime

Runtime-affecting diff vs the current pin is **only** the three public SSR files:
- `blueprints/public_bp.py` — `_has_pinnable_image()` gate
- `templates/public/recipe.html` — button wrapped in `{% if pinterest_share_url %}`
- `templates/public/base_public.html` — inert `p:domain_verify` placeholder

The pointer also crosses the CI `claude-review.yml` workflow and the Backend test file, neither of which is part of the Flask image.

## Effect

- "Save to Pinterest" renders only when a recipe has a fetchable image → no more broken pins whose `media` 404s (the three currently-imageless recipes stop offering a broken pin).
- No schema/migration change (Backend migration head unchanged: `f4a1c2d3e4b5`).

## Sequencing

Backend #200 is merged to Backend `dev`. This is the cookbook pointer bump that carries it. Merging this to `dev` doesn't deploy; it ships on the next `dev` → `main` release. Related open cookbook PR #3138 (slug fix) is independent and can ship in the same release.

Once the Pinterest domain is claimed, fill the `p:domain_verify` token in `Backend/templates/public/base_public.html` (separate small Backend PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

