### PR TITLE
release: v0.4.0 — SSR crawlable home links + webview sign-in fallback [KAN-110]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2026-07-20
+
+Discoverability and conversion release closing out Sprint 1 (KAN-110). Ends the
+home-page crawl dead-end with server-rendered anchors and unblocks Google
+sign-in for visitors arriving inside in-app browsers. No schema migration.
+
+### Added
+
+- **Server-rendered crawlable links on the home shell**: the Angular home shell
+  previously served only `<app-root>` — a crawler or no-JS client hitting `/`
+  found zero anchors, making the public SSR pages (`/browse`, `/r/<slug>`) a
+  crawl dead-end. A `<noscript>` nav now ships in the server HTML with
+  `<a href="/browse">` plus two published recipe links, without changing the
+  JS-rendered UI
+  ([#3185](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3185),
+  TAS-2896, KAN-114).
+
 ### Fixed
 
 - **Google sign-in no longer dead-ends inside in-app browsers**: visitors who
@@ -17,7 +36,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   browser and, instead of firing a doomed consent redirect, shows an "open this
   page in Safari/Chrome to sign in" fallback with a copy-link button. Guest
   saving already works in-webview, so first-time saves are no longer blocked at
-  the conversion moment (TAS-2899).
+  the conversion moment
+  ([#3186](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3186),
+  TAS-2899, KAN-113).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Google sign-in no longer dead-ends inside in-app browsers**: visitors who
+  arrive from Pinterest (and Instagram/Facebook/etc.) view the site inside that
+  app's embedded webview, where Google blocks OAuth with
+  `Error 403: disallowed_useragent`. The sign-in dialog now detects the in-app
+  browser and, instead of firing a doomed consent redirect, shows an "open this
+  page in Safari/Chrome to sign in" fallback with a copy-link button. Guest
+  saving already works in-webview, so first-time saves are no longer blocked at
+  the conversion moment (TAS-2899).
+
+---
+
 ## [0.3.9] - 2026-07-19
 
 Stability and infrastructure release. Restores the Flask backend's shared

--- a/index.html
+++ b/index.html
@@ -122,5 +122,19 @@
   </head>
   <body class="bg-stone-50 text-stone-800 antialiased min-h-screen">
     <app-root></app-root>
+    <!--
+      SSR crawlable links. The Angular shell is otherwise a JS-only app-root,
+      so a crawler (or any no-JS client) hitting "/" finds no anchors and the
+      site's public SSR pages (/browse, /r/<slug>) become a crawl dead-end.
+      These live inside <noscript> so they add real, followable links to the
+      server HTML without changing the JS app's rendered UI.
+    -->
+    <noscript>
+      <nav aria-label="Recipe navigation">
+        <a href="/browse">Browse all vegan recipes</a>
+        <a href="/r/classic-vegan-margherita-pizza">Classic Vegan Margherita Pizza</a>
+        <a href="/r/vegan-cornbread">Vegan Cornbread</a>
+      </nav>
+    </noscript>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "dependencies": {
         "@angular/build": "22.0.7",
         "@angular/cli": "22.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.3.9",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "ng serve",

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -1279,56 +1279,86 @@
             </div>
           }
 
-          <!-- Google Sign-In Button -->
-          <button
-            (click)="onGoogleLogin()"
-            [disabled]="authLoginLoading()"
-            class="w-full flex items-center justify-center gap-3 px-6 py-4 bg-white border-2 border-stone-200 rounded-xl hover:bg-stone-50 hover:border-stone-300 disabled:opacity-70 transition-all duration-200 shadow-sm"
-          >
-            @if (authLoginLoading()) {
-              <svg
-                class="animate-spin h-5 w-5 text-stone-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
+          @if (isInAppBrowser()) {
+            <!-- In-app browser (Pinterest/Instagram/Facebook/…): Google blocks
+                 OAuth here with Error 403: disallowed_useragent, so offer an
+                 "open in your browser" fallback instead of a doomed sign-in.
+                 Guest saving still works — closing the dialog keeps everything
+                 in this browser. -->
+            <div class="rounded-xl border-2 border-amber-200 bg-amber-50 p-4 text-left">
+              <p class="text-sm font-semibold text-amber-900 mb-1">
+                Finish sign-in in your browser
+              </p>
+              <p class="text-sm text-amber-800">
+                You're viewing this inside another app, and Google won't let you sign in here. Open
+                this page in Safari or Chrome to sign in with Google.
+              </p>
+              <button
+                (click)="copyShareLink()"
+                class="mt-3 w-full flex items-center justify-center gap-2 px-4 py-3 bg-white border-2 border-amber-300 rounded-lg text-amber-900 font-semibold hover:bg-amber-100 transition-colors duration-200"
               >
-                <circle
-                  class="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  stroke-width="4"
-                ></circle>
-                <path
-                  class="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                ></path>
-              </svg>
-              <span class="text-stone-600 font-semibold">Connecting...</span>
-            } @else {
-              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
-                <path
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                  fill="#4285F4"
-                />
-                <path
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  fill="#EA4335"
-                />
-              </svg>
-              <span class="text-stone-700 font-semibold">Sign in with Google</span>
-            }
-          </button>
+                @if (copiedShareLink()) {
+                  <span>Link copied — paste it in your browser</span>
+                } @else {
+                  <span>Copy page link</span>
+                }
+              </button>
+              <p class="mt-2 text-xs text-amber-700">
+                Tip: tap the “⋯” or share menu, then “Open in Safari” / “Open in Chrome”.
+              </p>
+            </div>
+          } @else {
+            <!-- Google Sign-In Button -->
+            <button
+              (click)="onGoogleLogin()"
+              [disabled]="authLoginLoading()"
+              class="w-full flex items-center justify-center gap-3 px-6 py-4 bg-white border-2 border-stone-200 rounded-xl hover:bg-stone-50 hover:border-stone-300 disabled:opacity-70 transition-all duration-200 shadow-sm"
+            >
+              @if (authLoginLoading()) {
+                <svg
+                  class="animate-spin h-5 w-5 text-stone-500"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    class="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    stroke-width="4"
+                  ></circle>
+                  <path
+                    class="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                <span class="text-stone-600 font-semibold">Connecting...</span>
+              } @else {
+                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                  <path
+                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                    fill="#4285F4"
+                  />
+                  <path
+                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                    fill="#34A853"
+                  />
+                  <path
+                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                    fill="#FBBC05"
+                  />
+                  <path
+                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                    fill="#EA4335"
+                  />
+                </svg>
+                <span class="text-stone-700 font-semibold">Sign in with Google</span>
+              }
+            </button>
+          }
 
           <div class="relative my-6">
             <div class="absolute inset-0 flex items-center">

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from './services/auth.service';
 import { PersistenceService } from './services/persistence.service';
 import { buildSavedRecipeFromPublic } from './services/public-recipe.mapper';
 import { Ingredient, IngredientGroup, InstructionStep, Recipe } from './recipe.types';
+import { isInAppBrowserEnvironment } from './utils/in-app-browser';
 
 @Component({
   selector: 'app-root',
@@ -226,6 +227,18 @@ export class AppComponent {
   authError = signal<string | null>(null);
   authLoginLoading = signal<boolean>(false);
   showUserProfileCard = signal<boolean>(false);
+
+  /**
+   * True when we're running inside a third-party in-app browser (Pinterest,
+   * Instagram, Facebook, …) where Google OAuth returns
+   * `Error 403: disallowed_useragent`. When true the auth modal swaps the
+   * doomed "Sign in with Google" button for an "Open in your browser" fallback.
+   * Computed once from the User-Agent — it can't change without a reload.
+   */
+  readonly isInAppBrowser = signal<boolean>(isInAppBrowserEnvironment());
+
+  /** Transient confirmation after the user copies the page link in the fallback. */
+  copiedShareLink = signal<boolean>(false);
 
   // Recipe Gen State
   prompt = signal<string>('');
@@ -627,6 +640,15 @@ export class AppComponent {
   }
 
   async onGoogleLogin() {
+    // Google refuses OAuth inside embedded webviews (Error 403:
+    // disallowed_useragent). Firing login() here would bounce the user to a
+    // dead-end consent screen, so short-circuit to the "open in your browser"
+    // fallback instead.
+    if (this.isInAppBrowser()) {
+      this.authError.set(null);
+      return;
+    }
+
     this.authError.set(null);
     this.authLoginLoading.set(true);
 
@@ -637,6 +659,24 @@ export class AppComponent {
       const message = err instanceof Error ? err.message : 'Failed to start Google login';
       this.authError.set(message);
       this.authLoginLoading.set(false);
+    }
+  }
+
+  /**
+   * Copy the current page URL so the user can paste it into a real browser
+   * (Safari/Chrome) where Google sign-in works. Fallback path for in-app
+   * browsers — see {@link isInAppBrowser}. Best-effort: on clipboard failure
+   * the user has to copy from the address bar or the share menu (per the
+   * tip shown next to the button).
+   */
+  async copyShareLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      this.copiedShareLink.set(true);
+      setTimeout(() => this.copiedShareLink.set(false), 2500);
+    } catch {
+      // Clipboard API unavailable/blocked in some webviews — no-op; the
+      // adjacent "share menu" tip is the manual fallback.
     }
   }
 

--- a/src/utils/in-app-browser.test.ts
+++ b/src/utils/in-app-browser.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { isInAppBrowser } from './in-app-browser';
+
+describe('isInAppBrowser', () => {
+  it('returns false for empty / missing user agents', () => {
+    expect(isInAppBrowser('')).toBe(false);
+    expect(isInAppBrowser(null)).toBe(false);
+    expect(isInAppBrowser(undefined)).toBe(false);
+  });
+
+  it('detects the Pinterest in-app browser', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 ' +
+      '(KHTML, like Gecko) Mobile/15E148 [Pinterest/iOS]';
+    expect(isInAppBrowser(ua)).toBe(true);
+  });
+
+  it('detects the Facebook in-app browser', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 ' +
+      '(KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/470.0.0]';
+    expect(isInAppBrowser(ua)).toBe(true);
+  });
+
+  it('detects the Instagram in-app browser', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 ' +
+      '(KHTML, like Gecko) Mobile/15E148 Instagram 300.0.0.0';
+    expect(isInAppBrowser(ua)).toBe(true);
+  });
+
+  it('detects a generic Android System WebView (wv token)', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8; wv) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+      'Version/4.0 Chrome/126.0.0.0 Mobile Safari/537.36';
+    expect(isInAppBrowser(ua)).toBe(true);
+  });
+
+  it('returns false for real mobile Safari', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 ' +
+      '(KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+    expect(isInAppBrowser(ua)).toBe(false);
+  });
+
+  it('returns false for real Chrome on Android (no wv token)', () => {
+    const ua =
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+      'Chrome/126.0.0.0 Mobile Safari/537.36';
+    expect(isInAppBrowser(ua)).toBe(false);
+  });
+
+  it('returns false for desktop Chrome', () => {
+    const ua =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+      'Chrome/126.0.0.0 Safari/537.36';
+    expect(isInAppBrowser(ua)).toBe(false);
+  });
+});

--- a/src/utils/in-app-browser.ts
+++ b/src/utils/in-app-browser.ts
@@ -1,0 +1,74 @@
+/**
+ * In-app browser (embedded webview) detection.
+ *
+ * Google blocks OAuth inside embedded webviews with
+ * `Error 403: disallowed_useragent` (secure-browser policy, enforced since
+ * 2021-09-30). Visitors who arrive from a third-party app's in-app browser —
+ * most notably Pinterest, one of the largest referral sources for recipe
+ * sites — are trapped: tapping "Sign in with Google" fires a request Google
+ * refuses to render.
+ *
+ * These helpers detect that situation from the User-Agent string so the UI can
+ * offer an "Open in your browser to sign in" fallback instead of a doomed
+ * OAuth redirect. Detection is heuristic — User-Agents are not standardized —
+ * so it errs toward known in-app markers rather than guessing aggressively.
+ */
+
+/**
+ * User-Agent substrings that identify a known in-app browser / embedded
+ * webview. Matched case-insensitively. Ordered roughly by referral relevance
+ * for a recipe site (Pinterest first).
+ */
+const IN_APP_BROWSER_MARKERS: readonly string[] = [
+  'Pinterest', // Pinterest in-app browser — the primary recipe-referral trigger
+  'FBAN', // Facebook app (iOS)
+  'FBAV', // Facebook app (version token, iOS/Android)
+  'FB_IAB', // Facebook in-app browser (Android)
+  'FBIOS',
+  'Instagram',
+  'Line/', // LINE messenger
+  'Twitter', // legacy Twitter app
+  'TwitterAndroid',
+  'LinkedInApp',
+  'Snapchat',
+  'musical_ly', // TikTok (legacy token)
+  'Bytedance', // TikTok / Bytedance webviews
+  'TikTok',
+  'WhatsApp',
+  'GSA/', // Google Search App in-app browser
+];
+
+/**
+ * Returns true when the given User-Agent looks like a known third-party
+ * in-app browser / embedded webview where Google OAuth is blocked.
+ *
+ * Pure and side-effect free so it can be unit tested and called safely on the
+ * server during SSR (pass `''` when no UA is available).
+ */
+export function isInAppBrowser(userAgent: string | null | undefined): boolean {
+  if (!userAgent) return false;
+  const ua = userAgent.toLowerCase();
+
+  if (IN_APP_BROWSER_MARKERS.some((marker) => ua.includes(marker.toLowerCase()))) {
+    return true;
+  }
+
+  // Generic Android System WebView: Chrome's mobile UA plus the `; wv` token
+  // (or the legacy `Version/x.x` + Chrome combo used by many wrapped apps).
+  // Real Chrome for Android never carries `; wv`.
+  if (ua.includes('android') && ua.includes('wv')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Browser-safe wrapper around {@link isInAppBrowser} that reads the current
+ * navigator's User-Agent. Returns false during SSR (no `navigator`), where an
+ * OAuth redirect never originates anyway.
+ */
+export function isInAppBrowserEnvironment(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return isInAppBrowser(navigator.userAgent);
+}


### PR DESCRIPTION
## Release v0.4.0 (Sprint 1 close — KAN-110)

dev → main release PR. Merging this (merge commit, not squash) triggers `release.yml`: tag `v0.4.0` + GitHub Release, and the Cloud Build tag trigger deploys both services.

### Ships
- **feat(seo):** SSR crawlable links on the home shell (#3185, TAS-2896, KAN-114) — ends the home crawl dead-end.
- **fix(auth):** browser fallback for Google sign-in inside in-app webviews (#3186, TAS-2899, KAN-113).
- **chore(release):** version 0.3.9 → 0.4.0 + CHANGELOG (#3191).

### Notes
- No schema migration (migrate Job will no-op).
- Backend submodule pointer unchanged at `18a303a` (Backend dev == main tip; no Backend promotion needed this release).
- Sprint 1 DONE gate (owner amendment in `specs/SPRINT_1_PLAN.md`): this release + Cloud Build SUCCESS + both services serving v0.4.0 + live 200 closes the sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBVGVmqmwiyTThD4dUSuXs
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

