### PR TITLE
fix(deploy): bump flask-backend Cloud Run memory to 1Gi

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -177,6 +177,9 @@ steps:
       - --region=$_REGION
       - --port=8080
       - --min-instances=1
+      # Memory: 512Mi (Cloud Run default) left idle RSS — gunicorn + ddtrace +
+      # google SDKs — at ~84% p95 / 99.2% max (OOM edge). 1Gi drops it to ~42%.
+      - --memory=1Gi
       # KAN-29: FLASK_ENV=production activates production-only guards:
       #   - OAUTHLIB_INSECURE_TRANSPORT guard (CRITICAL-2)
       #   - FLASK_SECRET_KEY fail-fast at startup (CRITICAL-4)


### PR DESCRIPTION
## What
The `flask-backend` Cloud Run service deploy in `cloudbuild.yaml` had **no `--memory` flag**, so it ran on Cloud Run's **default 512Mi**. gcp-monitor telemetry showed idle memory flat at **~84% p95 / 99.2% max** — an **OOM edge**, not a leak (baseline working set of gunicorn + the in-process Datadog stack + google SDKs, held resident by `min-instances=1`).

## Change
- `flask-backend` service: **`--memory=1Gi`** (512Mi→1Gi ⇒ utilization ~84%→~42%, OOM headroom restored). The `flask-backend-migrate` Job already runs at 1Gi; this aligns the service to it.

## Pairs with
Backend PR #220 (`DD_PROFILING_ENABLED=false` + gunicorn `--max-requests`). **Follow-up:** once #220 merges, a submodule pointer bump to pull it in will be folded into this PR so both land in the same release.

## Test plan
Deploy-config only. Post-deploy, verify via gcp-monitor `check_system_health backend` that memory utilization drops toward ~42%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

