### PR TITLE
fix(deploy): mount VALKEY_CA_CERT on Flask backend so it uses shared Valkey (pairs Backend #222)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -189,7 +189,12 @@ steps:
       # scripts/gcloud/setup_pubsub.sh. Both must be set or worker_api_bp
       # fails closed with 503.
       - --set-env-vars=FLASK_ENV=production,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
-      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest,DD_API_KEY=DD_API_KEY:latest
+      # VALKEY_CA_CERT: Memorystore's Google-managed CA, trusted by the Flask
+      # IAM Valkey client (Backend/utils/valkey_auth.py) so the response cache
+      # (Flask-Caching) uses shared Valkey instead of silently degrading to a
+      # per-worker in-process SimpleCache. Same secret express-frontend mounts
+      # below; created by scripts/gcloud/setup_valkey_ca.sh.
+      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest,VALKEY_CA_CERT=VALKEY_CA_CERT:latest,DD_API_KEY=DD_API_KEY:latest
       - --labels=service=flask-backend,dd_sls_mcp_tool=true
       - --no-allow-unauthenticated
       - --quiet


### PR DESCRIPTION
**Part 2 of 2** — deploy side of the Flask Valkey TLS fix. Pairs with Backend PR **adamtasteslikegood/tasteslikegood.com#222**.

## Problem
Since v0.3.5, flask-backend silently falls back to in-process `SimpleCache` on **every boot** (proven from Datadog, `service:flask-backend`): its IAM Valkey client can't verify Memorystore's Google-managed CA, so the TLS handshake fails `CERTIFICATE_VERIFY_FAILED`. The response cache (Flask-Caching) degrades to a **per-worker** in-process `SimpleCache`.

Two gaps, both required (Express does both and works):
1. **Code** — Backend #222: `utils/valkey_auth.py` now reads `VALKEY_CA_CERT` and hands it to redis-py as `ssl_ca_data`.
2. **Config (this PR)** — the *Deploy Flask Backend* step in `cloudbuild.yaml` didn't mount `VALKEY_CA_CERT`. This adds it, at parity with express-frontend (which has mounted it since #3027). The secret already exists in Secret Manager (`scripts/gcloud/setup_valkey_ca.sh`) — no setup needed.

## Why draft
The submodule pointer bump to the Backend fix lands here once #222 merges to Backend `dev` (its merged SHA, not the feature-branch SHA). Until then this config change alone is a **safe no-op** — Flask ignores the mounted secret until the code lands. I'll bump the pointer, mark ready, and it ships in the next `dev` → `main` release.

## Coexists with
- #3173 (`--memory=1Gi`, already merged) — same deploy step, no overlap.
- Backend #220 (profiler off) — already the pinned pointer `92fd8b1`.

## Verify after deploy
flask-backend logs show `Valkey connection OK at 10.128.0.11:6379` + `Response cache: Valkey/Redis backend` instead of the SSL error; the ~58 MiB of per-worker image bytes move to shared Valkey and memory-util p95 drops from ~82%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

