### PR TITLE
fix(ux): resolve public View link through sourceSlug for saved-from-public copies (KAN-119)

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -405,11 +405,11 @@
                          plain "View" affordance instead of the raw /r/<slug>,
                          which read as clutter next to the toggle. -->
                     <a
-                      [href]="'/r/' + r.slug"
+                      [href]="'/r/' + publicSlugOf(r)"
                       target="_blank"
                       rel="noopener noreferrer"
                       class="inline-flex items-center gap-1 ml-1 text-xs font-semibold text-stone-500 hover:text-green-600 transition-colors animate-[fadeIn_0.2s]"
-                      [title]="'View public page: /r/' + r.slug"
+                      [title]="'View public page: /r/' + publicSlugOf(r)"
                     >
                       View
                       <svg

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -7,7 +7,7 @@ import { PersistenceService } from './services/persistence.service';
 import { buildSavedRecipeFromPublic } from './services/public-recipe.mapper';
 import { Ingredient, IngredientGroup, InstructionStep, Recipe } from './recipe.types';
 import { isInAppBrowserEnvironment } from './utils/in-app-browser';
-import { isPublicViewable } from './utils/public-link';
+import { isPublicViewable, publicSlugOf } from './utils/public-link';
 
 @Component({
   selector: 'app-root',
@@ -1015,6 +1015,12 @@ export class AppComponent {
    *  page needs no publish rights, unlike the toggle above. */
   isPublicViewable(recipe: Recipe): boolean {
     return isPublicViewable(recipe);
+  }
+
+  /** Slug of the public page this recipe links to (own published slug, else
+   *  the sourceSlug it was saved from). Null when there is none. */
+  publicSlugOf(recipe: Recipe): string | null {
+    return publicSlugOf(recipe);
   }
 
   async togglePublic(recipe: Recipe) {

--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -1,12 +1,48 @@
 import { describe, it, expect } from 'vitest';
-import { isPublicViewable } from './public-link';
+import { isPublicViewable, publicSlugOf } from './public-link';
 
 // KAN-119: the View link to /r/<slug> must not depend on auth state — a
 // published recipe's public page is viewable by anyone, so the link renders
 // from recipe data alone (guests and in-app-webview visitors included).
+//
+// Follow-up (adversarial review of #3195): guest-saved copies carry only
+// sourceSlug (public-recipe.mapper.ts) — the link must resolve through it,
+// or the fix never fires for actual guests.
+describe('publicSlugOf', () => {
+  it("resolves the recipe's own slug when it is published", () => {
+    expect(publicSlugOf({ is_public: true, slug: 'vegan-cornbread' })).toBe('vegan-cornbread');
+  });
+
+  it('prefers the own published slug over sourceSlug', () => {
+    expect(publicSlugOf({ is_public: true, slug: 'my-remix', sourceSlug: 'vegan-cornbread' })).toBe(
+      'my-remix'
+    );
+  });
+
+  it('falls back to sourceSlug for copies saved from a public page (guest case)', () => {
+    // Exactly what buildSavedRecipeFromPublic produces: no is_public, no slug.
+    expect(publicSlugOf({ sourceSlug: 'vegan-cornbread' })).toBe('vegan-cornbread');
+    expect(publicSlugOf({ is_public: false, sourceSlug: 'vegan-cornbread' })).toBe(
+      'vegan-cornbread'
+    );
+  });
+
+  it('is null when there is no public page to link to', () => {
+    expect(publicSlugOf({})).toBeNull();
+    expect(publicSlugOf({ is_public: false, slug: 'draft' })).toBeNull();
+    expect(publicSlugOf({ is_public: true })).toBeNull();
+    expect(publicSlugOf({ is_public: true, slug: '' })).toBeNull();
+    expect(publicSlugOf({ sourceSlug: '' })).toBeNull();
+  });
+});
+
 describe('isPublicViewable', () => {
   it('is true for a published recipe with a slug', () => {
     expect(isPublicViewable({ is_public: true, slug: 'vegan-cornbread' })).toBe(true);
+  });
+
+  it('is true for a guest-saved copy carrying only sourceSlug', () => {
+    expect(isPublicViewable({ sourceSlug: 'vegan-cornbread' })).toBe(true);
   });
 
   it('takes no auth input at all — visibility is a pure function of the recipe', () => {
@@ -15,13 +51,9 @@ describe('isPublicViewable', () => {
     expect(isPublicViewable.length).toBe(1);
   });
 
-  it('is false when the recipe is not public', () => {
+  it('is false when the recipe has no public page', () => {
     expect(isPublicViewable({ is_public: false, slug: 'vegan-cornbread' })).toBe(false);
-    expect(isPublicViewable({ slug: 'vegan-cornbread' })).toBe(false);
-  });
-
-  it('is false without a slug — never renders href="/r/undefined"', () => {
     expect(isPublicViewable({ is_public: true })).toBe(false);
-    expect(isPublicViewable({ is_public: true, slug: '' })).toBe(false);
+    expect(isPublicViewable({})).toBe(false);
   });
 });

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -6,9 +6,30 @@
  * for guests and in-app-webview visitors (who may be unable to sign in at
  * all — see in-app-browser.ts). Publishing stays gated by canPublish().
  *
- * The slug guard prevents ever rendering href="/r/undefined" for a recipe
- * whose public flag is set but whose server-derived slug hasn't synced yet.
+ * Two ways a recipe has a public page:
+ *  - it is itself published (`is_public` + server-derived `slug`), or
+ *  - it was saved from a public page and remembers it via `sourceSlug`
+ *    (buildSavedRecipeFromPublic copies neither is_public nor slug — the
+ *    guest case would silently never link without this fallback).
+ * The own published slug wins when both exist. A sourceSlug target can have
+ * been unpublished since saving; worst case is a 404 on a public route, not
+ * a leak.
  */
-export function isPublicViewable(recipe: { is_public?: boolean; slug?: string }): boolean {
-  return recipe.is_public === true && !!recipe.slug;
+export function publicSlugOf(recipe: {
+  is_public?: boolean;
+  slug?: string;
+  sourceSlug?: string;
+}): string | null {
+  if (recipe.is_public === true && recipe.slug) {
+    return recipe.slug;
+  }
+  return recipe.sourceSlug || null;
+}
+
+export function isPublicViewable(recipe: {
+  is_public?: boolean;
+  slug?: string;
+  sourceSlug?: string;
+}): boolean {
+  return publicSlugOf(recipe) !== null;
 }


### PR DESCRIPTION
## Why (follow-up to #3195)

The Independent Claude review job on #3195 **failed without posting** (completed/failure — no review landed), so a compensating adversarial review was run on the merged diff. It confirmed the fix but found one medium gap:

> `buildSavedRecipeFromPublic` (`public-recipe.mapper.ts:31`) copies `sourceSlug` but **omits `is_public` and `slug`** — so a pure guest who saves a recipe from a public page gets a copy for which `isPublicViewable()` is false. The #3195 fix only fired for signed-in users' own published recipes; KAN-119's flagship guest/iOS scenario was still unmet.

## Fix

- `publicSlugOf(r)`: own published slug (`is_public && slug`) wins, else `sourceSlug`, else null. `isPublicViewable(r) = publicSlugOf(r) !== null`.
- Template href/title resolve through `publicSlugOf(r)` (previously hardcoded `r.slug` — would have rendered `/r/undefined` for sourceSlug-only copies).
- A `sourceSlug` target can have been unpublished since saving: worst case is a 404 on a public route, not a leak (`/r/` serves only public recipes).

## Gates

- [x] TDD: extended spec red (5 failing) → 8/8 green (guest fallback, precedence, null cases, no-auth-input arity guard)
- [x] `npm run lint` 0 · `npm run type-check` 0 · `npm run build` 0

Completes KAN-119's proving gate scope: signed-out iOS visit shows View on a guest-saved public recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBVGVmqmwiyTThD4dUSuXs
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

