### PR TITLE
scratch: gate negative test — must be unmergeable (DO NOT MERGE)

### DIFF
--- a/server/gate-negative-control.spec.ts
+++ b/server/gate-negative-control.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+// Harness negative control (SPEC-01 acceptance 6): this PR must be blocked
+// by branch protection. Never merge.
+describe('gate negative control', () => {
+  it('deliberately fails to prove the gate blocks merging', () => {
+    expect(true).toBe(false);
+  });
+});


### PR DESCRIPTION
SPEC-01 acceptance 6 / PROMPT T8 negative control.

This PR adds a single deliberately failing vitest spec (`server/gate-negative-control.spec.ts`) to prove that the required status checks on `dev` (`Gate — all checks passed`, `Analyze (javascript-typescript)`, `Dependency Review`) actually block merging when a check fails.

- **DO NOT MERGE.** The whole point is that GitHub must refuse the merge.
- A merge attempt will be made while the gate is red, its refusal recorded, and this PR will then be **closed unmerged** and the branch deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

