### PR TITLE
fix(mcp): point Continue Atlassian check at streamable-HTTP MCP endpoint

### DIFF
--- a/.continue/checks/jira-ticket-updater.md
+++ b/.continue/checks/jira-ticket-updater.md
@@ -1,6 +1,6 @@
 ---
 name: jira-ticket-updater
-tools: https://mcp.atlassian.com/v1/sse
+tools: https://mcp.atlassian.com/v1/mcp
 ---
 
 You are a Jira ticket updater that translates technical code changes into business-friendly summaries.


### PR DESCRIPTION
## What

`.continue/checks/jira-ticket-updater.md` pointed at the hosted Atlassian MCP server's deprecated **HTTP+SSE** endpoint (`https://mcp.atlassian.com/v1/sse`). Atlassian sunset that transport after **2026-06-30** in favor of **streamable HTTP** at `https://mcp.atlassian.com/v1/mcp`. This swaps the one URL.

## Scope — what this covers, and what it deliberately doesn't

Exactly one in-tree reference to the dead endpoint existed (grep-verified across every config):

- ✅ `.continue/checks/jira-ticket-updater.md` — fixed here.
- ➖ `.mcp.json` / `Backend/.mcp.json` — only `pm-daemon` + `gcp-monitor` (local stdio); no Atlassian entry.
- ➖ `.junie/mcp/mcp.json` — Linear only.
- ➖ `scripts/pm/*` — calls the Atlassian **REST API** directly (`/rest/api/3`, `/wiki/api/v2`), never the MCP gateway; unaffected by the SSE deprecation.

**Out of scope (not a repo change):** the claude.ai **hosted Atlassian connector**'s transport lives in claude.ai → Connectors, not in git. If it still reads `/v1/sse`, it's swapped there.

## Testing

Config-only; no runtime surface in CI. Worth confirming Continue still loads the check after the URL swap (some Continue versions want an explicit transport type alongside the URL).

Refs RCP-50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

