### PR TITLE
docs(ci): close out CI-refresh Phases 1-3 (checkboxes + CLAUDE.md required-checks note)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,8 @@ Both this repo and the `Backend/` submodule follow the same model:
 
 Never commit directly to `main` or `dev`. Always branch off `dev`.
 
+Since 2026-07-18 this is enforced by branch protection: `dev` and `main` both carry required status checks `Gate — all checks passed` (the pr-gate aggregate, which includes the Express Docker image build), `Analyze (javascript-typescript)`, and `Dependency Review` (strict off, 0 approvals, admin break-glass audited; SPEC-01 §4.3, `docs/ci/refresh/`).
+
 The `.gitmodules` `Backend` entry tracks `dev`, so `git submodule update --remote Backend` fast-forwards to the Backend integration tip. To ship a Backend change:
 
 1. PR into Backend `dev` (in `Backend/` submodule).
@@ -241,7 +243,7 @@ To verify the daemon is running during a session: `ps -ef | grep pm_daemon | gre
   - `git -C Backend log --oneline origin/main..origin/dev` — commits on `dev` not yet promoted to Backend `main`
   - `cd Backend && uv run flask db heads` — must print exactly one line with `(head)`. Two heads = unmerged migrations, deploy will break.
   - `git submodule update --remote Backend` — fast-forward the pointer to the latest `dev` tip when ready
-- **CI auto-formats** — Prettier runs as a CI job and commits fixes on push; don't be alarmed by bot commits
+- **CI auto-formats** — `ci.yml` is now just a push-only Prettier auto-commit safety net: PRs are already gated by `format:check` in pr-gate and direct pushes to `dev`/`main` are blocked by branch protection, so it's a near-no-op and bot format commits are rare rather than routine
 - **TypeScript is pinned exactly** (`6.0.3`) — Angular majors peer-require specific TS majors (Angular 22 needs TS >=6.0 <6.1), so TS and Angular must move together, manually. Dependabot ignores `@angular/*` semver-major updates; when upgrading Angular, bump `typescript`, all `@angular/*`, and `@angular-eslint/*` in the same PR
 
 ## Further reading

--- a/docs/ci/refresh/TODO.md
+++ b/docs/ci/refresh/TODO.md
@@ -20,44 +20,48 @@ consolidation + a Docker gate, not fixing rot.**
 
 ## Phase 1 — Consolidate to one blocking gate (one PR)
 
-- [ ] Delete `ci-cd-backend.yml` (redundant with pr-gate `backend-test`; never
-      runs on `dev`)
+- [x] Delete `ci-cd-backend.yml` (redundant with pr-gate `backend-test`; never
+      runs on `dev`) — done in #3157
       — verify: `git grep -n ci-cd-backend` returns no live references; pr-gate
       still runs backend pytest on a scratch PR into `dev`
-- [ ] Delete `ci-cd.yml` (redundant lint + vitest)
+- [x] Delete `ci-cd.yml` (redundant lint + vitest) — done in #3157
       — verify: scratch PR into `dev` shows pr-gate frontend jobs still running
-- [ ] `ci.yml`: per decision, either trim to the push-only Prettier auto-commit
+- [x] `ci.yml`: per decision, either trim to the push-only Prettier auto-commit
       `format` job (drop `build`/`lint`/`test`/`type-check`) or delete
+      — done in #3157 (trimmed per D1)
       — verify: `actionlint .github/workflows/*.yml` clean; a PR runs lint/test
       exactly once (only pr-gate)
-- [ ] Confirm `pr-gate.yml` remains the authoritative gate (aggregate `gate` job
-      unchanged)
+- [x] Confirm `pr-gate.yml` remains the authoritative gate (aggregate `gate` job
+      unchanged) — confirmed on #3158 and #3160
       — verify: scratch PR shows `Gate — all checks passed`
 
 ## Phase 2 — Add the Docker-build gate (one PR)
 
-- [ ] Add a `docker-build` job to `pr-gate.yml`: `docker build -f Dockerfile .`
+- [x] Add a `docker-build` job to `pr-gate.yml`: `docker build -f Dockerfile .`
       (Express image, no push, no creds); wire it into the `gate` aggregate's
-      `needs:`
+      `needs:` — done in #3158; red test #3159
       — verify: job green on a normal PR; then red on a scratch branch with a
       deliberately broken `Dockerfile` (test once, revert)
-- [ ] ~~Flask image build~~ — DEFERRED per D2 (Express-only). The Flask image is
+- [x] ~~Flask image build~~ — DEFERRED per D2 (Express-only). The Flask image is
       owned by the Backend submodule's own CI; out of scope for the cookbook gate.
 
 ## Phase 3 — Branch protection (**escalate before applying**)
 
-- [ ] ESCALATE: get human approval for the required-check list and settings
-      (SPEC-01 §4.3)
-- [ ] Configure required status checks on `dev` (exact context names):
+- [x] ESCALATE: get human approval for the required-check list and settings
+      (SPEC-01 §4.3) (approved by Adam 2026-07-17)
+- [x] Configure required status checks on `dev` (exact context names):
       `Gate — all checks passed`, `Analyze (javascript-typescript)`,
       `Dependency Review` (required per D3). `strict: off`,
-      `enforce_admins: off`, require-PR: on
+      `enforce_admins: off`, require-PR: on — applied 2026-07-18
       — verify: `gh api repos/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/branches/dev/protection --jq '.required_status_checks.contexts'`
       returns exactly that list
-- [ ] Same for `main`
+- [x] Same for `main` — applied 2026-07-18
       — verify: same `gh api` on `main`
-- [ ] Negative test: PR with a deliberately failing test cannot merge; revert
-- [ ] Confirm `dependabot-automerge.yml` now waits on the gate
+- [x] Negative test: PR with a deliberately failing test cannot merge; revert
+      — done in #3160 (gate red → merge refused, closed unmerged)
+- [x] Confirm `dependabot-automerge.yml` now waits on the gate
+      (mechanism verified: native auto-merge + required checks + negative test
+      #3160; empirical confirm on next Dependabot PR)
       — verify: next Dependabot PR only auto-merges after `gate` passes
 
 ## Phase 4 — Housekeeping (one PR, low priority)


### PR DESCRIPTION
Docs-only close-out for the CI-refresh work (SPEC-01, `docs/ci/refresh/`): checks off Phases 1–3 in `docs/ci/refresh/TODO.md` and updates `CLAUDE.md` (branching-strategy protection note + the now-near-no-op CI auto-format bullet).

## Evidence

- **#3157** (merged) — deleted `ci-cd.yml` + `ci-cd-backend.yml`, trimmed `ci.yml` to the push-only Prettier format job (D1). `pr-gate.yml` is the single blocking gate.
- **#3158** (merged) — added `docker-build` ("Docker — Express image build") to pr-gate, wired into the `gate` aggregate (D2).
- **#3159** (red test, closed unmerged) — proved `docker-build` fails on a deliberately broken Dockerfile.
- **Branch protection** applied 2026-07-18 on **dev and main** (approved by Adam 2026-07-17): required status checks exactly `Gate — all checks passed`, `Analyze (javascript-typescript)`, `Dependency Review`; strict off; enforce_admins off; PR required, 0 approvals.
- **#3160** (negative test, closed unmerged) — gate FAILURE → merge refused ("base branch policy prohibits the merge", `mergeStateStatus=BLOCKED`).
- Dependabot: `dependabot-automerge.yml` uses native auto-merge (SQUASH), which now waits on the required checks; empirical confirmation lands with the next real Dependabot PR.

## Positive control

This PR is itself the positive control that a normal, green PR merges cleanly under the new protection — the four evidence PRs proved delete/add/red/blocked; this one proves the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

