### PR TITLE
chore: remove unused @google/genai dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@angular/forms": "22.0.7",
         "@angular/platform-browser": "22.0.7",
         "@google-cloud/secret-manager": "^6.2.0",
-        "@google/genai": "^2.12.0",
         "autoprefixer": "^10.5.4",
         "dd-trace": "^6.4.0",
         "express": "^5.2.1",
@@ -2825,30 +2824,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@google/genai": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.12.0.tgz",
-      "integrity": "sha512-LUr972DZosqPUhf9Mb3CIVu/B99woD3QW6ZJV1T9aNgxaoimAZARmo+IyyDsxIL+zouFiYSdA4hzfEWXc9oNIQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
@@ -5602,12 +5577,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -10174,19 +10143,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -10907,15 +10863,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/retry-request": {
@@ -12546,27 +12493,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@angular/forms": "22.0.7",
     "@angular/platform-browser": "22.0.7",
     "@google-cloud/secret-manager": "^6.2.0",
-    "@google/genai": "^2.12.0",
     "autoprefixer": "^10.5.4",
     "dd-trace": "^6.4.0",
     "express": "^5.2.1",


### PR DESCRIPTION
## Description

Remove the unused `@google/genai` npm dependency (`^2.12.0`). The package is not imported anywhere in the built code — `grep -rn "@google/genai\|GoogleGenAI" src/ server/ index.tsx` returns no matches (verified on top of `origin/dev` e2a2fdb). All Gemini/Imagen calls happen in the Flask Backend via the `google-genai` **Python** SDK; the Angular client only calls `/api/generate` / `/api/generate_image` through the Express proxy.

`npm uninstall @google/genai` also drops its now-orphaned transitives from the lockfile: `ws`, `p-retry`, `retry`, `@types/retry` (74 lock lines, no other churn). `google-auth-library` stays — it is its own direct dependency used by the server.

Pre-removal audit found no load-bearing references elsewhere:

- `.github/copilot-instructions.md` still describes the old stack ("via `@google/genai`"), but #3154 (in flight) already rewrites those lines and explicitly states the npm package is not imported anywhere in `src/` or `server/`. Disjoint files — no conflict either merge order.
- `CHANGELOG.md` matches are historical bump entries (one even notes the package is "not imported in TypeScript — version-only") — left untouched.
- Zero references in `.github/workflows/`, `dependabot.yml`, `scripts/`, `angular.json`, tsconfigs, `Dockerfile`, or `cloudbuild.yaml`.
- `triage/*.json` matches are archival Jira ticket text about past dependabot bump reviews.

Side benefit: dependabot stops proposing `@google/genai` bumps (most recently #3143).

## Related Issues

Relates to #3154 (copilot-instructions refresh documenting that `@google/genai` is not imported)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes

## Testing

- [x] Tests pass locally (`npm run test`) — 7 files, 101 tests passing
- [x] Linting passes (`npm run lint`)
- [x] Code is formatted (`npm run format`) — `prettier --check` clean on both changed files
- [x] Build succeeds (`npm run build`) — pre-existing bundle-budget warning unchanged
- [x] Type checking passes (`npm run type-check`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — n/a, dependency removal only
- [ ] I have made corresponding changes to the documentation — handled by #3154
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, no behavior change
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Diff is exactly the one-line `package.json` removal plus the minimal lockfile pruning — npm's `allowScripts` policy blocked 10 install scripts during the local reinstall, which is expected on this machine and did not modify `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

