### PR TITLE
feat(seo): SSR crawlable links on home shell (TAS-2896)- [KAN-114]

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,5 +122,19 @@
   </head>
   <body class="bg-stone-50 text-stone-800 antialiased min-h-screen">
     <app-root></app-root>
+    <!--
+      SSR crawlable links. The Angular shell is otherwise a JS-only app-root,
+      so a crawler (or any no-JS client) hitting "/" finds no anchors and the
+      site's public SSR pages (/browse, /r/<slug>) become a crawl dead-end.
+      These live inside <noscript> so they add real, followable links to the
+      server HTML without changing the JS app's rendered UI.
+    -->
+    <noscript>
+      <nav aria-label="Recipe navigation">
+        <a href="/browse">Browse all vegan recipes</a>
+        <a href="/r/classic-vegan-margherita-pizza">Classic Vegan Margherita Pizza</a>
+        <a href="/r/vegan-cornbread">Vegan Cornbread</a>
+      </nav>
+    </noscript>
   </body>
 </html>


### PR DESCRIPTION
## What

Adds server-rendered, crawlable anchors to the Angular home shell (`index.html`, built into `dist/index.html`, served by Express at `server/index.ts`).

The shell previously rendered only `<app-root>`, so a crawler (or any no-JS client) hitting `/` found **no anchors** — the public SSR pages (`/browse`, `/r/<slug>`) were a crawl dead-end. This adds real, followable links to the server HTML.

## How

A single `<noscript>` `<nav>` block after `<app-root>` with:
- `<a href="/browse">` — the public recipe index
- two `<a href="/r/<slug>">` recipe links (real published slugs from the live sitemap)

`<noscript>` keeps the links in the server HTML for crawlers/no-JS clients **without changing the JS app's rendered UI** — honoring the scope fence (anchors only; no redesign, no restyle, no new sections).

## Gate

- [x] `grep -q 'href="/browse"' index.html && grep -qE 'href="/r/' index.html` — passes
- [x] Anchors survive `ng build` — present in `dist/index.html` after `npm run build`
- [x] `npm run format:check`, `npm run lint`, `npm run type-check` — pass

_Note: the pre-existing `server/redirects.test.ts > /favicon.ico` failure reproduces identically on clean `dev` (public/ ships `favicon.svg`, no `favicon.ico`) and is unrelated to this change._

Closes TAS-2896.

<!-- generated-by-cyrus -->
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

