### PR TITLE
scratch: docker-gate red test (DO NOT MERGE)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -107,6 +107,18 @@ jobs:
           PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest
 
+  # ── Docker ────────────────────────────────────────────────────────────────
+  # Builds the production Express image (no push, no credentials). Catches
+  # Dockerfile/lockfile breakage before a release tag hands it to Cloud Build
+  # (the v0.3.4 failure mode). Flask image is owned by Backend CI (D2).
+
+  docker-build:
+    name: Docker — Express image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: docker build -f Dockerfile .
+
   # ── Changelog ─────────────────────────────────────────────────────────────
 
   changelog-check:
@@ -139,6 +151,7 @@ jobs:
       - frontend-build
       - frontend-test
       - backend-test
+      - docker-build
       - changelog-check
     if: always()
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:26-alpine AS build
+FROM node:26-alpine-does-not-exist AS build
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci


### PR DESCRIPTION
**Negative control for SPEC-01 acceptance 3** — this PR exists only to prove the new `Docker — Express image build` job (added in #3158) actually fails on a broken image.

It deliberately changes the Dockerfile's first `FROM` to a nonexistent tag (`node:26-alpine-does-not-exist`). The `docker-build` check (and therefore the `gate`) is expected to go **red**.

**This PR will be closed unmerged** as soon as the failure is observed. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

