### PR TITLE
docs(changelog): dedupe the v0.3.9 #224 note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,7 @@ and unclips the public recipe hero on mobile. No schema migration.
   ([#3173](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3173)),
   the Datadog continuous profiler disabled, and gunicorn workers now recycle on
   a max-request cap (Backend
-  [#220](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/220));
-  gunicorn's graceful-timeout is raised to **540s** so those worker recycles
-  don't kill in-flight recipe generations (Backend
-  [#224](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/224)) —
+  [#220](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/220)) —
   headroom over the flat ~84% memory baseline that risked an OOM at the 99% edge.
   Gunicorn's `--graceful-timeout` is raised to **540s** to match
   `GENAI_HTTP_TIMEOUT_MS` so a worker restart lets an in-flight Gemini/Imagen


### PR DESCRIPTION
#3180 and 8281f76 landed on `dev` in parallel and each added a Backend #224 (gunicorn 540s graceful-timeout) line to the memory-headroom bullet, so the v0.3.9 CHANGELOG carried it **twice**.

This removes the #3180 clause and keeps the fuller `GENAI_HTTP_TIMEOUT_MS` wording from 8281f76. Net: one #224 note, no content lost. Blocks the v0.3.9 dev→main release so the public release notes aren't redundant.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

