### PR TITLE
chore(release): bump 0.3.9 → 0.4.0 + CHANGELOG [KAN-110]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-07-20
+
+Discoverability and conversion release closing out Sprint 1 (KAN-110). Ends the
+home-page crawl dead-end with server-rendered anchors and unblocks Google
+sign-in for visitors arriving inside in-app browsers. No schema migration.
+
+### Added
+
+- **Server-rendered crawlable links on the home shell**: the Angular home shell
+  previously served only `<app-root>` — a crawler or no-JS client hitting `/`
+  found zero anchors, making the public SSR pages (`/browse`, `/r/<slug>`) a
+  crawl dead-end. A `<noscript>` nav now ships in the server HTML with
+  `<a href="/browse">` plus two published recipe links, without changing the
+  JS-rendered UI
+  ([#3185](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3185),
+  TAS-2896, KAN-114).
+
 ### Fixed
 
 - **Google sign-in no longer dead-ends inside in-app browsers**: visitors who
@@ -17,7 +36,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   browser and, instead of firing a doomed consent redirect, shows an "open this
   page in Safari/Chrome to sign in" fallback with a copy-link button. Guest
   saving already works in-webview, so first-time saves are no longer blocked at
-  the conversion moment (TAS-2899).
+  the conversion moment
+  ([#3186](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3186),
+  TAS-2899, KAN-113).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "dependencies": {
         "@angular/build": "22.0.7",
         "@angular/cli": "22.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.3.9",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
## What

Version bump `0.3.9` → `0.4.0` (package.json + lockfile) and cuts the `[0.4.0] - 2026-07-20` CHANGELOG section from Unreleased:

- **Added** — SSR crawlable links on the home shell (#3185, TAS-2896, KAN-114) — entry was missing from Unreleased, added here.
- **Fixed** — in-app-webview Google sign-in fallback (#3186, TAS-2899, KAN-113).

No schema migration.

## Why

Step 2 of the Sprint 1 DONE gate (owner amendment, `specs/SPRINT_1_PLAN.md`): bump lands on **dev** first, then a dev → main release PR ships and tags `v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBVGVmqmwiyTThD4dUSuXs
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

