### PR TITLE
feat(skills): add harness-qa-loop QA-gated harness workflow + .env.example creds callout

### DIFF
--- a/.claude/skills/harness-qa-loop/SKILL.md
+++ b/.claude/skills/harness-qa-loop/SKILL.md
@@ -48,11 +48,13 @@ The harness scripts ship in the `engineering/agent-harness` plugin, not this
 repo. Resolve them once, and keep run state in `.agent-harness/` at repo root:
 
 ```bash
+# Anchor at the repo root so .agent-harness/ scratch and every relative plan/state
+# path below resolve the same way no matter which cwd you start in.
+cd "$(git rev-parse --show-toplevel)" || { echo "not inside a git repo"; exit 1; }
 AH_SCRIPT="$(find ~/.claude/plugins -path '*/agent-harness/scripts/goal_compiler.py' 2>/dev/null | head -1)"
 [ -n "$AH_SCRIPT" ] || { echo "agent-harness plugin not found under ~/.claude/plugins — install engineering/agent-harness first"; exit 1; }
 AH="$(dirname "$AH_SCRIPT")"
-# plan_qa.py ships in this skill; resolve from the repo root so it works from any cwd
-SKILL_DIR="$(git rev-parse --show-toplevel)/.claude/skills/harness-qa-loop"
+SKILL_DIR=".claude/skills/harness-qa-loop"   # plan_qa.py ships here (repo-relative after the cd above)
 mkdir -p .agent-harness
 ```
 
@@ -129,8 +131,10 @@ python3 "$AH/loop_controller.py" close --state .agent-harness/state.json   # ref
 
 - **Approving a REVIEW/BLOCK plan anyway.** A smoke-only check is not proof. Add
   an outcome check tied to `done_when`, or accept it out loud as a known gap.
-- **Editing a check to pass QA.** Same reward-hacking failure the harness forbids
-  in the loop — it applies to the plan too. Recompile instead.
+- **Weakening a check, or editing any check after init, to make a task pass.**
+  That is the reward-hacking the harness forbids. Strengthening a check *before*
+  init (Phase 2) is the opposite — allowed and expected; recompile or hand-author
+  *truer* checks, never weaker ones.
 - **Turning a secrets/human step into a fake check.** If a step needs a
   credential you can't create, it is a waiver with a reason, not a green check.
 - **Skipping QA "because the goal is small."** The linter is one command; a bad

--- a/.claude/skills/harness-qa-loop/SKILL.md
+++ b/.claude/skills/harness-qa-loop/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: harness-qa-loop
+description: >-
+  Use when driving a goal through this repo's agent-harness (any of the 18
+  domains) and you want a QA gate on the compiled plan before spending loop
+  budget — after goal_compiler emits plan.json, before loop_controller init.
+  Triggers: "run this goal through the harness with a QA/approval gate",
+  reviewing a plan.json before init, hardening a run so verifications aren't
+  tautological or smoke-only, dogfooding a domain loop, cs-harness plus an
+  explicit qa-session and approval step. Not for authoring the harness itself
+  (agent-harness) or Workflow .js scripts (workflow-builder).
+---
+
+# Harness QA Loop
+
+## Overview
+
+A goal-to-close run over the agent-harness with one thing added: an explicit
+**QA session on the compiled plan** between compile and init. Raw `cs-harness`
+goes compile → glance at plan → drive. That skips the cheapest place to catch a
+bad run — the plan itself, before any budget is spent.
+
+**Core principle:** the plan is a trust boundary and the loop budget is finite.
+QA and approve the plan *before* you spend either. A plan with a tautological or
+smoke-only check will "verify" a task that never happened; a plan missing a task
+will close a goal that isn't done. Both are cheap to catch on paper, expensive to
+catch mid-loop.
+
+**REQUIRED SUB-SKILL:** Use `agent-harness` (and its `/cs:harness` entry point)
+for the compile and loop mechanics — this skill does not restate them, it inserts
+a gate. Read its SKILL.md for exit codes and the state machine.
+
+## When to use
+
+- You have a goal and a domain and want it driven to a *verified* close, not a
+  vibes close.
+- A `plan.json` exists and you want it reviewed before `loop_controller init`.
+- You are dogfooding or hardening a domain harness and want weak verifications
+  surfaced mechanically.
+
+**Not when:** authoring a new domain manifest or the harness scripts themselves
+(`agent-harness`), or writing deterministic `.js` Workflow-tool scripts
+(`workflow-builder`).
+
+## Setup (paths)
+
+The harness scripts ship in the `engineering/agent-harness` plugin, not this
+repo. Resolve them once, and keep run state in `.agent-harness/` at repo root:
+
+```bash
+AH="$(dirname "$(find ~/.claude/plugins -path '*/agent-harness/scripts/goal_compiler.py' 2>/dev/null | head -1)")"
+SKILL_DIR="$(dirname "$0")"   # this skill's dir; holds plan_qa.py
+mkdir -p .agent-harness
+```
+
+## The four phases (gates are blocking — never skip forward)
+
+### 1. Compile → `.agent-harness/plan.json`
+
+Delegate to `agent-harness`. A vague goal is rejected (exit 3) with forcing
+questions — relay them one at a time, recommended answer first, recompile. No
+skill match (exit 4) — fix the domain or the goal.
+
+```bash
+python3 "$AH/goal_compiler.py" --goal "<goal>" \
+  --manifest "$AH/../assets/harnesses/<domain>.json" --out .agent-harness/plan.json
+```
+
+### 2. QA the plan (the gate this skill adds)
+
+Run the mechanical linter, then answer the human checklist it prints. If
+`plan_qa.py` exits 1 — or the checklist finds spurious tasks or checks that don't
+test the real outcome — do **not** advance as-is. Fix the plan first: recompile
+with a sharper goal or a different domain, **or** author a corrected plan by hand
+when the manifest's generic checks can't express the repo-real outcome (e.g. a
+specific `pytest` path the auto-compiler can't know). Correcting a plan means
+making checks *stronger and truer* — real outcome checks tied to `done_when` —
+never weaker; then re-run `plan_qa.py` and let the human approve the corrected
+plan at the gate. What you may **not** do is edit a check *after init* to dodge a
+failure (see The one rule).
+
+```bash
+python3 "$SKILL_DIR/plan_qa.py" --plan .agent-harness/plan.json   # exit 1 = blocked
+```
+
+| The linter flags (mechanical) | Only a human decides (checklist) |
+|---|---|
+| Task with no runnable verification → will escalate | Do the tasks *together* achieve the goal? |
+| Tautological check (`true`, `echo …`) → reward-hackable | Does any task touch a no-touch path? |
+| Smoke/sample-only check → proves tool runs, not outcome | Is each task's skill the right match? |
+| Iteration budget < task count → can't finish | Which steps need secrets/human input (→ waivers)? |
+
+### 3. Approve — the only human gate
+
+Present the QA report **and** the plan (tasks, verifications, caps) to the human
+and get an explicit go/no-go. This is the single approval gate in the loop; you
+do not self-approve. Steps that need secrets or human input are named here as
+pre-work or planned **waivers**, never disguised as machine checks.
+
+### 4. Execute the loop
+
+Init, then repeat `next → execute the task per its skill → record → verify` until
+the directive is `close`. Escalate (stop, show evidence, let the human decide) on
+exit 2 (attempts exhausted) or exit 5 (iteration cap). Never report an exhausted
+budget as success; waivers are the human's call.
+
+```bash
+python3 "$AH/loop_controller.py" init  --plan .agent-harness/plan.json --state .agent-harness/state.json
+python3 "$AH/loop_controller.py" next  --state .agent-harness/state.json
+# … do the task's real work …
+python3 "$AH/loop_controller.py" record --state .agent-harness/state.json --task <T> --phase execute --exit-code <n>
+python3 "$AH/loop_controller.py" verify --state .agent-harness/state.json --task <T> --cwd "$PWD"
+python3 "$AH/loop_controller.py" close --state .agent-harness/state.json   # refused (exit 4) while a task is unverified
+```
+
+## Quick reference
+
+| Phase | Command | Gate |
+|---|---|---|
+| Compile | `goal_compiler.py … --out .agent-harness/plan.json` | exit 3 vague / exit 4 no-match |
+| **QA** | `plan_qa.py --plan .agent-harness/plan.json` | **exit 1 → fix plan, don't approve** |
+| Approve | present QA report + plan to human | explicit go/no-go |
+| Execute | `loop_controller.py` init/next/record/verify/close | exit 2/5 → escalate |
+
+## Common mistakes
+
+- **Approving a REVIEW/BLOCK plan anyway.** A smoke-only check is not proof. Add
+  an outcome check tied to `done_when`, or accept it out loud as a known gap.
+- **Editing a check to pass QA.** Same reward-hacking failure the harness forbids
+  in the loop — it applies to the plan too. Recompile instead.
+- **Turning a secrets/human step into a fake check.** If a step needs a
+  credential you can't create, it is a waiver with a reason, not a green check.
+- **Skipping QA "because the goal is small."** The linter is one command; a bad
+  plan wastes the whole loop budget.
+
+## The one rule
+
+Once the loop is initialized, never modify a gate you are judged by — not the
+plan's checks, not the manifest — to make a failing task pass. That is
+reward-hacking. (*Before* init, correcting an unfaithful plan into *stronger*
+checks is the whole point of the QA gate, and the human approves the result.)
+Approval is *human*, verification is *the controller's*. You operate the loop;
+you do not adjudicate it.

--- a/.claude/skills/harness-qa-loop/SKILL.md
+++ b/.claude/skills/harness-qa-loop/SKILL.md
@@ -48,8 +48,11 @@ The harness scripts ship in the `engineering/agent-harness` plugin, not this
 repo. Resolve them once, and keep run state in `.agent-harness/` at repo root:
 
 ```bash
-AH="$(dirname "$(find ~/.claude/plugins -path '*/agent-harness/scripts/goal_compiler.py' 2>/dev/null | head -1)")"
-SKILL_DIR="$(dirname "$0")"   # this skill's dir; holds plan_qa.py
+AH_SCRIPT="$(find ~/.claude/plugins -path '*/agent-harness/scripts/goal_compiler.py' 2>/dev/null | head -1)"
+[ -n "$AH_SCRIPT" ] || { echo "agent-harness plugin not found under ~/.claude/plugins — install engineering/agent-harness first"; exit 1; }
+AH="$(dirname "$AH_SCRIPT")"
+# plan_qa.py ships in this skill; resolve from the repo root so it works from any cwd
+SKILL_DIR="$(git rev-parse --show-toplevel)/.claude/skills/harness-qa-loop"
 mkdir -p .agent-harness
 ```
 

--- a/.claude/skills/harness-qa-loop/plan_qa.py
+++ b/.claude/skills/harness-qa-loop/plan_qa.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""plan_qa.py — QA-lint an agent-harness ``plan.v1`` before you spend loop budget.
+
+This is the *mechanical* half of the harness-qa-loop QA session. It reads a
+compiled ``plan.json`` and flags tasks whose verification is missing,
+tautological, or smoke-only, plus budget/coverage red flags. It does NOT decide
+the judgment calls (does the plan cover the goal? are no-touch paths honored? is
+each skill the right match?) — it prints those as a human checklist instead.
+
+Exit codes (branch on these):
+  0  no hard blockers — warnings may remain, read them before approving.
+  1  hard blocker — a task has no runnable verification, or the iteration budget
+     cannot cover the task count. Do NOT approve the plan as-is.
+  2  plan file missing / unreadable / not an agent-harness plan.
+
+Usage:
+  python3 plan_qa.py [--plan .agent-harness/plan.json] [--strict] [--json]
+
+  --strict  treat warnings (tautological / smoke-only verification) as blockers.
+  --json    emit the findings as JSON instead of the human report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Commands whose exit code is independent of whether the task's work happened.
+# A verification built from these is reward-hackable — it passes even if nothing
+# changed. Same failure mode the harness warns about: never be judged by a gate
+# you could satisfy without doing the work.
+_ALWAYS_ZERO = {"true", ":", "echo", "echo ok", "exit 0", "printf"}
+
+# Verification kinds that prove the *tool runs*, not that the *goal outcome holds*.
+_WEAK_KINDS = {"smoke", "sample"}
+
+
+def _is_tautology(cmd: str) -> bool:
+    c = (cmd or "").strip()
+    if c in _ALWAYS_ZERO:
+        return True
+    return c.startswith("echo ") or c.startswith("printf ") or c == "true"
+
+
+def _load_plan(path: Path):
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        print(f"plan_qa: no plan at {path} — compile a goal first "
+              f"(goal_compiler.py ... --out {path})", file=sys.stderr)
+        raise SystemExit(2)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"plan_qa: cannot read {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    schema = str(data.get("schema", ""))
+    if not schema.startswith("agent-harness/plan"):
+        print(f"plan_qa: {path} is not an agent-harness plan "
+              f"(schema={schema!r})", file=sys.stderr)
+        raise SystemExit(2)
+    return data
+
+
+def qa(plan: dict) -> dict:
+    """Return {tasks:[...], blockers:[...], warnings:[...]}."""
+    tasks = plan.get("tasks", [])
+    loop = plan.get("loop", {})
+    order = loop.get("order", "sequential")
+    max_iters = int(loop.get("max_loop_iterations", 0) or 0)
+
+    rows, blockers, warnings = [], [], []
+
+    for t in tasks:
+        tid = t.get("id", "?")
+        skill = t.get("skill", "?")
+        checks = t.get("verification", []) or []
+        runnable = [c for c in checks if (c.get("cmd") or "").strip()]
+        kinds = {c.get("kind", "?") for c in runnable}
+
+        status, note = "ok", ""
+        if not runnable:
+            status = "BLOCK"
+            note = "no runnable verification"
+            blockers.append(
+                f"{tid} ({skill}) has no verification check — the loop will "
+                f"escalate (no_verification_available). Add a real check or drop it.")
+        else:
+            tauto = [c["cmd"] for c in runnable if _is_tautology(c.get("cmd", ""))]
+            if tauto:
+                status = "WARN"
+                note = "tautological check"
+                warnings.append(
+                    f"{tid} ({skill}) verification is reward-hackable "
+                    f"({tauto[0]!r} always exits 0). Replace with a check that "
+                    f"fails when the work is undone.")
+            elif kinds and kinds <= _WEAK_KINDS:
+                status = "WARN"
+                note = f"smoke-only ({','.join(sorted(kinds))})"
+                warnings.append(
+                    f"{tid} ({skill}) verification is smoke/sample-only — proves "
+                    f"the tool runs, not that the goal outcome holds. Add an "
+                    f"outcome check tied to done_when.")
+        if not str(t.get("done_when", "")).strip():
+            warnings.append(f"{tid} ({skill}) has an empty done_when.")
+
+        rows.append({"id": tid, "skill": skill,
+                     "checks": len(runnable), "status": status, "note": note})
+
+    # Budget sanity: a sequential loop needs at least one iteration per task
+    # (plus retries). Fewer iterations than tasks cannot finish.
+    if order == "sequential" and max_iters and max_iters < len(tasks):
+        blockers.append(
+            f"loop.max_loop_iterations ({max_iters}) < task count ({len(tasks)}) "
+            f"— a sequential loop cannot verify every task. Raise the cap.")
+
+    return {"rows": rows, "blockers": blockers, "warnings": warnings,
+            "goal": plan.get("goal", ""), "domain": plan.get("domain", ""),
+            "task_count": len(tasks), "max_iters": max_iters}
+
+
+_HUMAN_CHECKLIST = [
+    "Do the tasks TOGETHER achieve the goal? Any missing task (coverage gap)?",
+    "Does any task write a no-touch path named in the goal?",
+    "Is each task's skill the right match for its objective?",
+    "Any step needing secrets/human input? It must be a waiver, not a fake check.",
+]
+
+
+def _report(res: dict, strict: bool) -> int:
+    icon = {"ok": "✓", "WARN": "⚠", "BLOCK": "✗"}
+    print("harness-qa-loop · plan QA")
+    print(f"goal:   {res['goal']}")
+    print(f"domain: {res['domain']}   tasks: {res['task_count']}   "
+          f"loop.max_iters: {res['max_iters']}\n")
+    for r in res["rows"]:
+        line = f"  {icon.get(r['status'], '?')} {r['id']:<4} {r['skill']:<24} " \
+               f"verify:{r['checks']}"
+        if r["note"]:
+            line += f"   {r['note']}"
+        print(line)
+
+    if res["blockers"]:
+        print("\nHARD BLOCKERS (fix before approving):")
+        for b in res["blockers"]:
+            print(f"  ✗ {b}")
+    if res["warnings"]:
+        print("\nWARNINGS (weak verification — harden or accept with eyes open):")
+        for w in res["warnings"]:
+            print(f"  ⚠ {w}")
+
+    print("\nHUMAN QA (this tool can't decide — confirm each before approving):")
+    for item in _HUMAN_CHECKLIST:
+        print(f"  [ ] {item}")
+
+    hard = bool(res["blockers"]) or (strict and bool(res["warnings"]))
+    verdict = "BLOCK" if hard else ("REVIEW" if res["warnings"] else "PASS")
+    print(f"\nVERDICT: {verdict}"
+          f"  ({len(res['blockers'])} blocker(s), {len(res['warnings'])} warning(s))")
+    return 1 if hard else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="QA-lint an agent-harness plan.v1")
+    ap.add_argument("--plan", default=".agent-harness/plan.json",
+                    help="path to compiled plan.json (default: .agent-harness/plan.json)")
+    ap.add_argument("--strict", action="store_true",
+                    help="treat warnings as hard blockers")
+    ap.add_argument("--json", action="store_true",
+                    help="emit findings as JSON instead of the human report")
+    args = ap.parse_args()
+
+    plan = _load_plan(Path(args.plan))
+    res = qa(plan)
+    if args.json:
+        hard = bool(res["blockers"]) or (args.strict and bool(res["warnings"]))
+        print(json.dumps(res, indent=2))
+        return 1 if hard else 0
+    return _report(res, args.strict)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/harness-qa-loop/plan_qa.py
+++ b/.claude/skills/harness-qa-loop/plan_qa.py
@@ -45,7 +45,7 @@ def _is_tautology(cmd: str) -> bool:
 
 def _load_plan(path: Path):
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         print(f"plan_qa: no plan at {path} — compile a goal first "
               f"(goal_compiler.py ... --out {path})", file=sys.stderr)
@@ -67,7 +67,7 @@ def _load_plan(path: Path):
 
 
 def qa(plan: dict) -> dict:
-    """Return {tasks:[...], blockers:[...], warnings:[...]}."""
+    """Return {rows:[...], blockers:[...], warnings:[...], goal, domain, task_count, max_iters}."""
     tasks = plan.get("tasks", [])
     loop = plan.get("loop", {})
     order = loop.get("order", "sequential")

--- a/.claude/skills/harness-qa-loop/plan_qa.py
+++ b/.claude/skills/harness-qa-loop/plan_qa.py
@@ -40,7 +40,7 @@ def _is_tautology(cmd: str) -> bool:
     c = (cmd or "").strip()
     if c in _ALWAYS_ZERO:
         return True
-    return c.startswith("echo ") or c.startswith("printf ") or c == "true"
+    return c.startswith("echo ") or c.startswith("printf ")
 
 
 def _load_plan(path: Path):
@@ -52,6 +52,11 @@ def _load_plan(path: Path):
         raise SystemExit(2)
     except (OSError, json.JSONDecodeError) as exc:
         print(f"plan_qa: cannot read {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    if not isinstance(data, dict):
+        print(f"plan_qa: {path} is not an agent-harness plan "
+              f"(top-level JSON is {type(data).__name__}, expected object)",
+              file=sys.stderr)
         raise SystemExit(2)
     schema = str(data.get("schema", ""))
     if not schema.startswith("agent-harness/plan"):

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ FRONTEND_URL=http://localhost:8080
 #   Read-only rollups/briefings may also include plaza-game PLZG/TO;
 #   anything else (incl. the frozen TOSVC) is refused with an error.
 ATLASSIAN_URL=tasteslikegood.atlassian.net
+# REQUIRED for Confluence/Jira sync: uncomment BOTH lines below and fill them
+# with a real Atlassian account email + API token
+# (https://id.atlassian.com/manage-profile/security/api-tokens). Leave them
+# commented and every sync no-ops: pm_daemon logs "Atlassian credentials
+# missing from .env" and atlassian_pm_link.py exits "Missing required .env
+# variables". These two are the credentials that gate ALL pm-daemon sync.
 # ATLASSIAN_EMAIL=your-atlassian-email@example.com
 # ATLASSIAN_API_TOKEN=your-atlassian-api-token
 ATLASSIAN_JIRA_PROJECT_KEY=KAN

--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ ATLASSIAN_URL=tasteslikegood.atlassian.net
 # (https://id.atlassian.com/manage-profile/security/api-tokens). Leave them
 # commented and every sync no-ops: pm_daemon logs "Atlassian credentials
 # missing from .env" and atlassian_pm_link.py exits "Missing required .env
-# variables". These two are the credentials that gate ALL pm-daemon sync.
+# variables: <names>". These two are the credentials that gate ALL pm-daemon sync.
 # ATLASSIAN_EMAIL=your-atlassian-email@example.com
 # ATLASSIAN_API_TOKEN=your-atlassian-api-token
 ATLASSIAN_JIRA_PROJECT_KEY=KAN

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ scripts/pm/.venv/
 
 # Runtime session-log dedup markers (SessionEnd hook)
 .claude/session-logs/
+
+# agent-harness per-run working state (plan/state/evidence scratch)
+.agent-harness/


### PR DESCRIPTION
## What

Adds a new project skill **`harness-qa-loop`** and hardens the `.env.example` Atlassian-creds documentation — the two outputs of a `/cs:harness` run that dogfooded itself on "wire up `scripts/pm/`".

### 1. New skill: `.claude/skills/harness-qa-loop/`

Wraps this repo's agent-harness (`cs-harness`/`agent-harness` plugin) with an explicit **QA-session gate** between compile and loop init:

```
compile (goal_compiler → plan.json) → QA (plan_qa.py + human checklist) → human approve → drive (loop_controller) → close
```

- **`SKILL.md`** — the 4-phase procedure. Portable (resolves the plugin scripts via `find`, no hardcoded paths). The rule it adds over raw `cs-harness`: correcting a plan *before* init is allowed (and the point of the gate); editing a check *after* init to dodge a failure is reward-hacking.
- **`plan_qa.py`** — stdlib-only linter for `plan.v1`: flags tasks with no runnable verification, tautological checks (`true`/`echo`), smoke/sample-only checks, and iteration budgets smaller than the task count. Exit 1 = blocked.

### 2. `.env.example` — REQUIRED-for-sync callout

`ATLASSIAN_EMAIL` / `ATLASSIAN_API_TOKEN` were already present (commented, per convention) but easy to miss. Added a callout that they gate **all** pm-daemon sync — leave them commented and `pm_daemon` warns "credentials missing" while `atlassian_pm_link.py` `SystemExit`s. No secrets added; secrets stay commented.

### 3. `.gitignore`

Ignore `.agent-harness/` (the harness's per-run working state).

## How it was verified

The skill was dogfooded on the `scripts/pm` goal and driven to a **verified close** (3/3, controller-run evidence):

| Task | Result |
|---|---|
| PM1 | `md2cf` synced into the pm venv; `unittest discover` → **59 tests OK** (repo uses unittest, not pytest — confirmed after fast-forwarding to #3175) |
| PM2 | `.env.example` callout present (re-scoped after QA found the original "missing creds" premise false) |
| PM3 | **live** read-only Atlassian round-trip: `Fetched 50 Jira issue IDs. Fetched 8 Confluence spaces.` |

The QA gate caught two weak checks the raw auto-compiler produced (2 spurious tasks verifying the harness's own tooling; a tautological `fetch_atlassian.py` check that exits 0 even on failure) — that last one is filed as a follow-up.

## Scope

Touches only `.claude/skills/`, `.env.example`, `.gitignore`. No `Backend/`, no Angular app, no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

