### PR TITLE
refactor(view-link): fold isPublicViewable/publicSlugOf to readonly fields (KAN-119) [KAN-119]

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -1011,17 +1011,12 @@ export class AppComponent {
     return !!user && user.isGuest === false;
   });
 
-  /** KAN-119: the View link renders from recipe data alone — viewing a public
-   *  page needs no publish rights, unlike the toggle above. */
-  isPublicViewable(recipe: Recipe): boolean {
-    return isPublicViewable(recipe);
-  }
-
-  /** Slug of the public page this recipe links to (own published slug, else
-   *  the sourceSlug it was saved from). Null when there is none. */
-  publicSlugOf(recipe: Recipe): string | null {
-    return publicSlugOf(recipe);
-  }
+  /** The View link renders from recipe data alone — viewing a public
+   *  page needs no publish rights, unlike the toggle above. Exposed as
+   *  fields so a same-named class method can't accidentally recurse into
+   *  itself via a stray `this.` in a future refactor. */
+  readonly isPublicViewable = isPublicViewable;
+  readonly publicSlugOf = publicSlugOf;
 
   async togglePublic(recipe: Recipe) {
     if (!this.canPublish()) {

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -1,10 +1,10 @@
 /**
- * KAN-119 — visibility rule for the "View" link to a recipe's public page.
+ * Visibility rule for the "View" link to a recipe's public page.
  *
  * Deliberately a pure function of recipe data with no auth input: viewing a
  * public /r/<slug> page requires no publish rights, so the link must render
  * for guests and in-app-webview visitors (who may be unable to sign in at
- * all — see in-app-browser.ts). Publishing stays gated by canPublish().
+ * all — see in-app-browser.ts). Publishing stays gated separately.
  *
  * Two ways a recipe has a public page:
  *  - it is itself published (`is_public` + server-derived `slug`), or


### PR DESCRIPTION
## Description

Follow-up cleanup from the independent Claude review on #3199 (already merged/shipped as v0.4.1). Two small, non-functional fixes:

- **`src/app.component.ts`** — `isPublicViewable`/`publicSlugOf` were class methods with the same names as the module-level functions they delegate to (`import { isPublicViewable, publicSlugOf } from './utils/public-link'`). It only worked because a JS method body doesn't lexically scope its own name, so the unqualified call inside resolved to the import, not `this`. A future refactor that added `this.` (editor codemod, "prefix self-references" cleanup) would silently produce infinite recursion on every recipe render, with no compile error. Folded both to `readonly` class fields pointing straight at the imports — same call syntax from the template (`isPublicViewable(r)`, `publicSlugOf(r)`), zero shadow risk.
- **`src/utils/public-link.ts`** — stripped a `KAN-119 —` ticket reference from the JSDoc per this repo's `CLAUDE.md` convention ("Don't reference the current task, fix, or callers... those belong in the PR description and rot as the codebase evolves"). Kept the substantive WHY.

## Related Issues

Relates to #3199 (KAN-119 View-link fix)

## Type of Change

- [x] Refactoring (no functional changes)

## Testing

- [x] Tests pass locally (`npx vitest run src/app.component.test.ts src/utils/public-link.spec.ts` — 32/32 passed)
- [x] Linting passes (`npx eslint` on both changed files — clean)
- [x] Code is formatted (`npx prettier --check` — clean)
- [x] Type checking passes (`npm run type-check` — clean)

Template usage was checked first (`src/app.component.html:402,408,412`) — both are always called (`isPublicViewable(r)`, `publicSlugOf(r)`), so the method→field change is transparent.

## Additional Notes

Not addressed here — a separate scope call flagged in the same review, left for Adam: `findings.md` and `pintrest-research.md` at repo root (unrelated to KAN-119, unlinked from anywhere; the latter also misspelled). Not moved/renamed unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWP5ysDeKa5E2TLHwwCcpR)_






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

