### PR TITLE
docs: refresh .github/copilot-instructions.md (Angular 22, CSP, rate limits, public site) + CLAUDE.md Backend note

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -272,7 +272,7 @@ npm start
 
 #### Content-Security-Policy — HIGH-RISK, do not loosen or disable
 
-Helmet CSP is **ENABLED** with a deliberately scoped policy in `server/security.ts`: `script-src 'self'` (no inline scripts), `script-src-attr` allowing exactly one hashed inline handler emitted by Angular's critical-CSS optimization, Google Fonts origins for styles/fonts, and `img-src` open to `https:` because recipe image URLs are per-recipe data.
+Helmet CSP is **ENABLED** with a deliberately scoped policy in `server/security.ts`: `script-src 'self'` (no inline scripts), `script-src-attr` allowing exactly one hashed inline handler emitted by Angular's critical-CSS optimization, `style-src` allowing `'unsafe-inline'` (Angular runtime styles) + Google Fonts origins for styles/fonts, and `img-src` open to `https:` because recipe image URLs are per-recipe data.
 
 Treat ANY change to CSP directives, inline scripts/handlers, or the OAuth callback flow as high-risk:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,7 +82,7 @@ eslint.config.js             # Flat ESLint config (TS + Angular + Prettier)
 vitest.config.ts             # Vitest config (server + src unit tests; coverage on server/)
 proxy.conf.json              # Dev proxy: /api → localhost:5000 (Flask)
 Dockerfile                   # Multi-stage build (node:26-alpine)
-cloudbuild.yaml              # GCB pipeline: build images, run DB-migrate job, deploy services
+cloudbuild.yaml              # GCB pipeline: build images, run flask-backend-migrate Job, deploy services
 package.json                 # npm scripts, dependencies
 .env.example                 # Environment variable template
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -265,7 +265,7 @@ npm start
   - Static serving of the Angular `dist/` output + `GET /privacy-policy`
   - `GET /r/*`, `/browse`, `/sitemap.xml`, `/static/*` — proxied to Flask SSR, mounted BEFORE the SPA catch-all (see "Public Recipe Site" below)
   - Catch-all `GET *` → `dist/index.html` (SPA routing)
-- `server/security.ts` — Helmet with **CSP enabled** (see below); rate limiting `300 req/15 min` general (`/api/health` and public image serving exempt) and `20 req/hr` for the two AI endpoints; request logging; error handler.
+- `server/security.ts` — Helmet with **CSP enabled** (see below); rate limiting `300 req/15 min` general (`/api/health` and recipe-image serving — `/api/recipes/<id>/image`, public or private — are exempt) and `20 req/hr` for the two AI endpoints; request logging; error handler.
 - `server/valkey.ts` — Valkey (Redis-compatible) client backing the rate limiters, so limits are shared across Cloud Run instances; falls back to per-instance in-memory stores when Valkey is unavailable.
 - `server/validation.ts` — `express-validator` on POST `/api/generate` and `/api/generate_image` ONLY. Buffers the JSON body (10 kb cap), validates it (`prompt` 10–500 chars, optional `model` name, `recipe_id` UUID, `force_regenerate` boolean), then stashes the exact validated bytes on `req.rawBody` for the proxy to replay to Flask verbatim. Every other `/api/*` route keeps raw streaming — do not add body parsers ahead of the proxy.
 - **No AI logic** — Express is a pure reverse proxy + static host.
@@ -286,7 +286,7 @@ Since v0.2, recipes can be published to a public server-rendered site (SEO-focus
 - `Recipe` rows carry `is_public` (bool) and `slug` (unique, indexed). Slugs are **derived from the recipe title server-side** — the user-editable slug field was removed in v0.3.7 for URL hardening; do not reintroduce client-supplied slugs.
 - Flask renders the pages with Jinja (`Backend/templates/`, styles in `Backend/static/css/`): `/r/<slug>` (single recipe), `/browse` (paginated listing), `/sitemap.xml`, plus JSON at `/api/recipes/public/<slug>` used by the save-to-cookbook flow (`src/services/public-recipe.mapper.ts`).
 - Express proxies `GET /r/*`, `/browse`, `/sitemap.xml`, and `/static/*` (Flask template CSS) to Flask **BEFORE the Angular catch-all** in `server/index.ts` — a public route added after the catch-all is dead code.
-- Images of public recipes are served unauthenticated via `/api/recipes/<id>/image` (exempt from the general rate limit).
+- Images of public recipes load without authentication via `/api/recipes/<id>/image`. Access control lives in Flask (`serve_recipe_image` in `Backend/blueprints/generation_api_bp.py`): `is_public` recipes bypass ownership scoping so anonymous SSR pages and crawlers can load them; private recipes still require the owning user/guest session. On the Express side this path is exempt from the general rate limit (all recipe images, public or private).
 
 ### Flask Backend (API + AI + Auth + DB)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,14 +56,15 @@ Examples: `[quick-reply: Yes | No]`  `[quick-reply: Keep | Delete all:danger]`
 ## Project Overview
 
 **Vegangenius Chef** is a vegan recipe generator and personal cookbook app.
-Three-tier architecture: **Angular 21 SPA → Express reverse-proxy → Flask API → Cloud SQL (PostgreSQL)**.
+Three-tier architecture: **Angular 22 SPA → Express reverse-proxy → Flask API → Cloud SQL (PostgreSQL)**.
 
 Users can:
 
-- Generate vegan recipes from a natural-language prompt (Gemini `gemini-3.1-pro-preview`)
+- Generate vegan recipes from a natural-language prompt (Gemini — default model `gemini-3.1-pro-preview`, chosen server-side in Flask)
 - Have AI-generated food photos created for each recipe (Imagen `imagen-4.0-generate-001`)
 - Save recipes, organize them into named cookbooks, and scale ingredient portions
 - Enter recipes manually and import/export recipes as JSON
+- Publish recipes to the public SSR site (`is_public` + title-derived `slug`, served at `/r/<slug>` — see "Public Recipe Site" below)
 - Sign in via Google OAuth (or use the app as a guest, with data stored in `localStorage`)
 
 ---
@@ -72,15 +73,16 @@ Users can:
 
 ```
 index.tsx                    # Angular bootstrap (.tsx per tsconfig jsx:react-jsx)
+index.html                   # SPA HTML shell used by the Angular build
 angular.json                 # Angular CLI build config (builder: @angular/build:application)
 tsconfig.json                # Frontend TS config (target ES2022, jsx react-jsx)
 tailwind.config.js           # Tailwind CSS v3
 postcss.config.js            # PostCSS (Tailwind + autoprefixer)
 eslint.config.js             # Flat ESLint config (TS + Angular + Prettier)
-vitest.config.ts             # Vitest config (server tests only)
+vitest.config.ts             # Vitest config (server + src unit tests; coverage on server/)
 proxy.conf.json              # Dev proxy: /api → localhost:5000 (Flask)
 Dockerfile                   # Multi-stage build (node:26-alpine)
-cloudbuild.yaml              # GCB pipeline: build + push + deploy both services
+cloudbuild.yaml              # GCB pipeline: build images, run DB-migrate job, deploy services
 package.json                 # npm scripts, dependencies
 .env.example                 # Environment variable template
 
@@ -97,28 +99,36 @@ src/
     gemini.service.ts        # Calls /api/generate, /api/generate_image (fetch)
     auth.service.ts          # Google OAuth + guest localStorage sessions
     persistence.service.ts   # Hybrid persistence: Flask API + localStorage cache
+    public-recipe.mapper.ts  # Save-to-cookbook mapping for public-site payloads
+  (unit tests live alongside sources: *.test.ts / *.spec.ts)
 
 server/
-  index.ts                   # Express entry: health, proxy, static, SPA catch-all
+  index.ts                   # Express entry: health, limiters, validation, proxy,
+                             # SSR routes, SPA catch-all (mounting order matters)
   proxy.ts                   # createFlaskProxy() — streams to FLASK_BACKEND_URL
-  security.ts                # Helmet, rate limiters, request logger, error handler
-  validation.ts              # express-validator rules (prompt, image fields)
+  security.ts                # Helmet incl. CSP (ENABLED — high-risk, see below), rate limiters
+  validation.ts              # express-validator for the two AI POST endpoints (see below)
+  valkey.ts                  # Valkey client — distributed rate-limit store (in-memory fallback)
   types.ts                   # Server-side TypeScript interfaces
-  server.test.ts             # Vitest tests
+  public/                    # Static pages served by Express (privacy-policy.html)
+  *.test.ts                  # Vitest tests (server, routes, validation)
   tsconfig.server.json       # Separate TS config (target ES2022, outDir dist/)
 
-Backend/                     # Flask backend (Python)
+Backend/                     # Flask backend (Python) — GIT SUBMODULE, pinned by SHA;
+                             # Backend/CLAUDE.md is the authoritative Backend reference
   app.py                     # Flask factory (create_app), CORS, session middleware
   auth.py                    # Google OAuth blueprint
-  config.py                  # DB URI, environment loading
+  config.py                  # DB URI, DEFAULT_MODEL, environment loading
   extensions.py              # SQLAlchemy db, Flask-Migrate
-  blueprints/                # Route handlers (recipes, generation, collections, auth)
-  models/                    # SQLAlchemy models
+  blueprints/                # *_api_bp.py JSON APIs (recipes, generation, collections,
+                             # auth) + public_bp.py SSR pages (/r/<slug>, /browse, sitemap)
+  models/                    # SQLAlchemy models (Recipe carries is_public + slug)
   repositories/              # Data access layer
-  services/                  # Business logic (Gemini, images, stock images)
+  services/                  # Business logic (Gemini, Imagen, stock images)
+  templates/, static/        # Jinja templates + CSS for the public SSR pages
   migrations/                # Alembic/Flask-Migrate schema migrations
   Dockerfile                 # Flask production container
-  requirements.txt           # Python dependencies
+  pyproject.toml, uv.lock    # Python dependencies — install with `uv sync`
 
 docs/                        # Architecture decisions, guides, phase docs
 scripts/                     # Utility scripts (list_revisions.sh, etc.)
@@ -128,20 +138,23 @@ scripts/                     # Utility scripts (list_revisions.sh, etc.)
 
 ## Tech Stack
 
-| Layer              | Technology                                                  | Version  |
-| ------------------ | ----------------------------------------------------------- | -------- |
-| Frontend framework | Angular (standalone components, signals API)                | 21       |
-| Styling            | Tailwind CSS                                                | 3        |
-| Frontend build     | Angular CLI (`@angular/build`) backed by Vite               | 21       |
-| Reverse proxy      | Node.js + Express                                           | 20 / 4.x |
-| Backend API        | Python + Flask                                              | 3.x      |
-| Database           | Cloud SQL (PostgreSQL) via SQLAlchemy + Flask-Migrate       | —        |
-| AI — text          | Google Gemini `gemini-2.5-flash` via `@google/genai`        | —        |
-| AI — images        | Google Imagen `imagen-4.0-generate-001` via `@google/genai` | —        |
-| Auth               | Google OAuth (Flask sessions) + localStorage guests         | —        |
-| Deployment         | Google Cloud Run (2 services) + Cloud Build                 | —        |
-| Linting            | ESLint (flat config) + Prettier                             | 9 / 3    |
-| Testing            | Vitest (server tests)                                       | 4        |
+| Layer              | Technology                                                                     | Version  |
+| ------------------ | ------------------------------------------------------------------------------ | -------- |
+| Frontend framework | Angular (standalone components, signals API)                                   | 22       |
+| Language           | TypeScript — pinned EXACTLY (no `^`); moves in lockstep with Angular majors    | 6.0.3    |
+| Styling            | Tailwind CSS                                                                   | 3        |
+| Frontend build     | Angular CLI (`@angular/build` application builder, esbuild/Vite-based)         | 22       |
+| Reverse proxy      | Node.js + Express                                                              | 26 / 5.x |
+| Backend API        | Python + Flask                                                                 | 3.x      |
+| Database           | Cloud SQL (PostgreSQL) via SQLAlchemy + Flask-Migrate                          | —        |
+| AI — text          | Google Gemini in Flask (`google-genai` SDK) — default `gemini-3.1-pro-preview` | —        |
+| AI — images        | Google Imagen in Flask — `imagen-4.0-generate-001`                             | —        |
+| Auth               | Google OAuth (Flask sessions) + localStorage guests                            | —        |
+| Deployment         | Google Cloud Run (2 services + 1 migrate Job) + Cloud Build                    | —        |
+| Linting            | ESLint (flat config) + Prettier                                                | 10 / 3   |
+| Testing            | Vitest (server + src unit tests)                                               | 4        |
+
+All AI calls happen in Flask via the `google-genai` **Python** SDK — the `@google/genai` npm package is not imported anywhere in `src/` or `server/`. Model choice is server-side (`DEFAULT_MODEL` in `Backend/config.py`); model IDs listed by `GET /api/models` carry the `models/` prefix (e.g. `models/gemini-3.1-pro-preview`).
 
 ---
 
@@ -185,7 +198,7 @@ npm run format:check   # Prettier check
 npm run type-check
 
 # Tests
-npm test               # Vitest (server tests)
+npm test               # Vitest (server + src unit tests)
 npm run test:ci        # With coverage
 ```
 
@@ -210,15 +223,15 @@ export $(grep -v '^#' .env.local | xargs)
 npm start
 ```
 
-| Variable                  | Required  | Used by                          | Description                                 |
-| ------------------------- | --------- | -------------------------------- | ------------------------------------------- |
-| `GEMINI_API_KEY`          | ✅        | Express (Secret Manager in prod) | Gemini API key                              |
-| `FLASK_BACKEND_URL`       | No        | Express                          | Flask URL (default `http://localhost:5000`) |
-| `PORT`                    | No        | Express                          | Server port (default `8080`)                |
-| `NODE_ENV`                | No        | Express                          | `development` or `production`               |
-| `GOOGLE_API_KEY`          | ✅        | Flask (Secret Manager in prod)   | Gemini key for Flask                        |
-| `FLASK_SECRET_KEY`        | ✅ (prod) | Flask                            | Session signing key                         |
-| `SQLALCHEMY_DATABASE_URI` | ✅ (prod) | Flask                            | PostgreSQL connection string                |
+| Variable            | Required  | Used by                          | Description                                            |
+| ------------------- | --------- | -------------------------------- | ------------------------------------------------------ |
+| `GEMINI_API_KEY`    | ✅        | Express (Secret Manager in prod) | Gemini API key                                         |
+| `FLASK_BACKEND_URL` | No        | Express                          | Flask URL (default `http://localhost:5000`)            |
+| `PORT`              | No        | Express                          | Server port (default `8080`)                           |
+| `NODE_ENV`          | No        | Express                          | `development` or `production`                          |
+| `GOOGLE_API_KEY`    | ✅        | Flask (Secret Manager in prod)   | Gemini key for Flask                                   |
+| `FLASK_SECRET_KEY`  | ✅ (prod) | Flask                            | Session signing key                                    |
+| `DATABASE_URL`      | ✅ (prod) | Flask                            | PostgreSQL connection string (SQLite fallback locally) |
 
 **Rules:**
 
@@ -231,7 +244,7 @@ npm start
 
 ## Architecture Notes
 
-### Frontend (Angular 21)
+### Frontend (Angular 22)
 
 - **Single standalone component** (`app.component.ts`) — all UI state + logic.
 - **Signals API** (`signal()`, `computed()`) for all reactive state — no RxJS observables.
@@ -240,24 +253,48 @@ npm start
   - `AuthService` — Google OAuth (redirects to `/api/auth/login`), guest `localStorage` sessions. On startup calls `/api/auth/check` to restore an existing Flask session.
   - `PersistenceService` — hybrid persistence: writes to `localStorage` first (instant UI), then syncs to Flask API (`/api/recipes/*`, `/api/collections/*`). Uses `effect()` to auto-load from API when a user session is confirmed.
 - The dev server runs on **port 3000** and proxies `/api` to Flask on `:5000` via `proxy.conf.json`.
+- **TypeScript is pinned exactly** (`"typescript": "6.0.3"`, no `^`) — each Angular major peer-requires a specific TS range (Angular 22 needs TS >=6.0 <6.1). Never bump `typescript`, `@angular/*`, or `@angular-eslint/*` independently; they move together in one PR.
 
 ### Express Server (Reverse Proxy)
 
-- `server/index.ts` is the single entry point. It handles:
-  - `GET /api/health` — local health check
-  - `ALL /api/*` — proxied to Flask via `server/proxy.ts` (raw HTTP stream, mounted BEFORE `express.json()`)
-  - Static file serving of the Angular `dist/` output
+- `server/index.ts` is the single entry point. **Mounting order is load-bearing** — it registers, in order:
+  - `GET /api/health` — answered locally by Express (never proxied)
+  - Rate limiters (see below), Helmet security headers, request logging
+  - `POST /api/generate` / `POST /api/generate_image` — body validation via `server/validation.ts`
+  - `ALL /api/*` — proxied to Flask via `server/proxy.ts` (raw HTTP stream, mounted BEFORE `express.json()` so Flask parses bodies itself)
+  - Static serving of the Angular `dist/` output + `GET /privacy-policy`
+  - `GET /r/*`, `/browse`, `/sitemap.xml`, `/static/*` — proxied to Flask SSR, mounted BEFORE the SPA catch-all (see "Public Recipe Site" below)
   - Catch-all `GET *` → `dist/index.html` (SPA routing)
-- `server/security.ts` — Helmet headers (CSP disabled — Angular uses inline styles), rate limiting (`100 req/15 min` general, `20 req/hr` for AI endpoints), request logging, error handler.
-- `server/validation.ts` — `express-validator` rules for `prompt` (1–500 chars) and image request fields.
+- `server/security.ts` — Helmet with **CSP enabled** (see below); rate limiting `300 req/15 min` general (`/api/health` and public image serving exempt) and `20 req/hr` for the two AI endpoints; request logging; error handler.
+- `server/valkey.ts` — Valkey (Redis-compatible) client backing the rate limiters, so limits are shared across Cloud Run instances; falls back to per-instance in-memory stores when Valkey is unavailable.
+- `server/validation.ts` — `express-validator` on POST `/api/generate` and `/api/generate_image` ONLY. Buffers the JSON body (10 kb cap), validates it (`prompt` 10–500 chars, optional `model` name, `recipe_id` UUID, `force_regenerate` boolean), then stashes the exact validated bytes on `req.rawBody` for the proxy to replay to Flask verbatim. Every other `/api/*` route keeps raw streaming — do not add body parsers ahead of the proxy.
 - **No AI logic** — Express is a pure reverse proxy + static host.
+
+#### Content-Security-Policy — HIGH-RISK, do not loosen or disable
+
+Helmet CSP is **ENABLED** with a deliberately scoped policy in `server/security.ts`: `script-src 'self'` (no inline scripts), `script-src-attr` allowing exactly one hashed inline handler emitted by Angular's critical-CSS optimization, Google Fonts origins for styles/fonts, and `img-src` open to `https:` because recipe image URLs are per-recipe data.
+
+Treat ANY change to CSP directives, inline scripts/handlers, or the OAuth callback flow as high-risk:
+
+- **History:** enabling `script-src 'self'` (PR #3109) silently broke Google OAuth login in v0.3.4/v0.3.5 — the OAuth callback page relied on an inline-`<script>` redirect that CSP blocked, stranding users on a blank page. Fixed in v0.3.6 by switching the Flask callback to a plain HTTP 302 redirect (Backend PR #195).
+- **Lesson:** CSP breakage is invisible to unit tests and type-check; it only surfaces in a real browser. Any PR touching CSP must include a manual browser check of the full Google-login flow.
+
+### Public Recipe Site (SSR)
+
+Since v0.2, recipes can be published to a public server-rendered site (SEO-focused, JS-free pages):
+
+- `Recipe` rows carry `is_public` (bool) and `slug` (unique, indexed). Slugs are **derived from the recipe title server-side** — the user-editable slug field was removed in v0.3.7 for URL hardening; do not reintroduce client-supplied slugs.
+- Flask renders the pages with Jinja (`Backend/templates/`, styles in `Backend/static/css/`): `/r/<slug>` (single recipe), `/browse` (paginated listing), `/sitemap.xml`, plus JSON at `/api/recipes/public/<slug>` used by the save-to-cookbook flow (`src/services/public-recipe.mapper.ts`).
+- Express proxies `GET /r/*`, `/browse`, `/sitemap.xml`, and `/static/*` (Flask template CSS) to Flask **BEFORE the Angular catch-all** in `server/index.ts` — a public route added after the catch-all is dead code.
+- Images of public recipes are served unauthenticated via `/api/recipes/<id>/image` (exempt from the general rate limit).
 
 ### Flask Backend (API + AI + Auth + DB)
 
 - Google OAuth via Flask sessions (server-side, not JWT).
-- Gemini recipe generation and Imagen image generation.
+- Gemini recipe generation and Imagen image generation via the `google-genai` Python SDK. Default text model: `DEFAULT_MODEL = "gemini-3.1-pro-preview"` in `Backend/config.py`; images use `imagen-4.0-generate-001` (`Backend/services/image_service.py`).
+- `/api/generate` and `/api/generate_image` live in `blueprints/generation_api_bp.py` (`generation_bp.py` is legacy HTML-form helpers, not the JSON API).
 - CRUD for recipes and collections (cookbooks) in Cloud SQL.
-- Modular architecture: blueprints, repositories, services, models.
+- Modular architecture: blueprints, repositories, services, models. `Backend/CLAUDE.md` is the authoritative Backend reference.
 - `ProxyFix` middleware trusts `X-Forwarded-*` headers from Express.
 
 ### Data Persistence
@@ -269,10 +306,11 @@ npm start
 
 ### Deployment (Cloud Run)
 
-- **Two Cloud Run services** in `us-central1`, project `comdottasteslikegood`:
+- **Two Cloud Run services + one Job** in `us-central1`, project `comdottasteslikegood`:
   - `express-frontend` — serves SPA + proxies to Flask
   - `flask-backend` — API, AI, auth, database
-- **Cloud Build** (`cloudbuild.yaml`) builds + pushes Docker images, deploys both services.
+  - `flask-backend-migrate` — Cloud Run **Job** that runs `flask db upgrade` before each Flask deploy
+- **Cloud Build** (`cloudbuild.yaml`) builds + pushes Docker images, runs the migrate Job, then deploys both services.
 - Images stored in Artifact Registry: `us-central1-docker.pkg.dev/comdottasteslikegood/vegangenius/`
 - Secrets injected via Secret Manager (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `FLASK_SECRET_KEY`).
 - `flask-backend` has `roles/cloudsql.client` IAM for database access.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -154,7 +154,7 @@ scripts/                     # Utility scripts (list_revisions.sh, etc.)
 | Linting            | ESLint (flat config) + Prettier                                                | 10 / 3   |
 | Testing            | Vitest (server + src unit tests)                                               | 4        |
 
-All AI calls happen in Flask via the `google-genai` **Python** SDK — the `@google/genai` npm package is not imported anywhere in `src/` or `server/`. Model choice is server-side (`DEFAULT_MODEL` in `Backend/config.py`); model IDs listed by `GET /api/models` carry the `models/` prefix (e.g. `models/gemini-3.1-pro-preview`).
+All AI calls happen in Flask via the `google-genai` **Python** SDK — there is no client-side AI SDK (the unused `@google/genai` npm dependency was removed in #3155). Model choice is server-side: `DEFAULT_MODEL` in `Backend/config.py` and the generation paths use bare IDs (`gemini-3.1-pro-preview`), while entries from `GET /api/models` carry the `models/` prefix (e.g. `models/gemini-3.1-pro-preview`) — both forms are in active use.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -263,8 +263,8 @@ npm start
   - `POST /api/generate` / `POST /api/generate_image` — body validation via `server/validation.ts`
   - `ALL /api/*` — proxied to Flask via `server/proxy.ts` (raw HTTP stream, mounted BEFORE `express.json()` so Flask parses bodies itself)
   - Static serving of the Angular `dist/` output + `GET /privacy-policy`
-  - `GET /r/*`, `/browse`, `/sitemap.xml`, `/static/*` — proxied to Flask SSR, mounted BEFORE the SPA catch-all (see "Public Recipe Site" below)
-  - Catch-all `GET *` → `dist/index.html` (SPA routing)
+  - `GET /r/*splat`, `/browse`, `/sitemap.xml`, `/static/*splat` — proxied to Flask SSR, mounted BEFORE the SPA catch-all (see "Public Recipe Site" below)
+  - Catch-all `GET {*path}` → `dist/index.html` (SPA routing; `{*path}` / `*splat` are Express 5 wildcard syntax)
 - `server/security.ts` — Helmet with **CSP enabled** (see below); rate limiting `300 req/15 min` general (`/api/health` and recipe-image serving — `/api/recipes/<id>/image`, public or private — are exempt) and `20 req/hr` for the two AI endpoints; request logging; error handler.
 - `server/valkey.ts` — Valkey (Redis-compatible) client backing the rate limiters, so limits are shared across Cloud Run instances; falls back to per-instance in-memory stores when Valkey is unavailable.
 - `server/validation.ts` — `express-validator` on POST `/api/generate` and `/api/generate_image` ONLY. Buffers the JSON body (10 kb cap), validates it (`prompt` 10–500 chars, optional `model` name, `recipe_id` UUID, `force_regenerate` boolean), then stashes the exact validated bytes on `req.rawBody` for the proxy to replay to Flask verbatim. Every other `/api/*` route keeps raw streaming — do not add body parsers ahead of the proxy.
@@ -285,7 +285,7 @@ Since v0.2, recipes can be published to a public server-rendered site (SEO-focus
 
 - `Recipe` rows carry `is_public` (bool) and `slug` (unique, indexed). Slugs are **derived from the recipe title server-side** — the user-editable slug field was removed in v0.3.7 for URL hardening; do not reintroduce client-supplied slugs.
 - Flask renders the pages with Jinja (`Backend/templates/`, styles in `Backend/static/css/`): `/r/<slug>` (single recipe), `/browse` (paginated listing), `/sitemap.xml`, plus JSON at `/api/recipes/public/<slug>` used by the save-to-cookbook flow (`src/services/public-recipe.mapper.ts`).
-- Express proxies `GET /r/*`, `/browse`, `/sitemap.xml`, and `/static/*` (Flask template CSS) to Flask **BEFORE the Angular catch-all** in `server/index.ts` — a public route added after the catch-all is dead code.
+- Express proxies `GET /r/*splat`, `/browse`, `/sitemap.xml`, and `/static/*splat` (Flask template CSS) to Flask **BEFORE the Angular catch-all** in `server/index.ts` — a public route added after the catch-all is dead code.
 - Images of public recipes load without authentication via `/api/recipes/<id>/image`. Access control lives in Flask (`serve_recipe_image` in `Backend/blueprints/generation_api_bp.py`): `is_public` recipes bypass ownership scoping so anonymous SSR pages and crawlers can load them; private recipes still require the owning user/guest session. On the Express side this path is exempt from the general rate limit (all recipe images, public or private).
 
 ### Flask Backend (API + AI + Auth + DB)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,10 @@ Browser → Express :8080 → Flask :5000 → Cloud SQL (PostgreSQL)
 
 ### Layer 3 — Flask API (`Backend/`)
 
-Modular blueprint architecture (the `Backend/CLAUDE.md` is **outdated** — ignore its monolithic description):
+Modular blueprint architecture — `Backend/CLAUDE.md` is the authoritative reference for Backend details:
 
 - `auth.py` + `blueprints/auth_api_bp.py` — Google OAuth 2.0 flow, sessions
-- `blueprints/generation_bp.py` — `/api/generate` (Gemini text), `/api/generate_image` (Imagen)
+- `blueprints/generation_api_bp.py` — `/api/generate` (Gemini text), `/api/generate_image` (Imagen); `generation_bp.py` is legacy HTML-form helpers
 - `blueprints/recipes_api_bp.py` — CRUD for recipes
 - `blueprints/collections_api_bp.py` — CRUD for cookbooks
 - `services/` — business logic (Gemini, Imagen, stock images)


### PR DESCRIPTION
## ⚠️ Decision needed from Adam: IntelliJ preamble (lines 1–52)

Lines 1–52 of `.github/copilot-instructions.md` are an auto-generated **IntelliJ "IDE Agent" preamble** (IntelliJ MCP tool tips, quick-reply button syntax) committed into the file. This PR **keeps it untouched** (the safe default), because your JetBrains plugin may read this file and stripping it could break that integration.

- **Keep (what this PR does):** zero risk to the IntelliJ plugin; costs ~2.5 KB of irrelevant preamble for every other consumer of the file (GitHub Copilot included).
- **Strip:** cleaner instructions for Copilot on github.com; risk that the IntelliJ plugin regenerates it on next use (noisy diffs) or silently loses its tool guidance.

Say the word and I'll drop it in a follow-up commit; otherwise it stays.

## What changed

`.github/copilot-instructions.md` — every fact verified against the tree at e2a2fdb (post-v0.3.7):

| Stale claim | Now |
| --- | --- |
| Angular 21 (overview, tech table, arch notes) | Angular 22; TypeScript exact-pinned `6.0.3`, moves in lockstep with Angular majors (new Language row + frontend bullet) |
| Self-contradicting models (`gemini-3.1-pro-preview` at the top vs `gemini-2.5-flash` in the tech table) + "via `@google/genai`" | One truth: model choice is server-side in Flask — `DEFAULT_MODEL = "gemini-3.1-pro-preview"` (`Backend/config.py:55`); `models/` prefix convention noted; the `@google/genai` npm package is not imported anywhere — AI calls use the `google-genai` **Python** SDK in Flask (`gemini-2.5-flash` only survives as a legacy HTML-form fallback in `generation_bp.py:283`) |
| "CSP disabled — Angular uses inline styles" | **CSP is ENABLED** (PR #3109) with a scoped policy; new "HIGH-RISK" subsection documents the v0.3.4/v0.3.5 OAuth-callback breakage (inline-script redirect blocked by `script-src 'self'`; fixed by Backend #195's 302 redirect, shipped v0.3.6) and tells reviewers any CSP-touching PR needs a manual browser check of the Google-login flow |
| Rate limiting "100 req/15 min" | 300 req/15 min general (`/api/health` + public image serving exempt), 20 req/hr for the two AI endpoints, Valkey-backed distributed store (`server/valkey.ts`) with per-instance in-memory fallback |
| `server/validation.ts` under-described ("prompt 1–500 chars") | Full contract: express-validator on POST `/api/generate` + `/api/generate_image` ONLY; 10 kb buffered JSON body (`prompt` 10–500 chars, optional `model`, `recipe_id` UUID, `force_regenerate` bool); validated bytes replayed to Flask verbatim via `req.rawBody`; **all other `/api/*` routes keep raw streaming** |
| v0.2 public site missing entirely | New "Public Recipe Site (SSR)" section: `is_public` + unique `slug` on Recipe, slug **derived from the title server-side** (editable slug field removed in v0.3.7 for URL hardening), `/r/<slug>` `/browse` `/sitemap.xml` (+ `/static/*` template CSS) proxied to Flask **before** the SPA catch-all, unauthenticated images for public recipes |
| Repo-layout / misc drift | Added `index.html`, `server/valkey.ts`, `server/public/`, `public-recipe.mapper.ts`, Backend GIT-SUBMODULE note, `templates/`+`static/`, `pyproject.toml`/`uv.lock` (was `requirements.txt`); vitest covers server **and** src tests; env table `SQLALCHEMY_DATABASE_URI` → `DATABASE_URL` (the actual env var, `config.py:62`); Node 20→26, Express 4.x→5.x, ESLint 9→10; `flask-backend-migrate` Job documented in Deployment |

`CLAUDE.md` (2 lines, same PR per task scope):

- The "`Backend/CLAUDE.md` is **outdated** — ignore its monolithic description" note is itself stale (Backend/CLAUDE.md verified current 2026-07-17) → replaced with an "authoritative reference" pointer.
- Layer-3 list: `/api/generate` + `/api/generate_image` live in `generation_api_bp.py` (`generation_bp.py` is legacy HTML-form helpers).

## Verification sources

- `package.json`: `@angular/*` 22.0.7, `typescript: "6.0.3"` (exact, no `^`), `express ^5.2.1`, `eslint ^10.7.0`, `@types/node ^26`
- `server/security.ts`: CSP directives, 300/15 min + 20/hr limiters, Valkey store with MemoryStore fallback; `server/index.ts:96–107`: SSR routes mounted before the `{*path}` catch-all
- `server/validation.ts`: `AI_REQUEST_BODY_LIMIT = '10kb'`, `req.rawBody` replay contract
- `Backend/config.py:55` `DEFAULT_MODEL`; `Backend/services/image_service.py:79` Imagen ID; `Backend/blueprints/generation_api_bp.py` owns `/generate` + `/generate_image`; `Backend/blueprints/public_bp.py` serves `/r/<slug>`, `/browse`, `/sitemap.xml`, `/api/recipes/public/<slug>`
- `grep -rn "@google/genai" src/ server/ index.tsx` → no matches (npm dependency unused by code — flagged separately as a cleanup candidate, not touched here)

Docs-only change — no runtime behavior affected. Prettier already run on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
















<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

