### PR TITLE
docs(changelog): gunicorn 540s graceful-timeout for v0.3.9 (Backend #224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and unclips the public recipe hero on mobile. No schema migration.
   a max-request cap (Backend
   [#220](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/220)) —
   headroom over the flat ~84% memory baseline that risked an OOM at the 99% edge.
+  Gunicorn's `--graceful-timeout` is raised to **540s** to match
+  `GENAI_HTTP_TIMEOUT_MS` so a worker restart lets an in-flight Gemini/Imagen
+  call finish instead of the 30s default force-killing it (Backend
+  [#224](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/224)).
 - **Agent / PM tooling**: new `harness-qa-loop` QA-gated harness skill plus an
   `.env.example` credentials callout
   ([#3177](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3177));


### PR DESCRIPTION
## What

Adds one CHANGELOG line under v0.3.9 documenting the gunicorn
`--graceful-timeout 540` change from Backend
[#224](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/224).

## Why

Backend #224 sizes `--graceful-timeout` to `GENAI_HTTP_TIMEOUT_MS` (540s) so a
worker restart lets an in-flight Gemini/Imagen call finish instead of the 30s
default force-killing it — addresses Copilot feedback on the #220 max-requests
recycling ([#223 comment](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/223#discussion_r3610421169)).

## ⚠️ Release sequencing

Backend #224 moves the Backend `dev` tip **past `9c830b0`** (the SHA v0.3.9
currently pins). Before this merges I'll add the **submodule pointer re-bump**
to the post-#224 Backend `dev` SHA so #223's promotion and this release pin the
same commit. Merge order unchanged: Backend #224 → dev, then #223 (dev→main),
then this + the cookbook dev→main release, then tag.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

