### PR TITLE
ci(pr-gate): add Express Docker image build to the gate (D2)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -107,6 +107,18 @@ jobs:
           PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest
 
+  # ── Docker ────────────────────────────────────────────────────────────────
+  # Builds the production Express image (no push, no credentials). Catches
+  # Dockerfile/lockfile breakage before a release tag hands it to Cloud Build
+  # (the v0.3.4 failure mode). Flask image is owned by Backend CI (D2).
+
+  docker-build:
+    name: Docker — Express image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: docker build -f Dockerfile .
+
   # ── Changelog ─────────────────────────────────────────────────────────────
 
   changelog-check:
@@ -139,6 +151,7 @@ jobs:
       - frontend-build
       - frontend-test
       - backend-test
+      - docker-build
       - changelog-check
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds one job to `.github/workflows/pr-gate.yml`: **Docker — Express image build** (`docker build -f Dockerfile .`, no push, no credentials), wired into the `gate` job's `needs:` list. Nothing else in the file changes.

## Why

- **SPEC-01 §4.2** — the CI refresh plan calls for a Docker-build gate so image breakage is caught at PR time instead of at release time. The Express image currently has no CI build at all; the first build of a release is inside Cloud Build after the tag is already pushed (this is exactly how v0.3.4 burned a tag on a Dockerfile ENV syntax error).
- **DECISIONS.md D2** — Express image ONLY. The Flask image is owned by Backend CI, so this job intentionally does not build `Backend/Dockerfile`.

## Verification

- `actionlint` clean; YAML structure asserted (`docker-build` job exists and is in `gate.needs`).
- **Red test (SPEC-01 acceptance 3):** a separate draft PR off this branch deliberately breaks the Dockerfile's `FROM` line to prove the new check goes red on a broken image. It will be closed unmerged once the failure is observed; link will appear in the comments/checks of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

