### PR TITLE
chore(release): bump 0.4.0 → 0.4.1 + CHANGELOG [KAN-119]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+---
+
+## [0.4.1] - 2026-07-20
+
+Follow-up fix release: makes a published recipe's public page reachable from
+My Kitchen for everyone, not just its publisher. No schema migration.
+
 ### Fixed
 
 - **Public-recipe "View" link no longer requires publish rights**: the My
   Kitchen link to `/r/<slug>` was gated on being a signed-in non-guest, hiding
   it from guests and in-app-webview visitors (who cannot sign in at all).
-  Visibility is now a pure function of recipe data (`is_public` + slug); the
-  publish toggle stays auth-gated
+  Visibility is now a pure function of recipe data; the publish toggle stays
+  auth-gated
   ([#3195](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3195),
+  KAN-119).
+- **View link also resolves for copies saved from a public page**: guest-saved
+  copies carry only `sourceSlug`, so the link now falls back to it (own
+  published slug wins when both exist) — without this the fix above never
+  fired for the guest case it targeted
+  ([#3197](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3197),
   KAN-119).
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@angular/build": "22.0.7",
         "@angular/cli": "22.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
Version bump + `[0.4.1] - 2026-07-20` CHANGELOG section (View-link fix #3195 + sourceSlug follow-up #3197, both KAN-119). No schema migration. Bump lands on dev first per the release flow; dev → main PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBVGVmqmwiyTThD4dUSuXs
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

