### PR TITLE
chore(submodule): bump Backend pointer → 18a303a (+#224) for v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,10 @@ and unclips the public recipe hero on mobile. No schema migration.
   ([#3173](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3173)),
   the Datadog continuous profiler disabled, and gunicorn workers now recycle on
   a max-request cap (Backend
-  [#220](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/220)) —
+  [#220](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/220));
+  gunicorn's graceful-timeout is raised to **540s** so those worker recycles
+  don't kill in-flight recipe generations (Backend
+  [#224](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/224)) —
   headroom over the flat ~84% memory baseline that risked an OOM at the 99% edge.
 - **Agent / PM tooling**: new `harness-qa-loop` QA-gated harness skill plus an
   `.env.example` credentials callout
@@ -57,7 +60,7 @@ and unclips the public recipe hero on mobile. No schema migration.
 
 ### Deploy notes
 
-- Backend submodule pointer **`4857369` → `9c830b0`**. **No new Alembic
+- Backend submodule pointer **`4857369` → `18a303a`**. **No new Alembic
   migration** — single head unchanged, so `flask-backend-migrate` is a no-op
   this release.
 - The flask-backend Cloud Run deploy now mounts the **`VALKEY_CA_CERT`** secret


### PR DESCRIPTION
Bumps the cookbook Backend submodule pointer `9c830b0 → 18a303a` so v0.3.9 ships the promoted Backend `main` tip (Backend #227).

**What this adds vs `9c830b0`:**
- Backend **#224** — gunicorn `graceful-timeout` raised to **540s** so the max-request worker recycle (Backend #220) can't kill in-flight recipe generations. Dockerfile-only.
- Backend #225/#226 release plumbing.

**Safety:**
- Single Alembic head `b7e2a9c4d1f8` unchanged (10 migration files at both `9c830b0` and `18a303a`, no diff) → `flask-backend-migrate` stays a **no-op**.
- No new migration; no cloudbuild/env change needed (gunicorn timeout is inside the Backend image).

**CHANGELOG:** v0.3.9 deploy-notes pointer corrected `→ 18a303a` and the #224 line added under Changed.

Pairs with Backend #227 (dev→main promotion). Merges to `dev`; the v0.3.9 dev→main release rides on top.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

