### PR TITLE
fix(ux): show public-recipe View link without publish rights (KAN-119)

### DIFF
--- a/specs/KAN-119_LOOP_PLAN.md
+++ b/specs/KAN-119_LOOP_PLAN.md
@@ -1,0 +1,46 @@
+# KAN-119 Fix Loop — iOS: public-recipe View link hidden for guests/webview visitors
+
+_2026-07-20 · Owner: Adam · Executor: agent (this loop) · Sprint-2 early-drive (C8), Adam-directed
+ahead of charter lock. Vocabulary: **`fix/`** branch off `dev` (not "hotfix" — that means an
+emergency branch off `main` here; this rides the normal dev → release train)._
+
+## Defect (from KAN-119, code-confirmed)
+
+The My Kitchen "View" link to `/r/<slug>` renders only under `@if (canPublish() && r.is_public)`
+(`src/app.component.html:402`); `canPublish()` requires a signed-in **non-guest**
+(`src/app.component.ts:968-971`). Guests — and iOS in-app-webview visitors who cannot sign in at
+all — never get a path to an already-public recipe's page. Viewing needs no publish rights.
+
+The auth-coupling also means _any_ iOS auth-state hiccup (slow restore, dropped session) hides the
+link. The fix removes the auth dependency entirely, so it is robust to whichever variant Adam hit.
+
+## Fix design (scope fence: this conditional only — no other UI changes)
+
+1. New pure util `src/utils/public-link.ts`: `isPublicViewable(r): boolean` → `!!r.is_public && !!r.slug`
+   (slug guard: never render `href="/r/undefined"`). Mirrors the `in-app-browser.ts` util+spec
+   pattern #3186 established.
+2. `app.component.ts`: thin delegate `isPublicViewable(r)` calling the util.
+3. Template `:402`: `@if (canPublish() && r.is_public)` → `@if (isPublicViewable(r))`.
+   The publish **toggle** (`:363`) stays behind `canPublish()` — unchanged.
+
+## Tasks & machine gates (budgets: 3 attempts/task, 12 iterations)
+
+| #   | Task                                                                                                                                                                              | Gate (must exit 0)                                                                                                                       |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | Branch `fix/public-view-link-guest-visibility` off `origin/dev`                                                                                                                   | branch exists on the dev tip                                                                                                             |
+| T2  | **Test first**: `src/utils/public-link.spec.ts` — public+slug → true; guest-irrelevance (no auth input at all); `is_public` false → false; missing slug → false. Red before impl. | `npx vitest run src/utils/public-link.spec.ts` fails pre-impl, passes post-impl                                                          |
+| T3  | Implement util + component delegate + template swap                                                                                                                               | `git diff --stat` touches exactly 3 files + the spec                                                                                     |
+| T4  | Local quality gates                                                                                                                                                               | `npm run lint` · `npm run type-check` · `npm test -- --run` · `npm run build` all exit 0; built `dist/` still contains the anchor markup |
+| T5  | PR into `dev`, title `fix(ux): show public-recipe View link without publish rights (KAN-119)`, monitor to green                                                                   | required checks (Gate/Analyze/DepReview) SUCCESS                                                                                         |
+| T6  | Merge (squash) + Jira KAN-119 → Done with evidence; note in ux-backlog #6                                                                                                         | PR MERGED · KAN-119 Done                                                                                                                 |
+
+## Terminal states
+
+merged-to-dev+Jira-Done (**"ready"** — ships to prod in the next release, e.g. v0.4.1/v0.5.0;
+release itself is a separate Adam call) · escalate-with-finding (if any gate can't pass in 3
+attempts).
+
+## Post-release verification (deferred, lands with next release)
+
+Signed-out iOS visit shows View on a published recipe — the KAN-119 proving gate; also closes
+ux-backlog #6.

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -399,7 +399,7 @@
                       Sign in to publish
                     </button>
                   }
-                  @if (canPublish() && r.is_public) {
+                  @if (isPublicViewable(r)) {
                     <!-- Link to the published page. The slug is derived and
                          enforced server-side (not user-editable), so we show a
                          plain "View" affordance instead of the raw /r/<slug>,

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -7,6 +7,7 @@ import { PersistenceService } from './services/persistence.service';
 import { buildSavedRecipeFromPublic } from './services/public-recipe.mapper';
 import { Ingredient, IngredientGroup, InstructionStep, Recipe } from './recipe.types';
 import { isInAppBrowserEnvironment } from './utils/in-app-browser';
+import { isPublicViewable } from './utils/public-link';
 
 @Component({
   selector: 'app-root',
@@ -1009,6 +1010,12 @@ export class AppComponent {
     const user = this.authService.currentUser();
     return !!user && user.isGuest === false;
   });
+
+  /** KAN-119: the View link renders from recipe data alone — viewing a public
+   *  page needs no publish rights, unlike the toggle above. */
+  isPublicViewable(recipe: Recipe): boolean {
+    return isPublicViewable(recipe);
+  }
 
   async togglePublic(recipe: Recipe) {
     if (!this.canPublish()) {

--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isPublicViewable } from './public-link';
+
+// KAN-119: the View link to /r/<slug> must not depend on auth state — a
+// published recipe's public page is viewable by anyone, so the link renders
+// from recipe data alone (guests and in-app-webview visitors included).
+describe('isPublicViewable', () => {
+  it('is true for a published recipe with a slug', () => {
+    expect(isPublicViewable({ is_public: true, slug: 'vegan-cornbread' })).toBe(true);
+  });
+
+  it('takes no auth input at all — visibility is a pure function of the recipe', () => {
+    // Regression guard for KAN-119: the old template condition was
+    // canPublish() && is_public, which hid the link from guests/webview users.
+    expect(isPublicViewable.length).toBe(1);
+  });
+
+  it('is false when the recipe is not public', () => {
+    expect(isPublicViewable({ is_public: false, slug: 'vegan-cornbread' })).toBe(false);
+    expect(isPublicViewable({ slug: 'vegan-cornbread' })).toBe(false);
+  });
+
+  it('is false without a slug — never renders href="/r/undefined"', () => {
+    expect(isPublicViewable({ is_public: true })).toBe(false);
+    expect(isPublicViewable({ is_public: true, slug: '' })).toBe(false);
+  });
+});

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -1,0 +1,14 @@
+/**
+ * KAN-119 — visibility rule for the "View" link to a recipe's public page.
+ *
+ * Deliberately a pure function of recipe data with no auth input: viewing a
+ * public /r/<slug> page requires no publish rights, so the link must render
+ * for guests and in-app-webview visitors (who may be unable to sign in at
+ * all — see in-app-browser.ts). Publishing stays gated by canPublish().
+ *
+ * The slug guard prevents ever rendering href="/r/undefined" for a recipe
+ * whose public flag is set but whose server-derived slug hasn't synced yet.
+ */
+export function isPublicViewable(recipe: { is_public?: boolean; slug?: string }): boolean {
+  return recipe.is_public === true && !!recipe.slug;
+}


### PR DESCRIPTION
## Problem

Adam's iOS field report (2026-07-20, post-v0.4.0): the browser still hides the link to a recipe's public page. Root cause: the My Kitchen **View** link renders under `@if (canPublish() && r.is_public)` (`app.component.html:402`), and `canPublish()` requires a signed-in non-guest (`app.component.ts`). Guests — and iOS in-app-webview visitors who *cannot* sign in (Google `disallowed_useragent`; #3186 gives them a fallback panel, not auth) — never see the path to an already-public recipe. Any iOS auth-state hiccup hides it too.

## Fix

Viewing a public page needs no publish rights, so the link's visibility is now a **pure function of recipe data**, with no auth input:

- `src/utils/public-link.ts` — `isPublicViewable(r) = is_public && slug` (slug guard: never `href="/r/undefined"`). Mirrors the `in-app-browser.ts` util+spec pattern from #3186.
- Template `:402` → `@if (isPublicViewable(r))`. The publish **toggle** stays behind `canPublish()` — unchanged.
- TDD: spec written red-first; 4 tests incl. an arity regression guard (no auth parameter).

## Gates (specs/KAN-119_LOOP_PLAN.md, delivery-loop PLAN-OK)

- [x] `npx vitest run src/utils/public-link.spec.ts` — 4/4 (red before impl)
- [x] Scope: exactly 4 src files + loop doc
- [x] `npm run lint` 0 · `npm run type-check` 0 · `npm run build` 0 (noscript anchors survive in `dist/`)
- [x] Full vitest: 133 passed; only the pre-existing `server/redirects.test.ts` favicon failure (documented in #3185 as reproducing on clean dev; `server/` untouched here)

Closes KAN-119. Post-release proving gate: signed-out iOS visit shows View on a published recipe (ux-backlog #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBVGVmqmwiyTThD4dUSuXs
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

