### PR TITLE
fix(public-site): Express/SPA half of the UX/nav/dead-links audit (#3164)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,5 +8,10 @@ Allow: /
 Disallow: /api/
 Disallow: /assets/
 
+# Every public recipe's hero/og:image is served from /api/recipes/<id>/image;
+# without this Allow (longest-match wins over Disallow: /api/) image crawlers
+# could never fetch recipe images (issue #3164).
+Allow: /api/recipes/*/image
+
 # Sitemap location
 Sitemap: https://www.tasteslikegood.org/sitemap.xml

--- a/scripts/audit/crawl-links.sh
+++ b/scripts/audit/crawl-links.sh
@@ -2,7 +2,10 @@
 # crawl-links.sh — public-site link & image crawl gate (issue #3164, AC 1).
 #
 # Contract (Acceptance Criterion 1):
-#   - bash + curl only, no auth
+#   - bash + curl for all HTTP work, no auth. Also requires these standard
+#     tools: file (image byte-sniffing), grep, sed, sort, head, wc, mktemp.
+#     All are present on stock Linux/macOS; minimal containers may need
+#     `file` installed (e.g. apt-get install file / apk add file).
 #   - BASE_URL env (default https://www.tasteslikegood.org)
 #   - fetch /sitemap.xml, /, every /browse page (follow rel=next), and every
 #     /r/<slug> from the sitemap
@@ -113,9 +116,11 @@ while [ "$i" -lt "${#pages[@]}" ]; do
   visit "$page"
   body_file="${body_of[$page]}"
   page_files+=("$body_file")
-  # Follow /browse pagination via rel=next.
-  next="$(grep -oE 'href="[^"]*"[^>]*rel="next"' "$body_file" 2>/dev/null |
-    head -1 | sed -E 's/^href="([^"]*)".*/\1/')"
+  # Follow /browse pagination via rel=next. Attribute order isn't
+  # guaranteed, so find the single-line <a>/<link> tag carrying rel="next"
+  # and pull its href from anywhere within the tag.
+  next="$(grep -oE '<(a|link)[^>]*rel="next"[^>]*>' "$body_file" 2>/dev/null |
+    head -1 | grep -oE 'href="[^"]*"' | head -1 | sed -E 's/^href="([^"]*)"$/\1/')"
   if [ -n "$next" ]; then
     next="$(normalize "$next")"
     if [ -n "$next" ] && [ -z "${checked[$next]:-}" ]; then

--- a/scripts/audit/crawl-links.sh
+++ b/scripts/audit/crawl-links.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# crawl-links.sh — public-site link & image crawl gate (issue #3164, AC 1).
+#
+# Contract (Acceptance Criterion 1):
+#   - bash + curl only, no auth
+#   - BASE_URL env (default https://www.tasteslikegood.org)
+#   - fetch /sitemap.xml, /, every /browse page (follow rel=next), and every
+#     /r/<slug> from the sitemap
+#   - extract internal href/src/og:image/canonical values via grep
+#   - GET each unique same-host URL with -L --max-time 30
+#   - FAIL on any final status >= 400
+#   - for image URLs, FAIL if the content-type prefix doesn't match
+#     `file --mime-type` of the downloaded bytes
+#   - print a TSV of url/status/content-type; exit non-zero on any failure
+#
+# Read-only: performs GETs only. Usage:
+#   scripts/audit/crawl-links.sh
+#   BASE_URL=http://localhost:8080 scripts/audit/crawl-links.sh
+
+set -u
+
+BASE_URL="${BASE_URL:-https://www.tasteslikegood.org}"
+BASE_URL="${BASE_URL%/}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+failures=0
+declare -A checked=()  # url -> "status<TAB>content_type"
+declare -A body_of=()  # url -> downloaded body file
+declare -A link_set=() # unique same-host URLs harvested from pages
+body_seq=0
+
+note_failure() {
+  failures=$((failures + 1))
+  echo "FAIL: $*" >&2
+}
+
+# normalize <raw> — resolve a harvested href/src value to a same-host
+# absolute URL on stdout; prints nothing for external/non-HTTP values.
+normalize() {
+  local raw="$1"
+  raw="${raw%%#*}" # strip fragment
+  [ -n "$raw" ] || return 0
+  case "$raw" in
+    "$BASE_URL" | "$BASE_URL"/*) printf '%s\n' "$raw" ;;
+    http://* | https://* | //*) return 0 ;; # other hosts: out of scope
+    mailto:* | javascript:* | data:* | tel:*) return 0 ;;
+    /*) printf '%s\n' "$BASE_URL$raw" ;;
+    *) return 0 ;; # page-relative paths are not emitted by our templates
+  esac
+}
+
+# check_image <url> <file> <content_type> — content-type must match the bytes.
+check_image() {
+  local url="$1" file="$2" declared="${3%%;*}" actual
+  actual="$(file --brief --mime-type "$file" 2>/dev/null || echo unknown)"
+  # Only meaningful when at least one side claims to be an image.
+  case "$declared,$actual" in *image/*) ;; *) return 0 ;; esac
+  [ "$declared" = "$actual" ] && return 0
+  # `file` versions disagree on SVG bytes (image/svg+xml vs generic XML) —
+  # accept XML detections for a declared SVG; a JPEG/PNG mismatch still fails.
+  if [ "$declared" = "image/svg+xml" ]; then
+    case "$actual" in image/svg* | text/xml | application/xml) return 0 ;; esac
+  fi
+  note_failure "content-type mismatch at $url: declared '$declared', bytes are '$actual'"
+}
+
+# visit <url> — GET once (deduped), record the TSV row, run the status and
+# image checks. Body path lands in body_of[<url>]. Runs in the main shell so
+# the checked/failures state survives.
+visit() {
+  local url="$1" out result status content_type
+  [ -n "${checked[$url]:-}" ] && return 0
+  body_seq=$((body_seq + 1))
+  out="$workdir/body.$body_seq"
+  result="$(curl -sS -L --max-time 30 -o "$out" \
+    -w '%{http_code}\t%{content_type}' "$url" 2>>"$workdir/curl-errors")" ||
+    result=$'000\t'
+  status="${result%%$'\t'*}"
+  content_type="${result#*$'\t'}"
+  checked[$url]="$status"$'\t'"$content_type"
+  body_of[$url]="$out"
+  printf '%s\t%s\t%s\n' "$url" "$status" "$content_type"
+  if ! [ "$status" -ge 100 ] 2>/dev/null || [ "$status" -ge 400 ]; then
+    note_failure "$url returned final status $status"
+  else
+    check_image "$url" "$out" "$content_type"
+  fi
+}
+
+# ── 1. Sitemap ────────────────────────────────────────────────────────
+visit "$BASE_URL/sitemap.xml"
+mapfile -t sitemap_urls < <(
+  grep -oE '<loc>[^<]+</loc>' "${body_of[$BASE_URL/sitemap.xml]}" 2>/dev/null |
+    sed -E 's|</?loc>||g' | sort -u
+)
+
+# ── 2. Page set: /, /browse (+ rel=next chain), every /r/<slug> ───────
+pages=("$BASE_URL/" "$BASE_URL/browse")
+for url in "${sitemap_urls[@]:-}"; do
+  case "$url" in
+    "$BASE_URL"/r/*) pages+=("$url") ;;
+  esac
+done
+
+page_files=()
+i=0
+while [ "$i" -lt "${#pages[@]}" ]; do
+  page="${pages[$i]}"
+  i=$((i + 1))
+  [ -n "${checked[$page]:-}" ] && continue
+  visit "$page"
+  body_file="${body_of[$page]}"
+  page_files+=("$body_file")
+  # Follow /browse pagination via rel=next.
+  next="$(grep -oE 'href="[^"]*"[^>]*rel="next"' "$body_file" 2>/dev/null |
+    head -1 | sed -E 's/^href="([^"]*)".*/\1/')"
+  if [ -n "$next" ]; then
+    next="$(normalize "$next")"
+    if [ -n "$next" ] && [ -z "${checked[$next]:-}" ]; then
+      pages+=("$next")
+    fi
+  fi
+done
+
+# ── 3. Harvest internal href/src/og:image/canonical from every page ───
+for body_file in "${page_files[@]:-}"; do
+  [ -f "$body_file" ] || continue
+  while IFS= read -r raw; do
+    link="$(normalize "$raw")"
+    [ -n "$link" ] && link_set["$link"]=1
+  done < <(
+    {
+      grep -oE 'href="[^"]*"' "$body_file" | sed -E 's/^href="//; s/"$//'
+      grep -oE 'src="[^"]*"' "$body_file" | sed -E 's/^src="//; s/"$//'
+      grep -oE '<meta property="og:image" content="[^"]*"' "$body_file" |
+        sed -E 's/.*content="//; s/"$//'
+      grep -oE '<link rel="canonical" href="[^"]*"' "$body_file" |
+        sed -E 's/.*href="//; s/"$//'
+    } 2>/dev/null | sort -u
+  )
+done
+
+# ── 4. GET every unique same-host URL not already visited ─────────────
+mapfile -t sorted_links < <(printf '%s\n' "${!link_set[@]}" | sort)
+for link in "${sorted_links[@]:-}"; do
+  [ -n "$link" ] && visit "$link"
+done
+
+# ── Result ────────────────────────────────────────────────────────────
+echo "checked ${#checked[@]} unique URLs; $failures failure(s)" >&2
+[ "$failures" -eq 0 ]

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,21 @@ export const ready = (async () => {
   // Connect to Valkey for shared rate limiting (falls back to in-memory)
   const valkeyClient = await createValkeyClient();
 
+  // ── Canonical-host redirect (issue #3164) ───────────────────────
+  // www.tasteslikegood.org is the canonical host: every canonical URL,
+  // sitemap entry, and robots.txt line declares www, but the apex served
+  // identical 200s, splitting indexing signals across two hosts. 301 the
+  // apex to www for ALL paths, before any other route. req.hostname honors
+  // X-Forwarded-Host ('trust proxy' is set above), which is how Cloud Run
+  // traffic arrives. Non-production hosts (localhost, *.run.app) pass through.
+  app.use((req, res, next) => {
+    if (req.hostname === 'tasteslikegood.org') {
+      res.redirect(301, `https://www.tasteslikegood.org${req.originalUrl}`);
+      return;
+    }
+    next();
+  });
+
   // Health check (local to Express — handled before the proxy)
   app.get('/api/health', (_req, res) => {
     res.status(200).json({
@@ -87,6 +102,18 @@ export const ready = (async () => {
     res.sendFile(path.join(publicPath, 'privacy-policy.html'));
   });
 
+  // /favicon.ico — browsers and crawlers request this path unconditionally,
+  // but the SPA only ships favicon.svg, so the request fell through to the
+  // catch-all and came back as index.html (text/html) — an HTML "icon"
+  // (issue #3164). Serve the SVG bytes explicitly; sendFile's .svg lookup
+  // yields an image/* content-type. Served from server/public (checked in,
+  // present in the Docker image) rather than dist so it works even before
+  // an Angular build.
+  app.get('/favicon.ico', staticPageLimiter, (_req, res) => {
+    res.type('image/svg+xml');
+    res.sendFile(path.join(publicPath, 'favicon.svg'));
+  });
+
   // Flask SSR routes — individual public recipes, the browse index, and the
   // sitemap must be proxied to Flask BEFORE the Angular catch-all so the HTML
   // the crawler receives is server-rendered (not the empty SPA shell). Using
@@ -94,6 +121,19 @@ export const ready = (async () => {
   // applies the same rate limit as the privacy policy and SPA shell.
   const ssrProxy = createFlaskProxy('SSR');
   app.get('/r/*splat', staticPageLimiter, ssrProxy);
+  // /browse/ (trailing slash) previously missed the /browse route and fell
+  // through to the SPA shell (issue #3164). 301 to the canonical /browse,
+  // preserving any query string. Exact-path middleware (not a route pattern)
+  // so non-strict pattern matching can never turn this into a redirect loop.
+  app.use((req, res, next) => {
+    if (req.path === '/browse/') {
+      const queryIndex = req.originalUrl.indexOf('?');
+      const query = queryIndex === -1 ? '' : req.originalUrl.slice(queryIndex);
+      res.redirect(301, `/browse${query}`);
+      return;
+    }
+    next();
+  });
   app.get('/browse', staticPageLimiter, ssrProxy);
   app.get('/sitemap.xml', staticPageLimiter, ssrProxy);
   // The SSR templates link their stylesheets via Flask's /static/ (e.g.

--- a/server/index.ts
+++ b/server/index.ts
@@ -35,13 +35,29 @@ export const ready = (async () => {
   // ── Canonical-host redirect (issue #3164) ───────────────────────
   // www.tasteslikegood.org is the canonical host: every canonical URL,
   // sitemap entry, and robots.txt line declares www, but the apex served
-  // identical 200s, splitting indexing signals across two hosts. 301 the
-  // apex to www for ALL paths, before any other route. req.hostname honors
-  // X-Forwarded-Host ('trust proxy' is set above), which is how Cloud Run
-  // traffic arrives. Non-production hosts (localhost, *.run.app) pass through.
+  // identical 200s, splitting indexing signals across two hosts. Redirect
+  // the apex to www for ALL paths, before any other route. req.hostname
+  // honors X-Forwarded-Host ('trust proxy' is set above), which is how
+  // Cloud Run traffic arrives. Non-production hosts (localhost, *.run.app)
+  // pass through. 301 for GET/HEAD (SEO-canonical), 308 otherwise so
+  // clients preserve the method and body instead of downgrading to GET.
+  const CANONICAL_ORIGIN = 'https://www.tasteslikegood.org';
   app.use((req, res, next) => {
     if (req.hostname === 'tasteslikegood.org') {
-      res.redirect(301, `https://www.tasteslikegood.org${req.originalUrl}`);
+      // Re-parse the request path against the fixed canonical origin and
+      // refuse to leave it: a crafted path like //evil.com would otherwise
+      // resolve protocol-relative and turn this into an open redirect.
+      let target: URL;
+      try {
+        target = new URL(req.originalUrl, CANONICAL_ORIGIN);
+      } catch {
+        target = new URL(CANONICAL_ORIGIN + '/');
+      }
+      if (target.origin !== CANONICAL_ORIGIN) {
+        target = new URL(CANONICAL_ORIGIN + '/');
+      }
+      const status = req.method === 'GET' || req.method === 'HEAD' ? 301 : 308;
+      res.redirect(status, target.href);
       return;
     }
     next();

--- a/server/index.ts
+++ b/server/index.ts
@@ -111,7 +111,10 @@ export const ready = (async () => {
   // an Angular build.
   app.get('/favicon.ico', staticPageLimiter, (_req, res) => {
     res.type('image/svg+xml');
-    res.sendFile(path.join(publicPath, 'favicon.svg'));
+    // Express's `send` defaults to Cache-Control: public, max-age=0, so every
+    // page navigation re-fetches the favicon and counts toward
+    // staticPageLimiter's 300 req / 15 min per-IP budget. Cache it for a day.
+    res.sendFile(path.join(publicPath, 'favicon.svg'), { maxAge: '1d' });
   });
 
   // Flask SSR routes — individual public recipes, the browse index, and the

--- a/server/public/favicon.svg
+++ b/server/public/favicon.svg
@@ -1,0 +1,6 @@
+<!-- Copy of /public/favicon.svg — served by Express for /favicon.ico
+     (see server/index.ts). Keep the two files in sync. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="15" fill="#16a34a"/>
+  <text x="16" y="22" font-family="serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">V</text>
+</svg>

--- a/server/public/privacy-policy.html
+++ b/server/public/privacy-policy.html
@@ -121,7 +121,7 @@
     <main>
       <h2>1. Who We Are</h2>
       <p>
-        <a href="https://tasteslikegood.org">tasteslikegood.org</a> (also referred to as
+        <a href="https://www.tasteslikegood.org">tasteslikegood.org</a> (also referred to as
         <strong>Vegangenius Chef</strong>) is a vegan AI recipe generator web application that helps
         users discover, generate, and manage plant-based recipes using Google's Gemini AI. In this
         Privacy Policy, tasteslikegood.org is referred to as "we", "us", or "our", and the user is
@@ -134,7 +134,7 @@
       <h2>2. Scope of This Privacy Policy</h2>
       <p>
         This Privacy Policy applies to all personal data collected when you use
-        <a href="https://tasteslikegood.org">tasteslikegood.org</a>, including when you sign in with
+        <a href="https://www.tasteslikegood.org">tasteslikegood.org</a>, including when you sign in with
         Google, generate recipes, save cookbooks, or use the application as a guest. By using our
         service, you agree to the collection and use of information in accordance with this policy.
       </p>

--- a/server/public/privacy-policy.html
+++ b/server/public/privacy-policy.html
@@ -121,7 +121,7 @@
     <main>
       <h2>1. Who We Are</h2>
       <p>
-        <a href="https://www.tasteslikegood.org">tasteslikegood.org</a> (also referred to as
+        <a href="https://www.tasteslikegood.org">www.tasteslikegood.org</a> (also referred to as
         <strong>Vegangenius Chef</strong>) is a vegan AI recipe generator web application that helps
         users discover, generate, and manage plant-based recipes using Google's Gemini AI. In this
         Privacy Policy, tasteslikegood.org is referred to as "we", "us", or "our", and the user is
@@ -134,7 +134,7 @@
       <h2>2. Scope of This Privacy Policy</h2>
       <p>
         This Privacy Policy applies to all personal data collected when you use
-        <a href="https://www.tasteslikegood.org">tasteslikegood.org</a>, including when you sign in with
+        <a href="https://www.tasteslikegood.org">www.tasteslikegood.org</a>, including when you sign in with
         Google, generate recipes, save cookbooks, or use the application as a guest. By using our
         service, you agree to the collection and use of information in accordance with this policy.
       </p>

--- a/server/redirects.test.ts
+++ b/server/redirects.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for the issue #3164 routing fixes in server/index.ts:
+ *
+ * - apex → www canonical-host 301 (all paths, before any other route)
+ * - /browse/ (trailing slash) → /browse 301
+ * - /favicon.ico served as a real image (previously fell through to the SPA
+ *   catch-all and came back as index.html / text/html)
+ *
+ * Follows the boot pattern of server/routes.test.ts: import the real Express
+ * app with VITEST set so no listener binds, then talk to it over a local
+ * port. No Flask stub is needed — every route under test resolves inside
+ * Express before the proxy.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+let expressServer: Server;
+let baseUrl: string;
+
+const originalVitestEnv = process.env.VITEST;
+
+beforeAll(async () => {
+  process.env.VITEST = process.env.VITEST || 'true';
+
+  const { app, ready } = await import('./index.js');
+  await ready;
+
+  expressServer = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => expressServer.once('listening', resolve));
+  baseUrl = `http://127.0.0.1:${(expressServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  if (originalVitestEnv === undefined) {
+    delete process.env.VITEST;
+  } else {
+    process.env.VITEST = originalVitestEnv;
+  }
+  await new Promise<void>((resolve) => expressServer.close(() => resolve()));
+});
+
+describe('apex → www canonical-host redirect', () => {
+  // 'trust proxy' is enabled, so req.hostname honors X-Forwarded-Host —
+  // exactly how apex-host traffic arrives through the Cloud Run proxy.
+  it.each(['/', '/browse', '/r/some-slug'])('301s %s to the www host', async (path) => {
+    const res = await fetch(`${baseUrl}${path}`, {
+      redirect: 'manual',
+      headers: { 'X-Forwarded-Host': 'tasteslikegood.org' },
+    });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe(`https://www.tasteslikegood.org${path}`);
+  });
+
+  it('preserves the query string', async () => {
+    const res = await fetch(`${baseUrl}/browse?page=2`, {
+      redirect: 'manual',
+      headers: { 'X-Forwarded-Host': 'tasteslikegood.org' },
+    });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://www.tasteslikegood.org/browse?page=2');
+  });
+
+  it('applies to /api paths too (all paths redirect)', async () => {
+    const res = await fetch(`${baseUrl}/api/health`, {
+      redirect: 'manual',
+      headers: { 'X-Forwarded-Host': 'tasteslikegood.org' },
+    });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://www.tasteslikegood.org/api/health');
+  });
+
+  it('does not redirect the www host', async () => {
+    const res = await fetch(`${baseUrl}/api/health`, {
+      redirect: 'manual',
+      headers: { 'X-Forwarded-Host': 'www.tasteslikegood.org' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('does not redirect non-production hosts (localhost)', async () => {
+    const res = await fetch(`${baseUrl}/api/health`, { redirect: 'manual' });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('/browse/ trailing-slash redirect', () => {
+  it('301s /browse/ to /browse', async () => {
+    const res = await fetch(`${baseUrl}/browse/`, { redirect: 'manual' });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('/browse');
+  });
+
+  it('preserves the query string', async () => {
+    const res = await fetch(`${baseUrl}/browse/?page=2`, { redirect: 'manual' });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('/browse?page=2');
+  });
+});
+
+describe('/favicon.ico', () => {
+  it('returns 200 with an image/* content-type (not the SPA shell)', async () => {
+    const res = await fetch(`${baseUrl}/favicon.ico`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/^image\//);
+    const body = await res.text();
+    expect(body).toContain('<svg');
+    expect(body).not.toContain('<!doctype html>');
+  });
+});

--- a/server/redirects.test.ts
+++ b/server/redirects.test.ts
@@ -70,6 +70,26 @@ describe('apex → www canonical-host redirect', () => {
     expect(res.headers.get('location')).toBe('https://www.tasteslikegood.org/api/health');
   });
 
+  it('uses 308 for non-GET methods so the method/body survive the redirect', async () => {
+    const res = await fetch(`${baseUrl}/api/generate`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { 'X-Forwarded-Host': 'tasteslikegood.org' },
+    });
+    expect(res.status).toBe(308);
+    expect(res.headers.get('location')).toBe('https://www.tasteslikegood.org/api/generate');
+  });
+
+  it('never redirects off the canonical origin (protocol-relative smuggling)', async () => {
+    const res = await fetch(`${baseUrl}//evil.example`, {
+      redirect: 'manual',
+      headers: { 'X-Forwarded-Host': 'tasteslikegood.org' },
+    });
+    expect(res.status).toBe(301);
+    const location = res.headers.get('location') ?? '';
+    expect(new URL(location).origin).toBe('https://www.tasteslikegood.org');
+  });
+
   it('does not redirect the www host', async () => {
     const res = await fetch(`${baseUrl}/api/health`, {
       redirect: 'manual',

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -1943,6 +1943,11 @@
     >
       <p class="serif">&copy; 2026 Tasteslikegood.org &mdash; VeganGenius Chef</p>
       <nav class="flex items-center gap-5">
+        <!-- Public SSR site (server-rendered /browse) — the SPA previously had
+             no link to it at all (issue #3164). -->
+        <a href="/browse" class="hover:text-stone-800 underline underline-offset-2"
+          >Browse Public Recipes</a
+        >
         <a href="/privacy-policy" class="hover:text-stone-800 underline underline-offset-2"
           >Privacy Policy</a
         >


### PR DESCRIPTION
Refs #3164 (do **not** auto-close — the Backend half must land too).

Cookbook half of the tiered audit. The Backend half is **adamtasteslikegood/tasteslikegood.com#217** (draft): no-image guard, image-endpoint hygiene (content-type sniffing, no Set-Cookie/Vary, CORS strip), public-base 404/500 pages, `scripts/unpublish_slugs.py`, dev-only legacy-surface docs. **The Backend submodule pointer bump is intentionally NOT in this PR** — it happens in a follow-up commit/PR after #217 merges.

## What changed (by audit tier)

**Critical**
- **Item 2 — canonical host:** 301 `tasteslikegood.org` → `https://www.tasteslikegood.org` for **all** paths, mounted before every other route in `server/index.ts` (`req.hostname` honors `X-Forwarded-Host` via `trust proxy`). Privacy-policy apex hrefs updated to www (2 links).
- **Item 3 — robots.txt:** `Allow: /api/recipes/*/image` added — `Disallow: /api/` was blocking every recipe hero/og:image from image crawlers (longest-match Allow wins).
- **Item 4 — favicon:** `/favicon.ico` now serves real SVG bytes (`server/public/favicon.svg`, image/svg+xml) instead of falling through to the SPA catch-all as text/html.

**High**
- **Item 7 — SPA→public nav:** footer "Browse Public Recipes" link (`src/app.component.html`) — the compiled bundle previously contained zero references to `/browse`.

**Medium**
- **Item 9 — trailing slash:** 301 `/browse/` → `/browse` (exact-path middleware so non-strict route matching can't loop; query string preserved).

**Acceptance gate**
- **AC 1 — `scripts/audit/crawl-links.sh`:** bash+curl, read-only, `BASE_URL` env (default `https://www.tasteslikegood.org`); fetches sitemap + `/` + `/browse` (follows rel=next) + every `/r/<slug>`; greps internal `href`/`src`/`og:image`/`canonical`; GETs each unique same-host URL (`-L --max-time 30`); fails on final status ≥400 or on image content-type vs `file --mime-type` mismatch; prints a url/status/content-type TSV.

## Tests / checks

- `server/redirects.test.ts` (+10 vitest): apex 301 for `/`, `/browse`, `/r/<slug>`, query preservation, `/api` coverage, www + localhost negative cases; `/browse/` 301 (+query); favicon 200 image/*.
- `npm run lint` ✅  `npm run type-check` ✅  `npm run format:check` ✅  `npm test` ✅ **111 passed (8 files)**.

## Live crawl (pre-deploy baseline)

`./scripts/audit/crawl-links.sh` against production: **142 unique URLs, 10 failures — all of them the known defects this audit fixes, none new**:
- 2× 404 images: exactly the two imageless recipes named in the spec (`48b3856c…`, `9c3ff7a2…`) — resolved by the Backend template guard + running `unpublish_slugs.py` in prod (operator step, deliberately not done here).
- 8× `image/png` declared vs JPEG bytes — resolved by Backend #217's content-type sniffing once deployed.

The script is expected to go green only after Backend #217 deploys and the two slugs are unpublished. The 2 cornbread slugs are untouched (no confirming comment on #3164).

## Follow-ups (not this PR)
1. Merge Backend #217, then bump the submodule pointer in a cookbook PR.
2. Adam: run `Backend/scripts/unpublish_slugs.py` against prod for the 5 junk slugs + 2 imageless recipes.
3. Re-run the crawl script post-deploy — should exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReC11ynX32TSFGz9bzooF3









<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

