### PR TITLE
docs(arch): Angular SPA architecture upgrade planning documents

### DIFF
--- a/docs/ANGULAR-SPA-ARCH-UPGRADE/angular-arch-upgrade-devex-why.md
+++ b/docs/ANGULAR-SPA-ARCH-UPGRADE/angular-arch-upgrade-devex-why.md
@@ -1,0 +1,100 @@
+# Angular SPA Architecture Upgrade — The WHY and WHY NOW
+
+> Companion to: **Angular SPA Architecture Upgrade — Review & PRD Planning Prompt**
+> (that document defines the WHAT and the GOAL; this one tells the story that makes them urgent)
+
+---
+
+## The Developer Experience Case
+
+The Flask backend went through a clean refactoring arc: a 1,200-line `app.py` became a ~100-line composition root with modular blueprints, a service layer, repositories, and validators. That transformation took two deliberate steps and produced a production-grade system on the first deploy. The architecture now absorbs change efficiently — a new endpoint is a new blueprint file, a new business rule is a new service method, a new validation concern is a new schema.
+
+The Angular SPA never had that moment. It shipped as a Gemini AI Studio prototype and has been patched forward ever since. Every change — no matter how small in product terms — must be threaded through a single 1,096-line component class and a 2,028-line template. The cost of this is no longer theoretical. It is measurable in deploy frequency, session burn, and spec drift.
+
+---
+
+## Exhibit A: The Public Link (v0.3.8 → v0.4.1)
+
+The product requirement is straightforward: when a user publishes a recipe, show them a link to the public page (`/r/<slug>`) so they can share it.
+
+The link exists. It renders as a "View" anchor tag inline in the recipe detail view, next to the publish toggle. It opens `/r/<slug>` in a new tab. The implementation is technically correct.
+
+The problem is that a user cannot find it without prior knowledge of its existence.
+
+There is no routing — the entire app is two view states (`generator` and `kitchen`) toggled by a signal. There is no URL that leads to a specific recipe's detail view. The publish toggle and its sibling "View" link are buried inside a recipe detail expansion that the user must manually open within the kitchen view. The link has no visual prominence, no onboarding cue, no share-sheet pattern, no toast confirmation after publishing that surfaces the URL. It is a correct implementation rendered invisible by the architecture that contains it.
+
+This single UX gap — "user publishes a recipe and cannot find the shareable link" — has consumed:
+
+| Resource | Amount |
+|---|---|
+| Production deploys touching the public link flow | 4 (v0.3.8, v0.3.9, v0.4.0, v0.4.1) |
+| GitHub / Linear / Jira issues filed | ~6 |
+| Claude Code agent sessions | ~12 |
+| Cached token writes (Opus 4.8 / Fable 5) | 30–49M |
+| Output tokens | 10–12M |
+| Calendar time | v0.3.7 (Jul 17) → v0.4.1 (Jul 20) = 3 days of concentrated effort |
+
+Each session and each patch addressed symptoms: link visibility for non-publishers, link visibility for saved copies, slug derivation logic, toggle state sync. None addressed the root cause: **there is no component architecture that can give this link a proper home.** In a routed, decomposed app, the public link would live in a `RecipeDetailComponent` with its own URL (`/kitchen/recipe/:id`), a share action in a toolbar, and a post-publish confirmation flow. In the current monolith, it is a conditional `@if` block at line 408 of a 2,028-line template, discoverable only by scrolling.
+
+The architecture does not resist this fix. It resists *every* fix at this level of UX specificity.
+
+---
+
+## Exhibit B: The Patch Treadmill (v0.3.0 → v0.4.1)
+
+The version history from v0.3.0 onward tells a consistent story: each release is a corrective patch for the last, and each patch is a production deploy (`environment=production`, tag → build → deploy).
+
+| Version | Date | What happened |
+|---|---|---|
+| v0.3.0 | Jul 4 | SSR recipe/browse pages, Save-to-Cookbook CTA, Angular 22. **Failed to deploy** — 14 missing runtime deps from a corrupted `requirements.txt` export. |
+| v0.3.1 | Jul 4 | Hotfix for v0.3.0 deploy failure. |
+| v0.3.2 | Jul 5 | SSR styling fix, async retry, sitemap unshadow. |
+| v0.3.3 | Jul 11 | Editing regressions, auth-gated publishing, monitoring connector. |
+| v0.3.4 | Jul 15 | Security, Datadog, CSP, Express validation. **Never reached production** — Dockerfile parse error. |
+| v0.3.5 | Jul 15 | Deploy repair for v0.3.4. |
+| v0.3.6 | Jul 15 | Google OAuth CSP regression fix (caused by v0.3.4/v0.3.5). |
+| v0.3.7 | Jul 17 | Removed free-form slug input; slug is now server-derived. |
+| v0.3.8 | Jul 18 | Apex-to-www redirect, robots.txt, favicon, trailing-slash redirect. |
+| v0.3.9 | Jul 19 | Valkey cache fix, double-save guard, mobile hero clip fix. |
+| v0.4.0 | Jul 20 | SSR crawlable home-shell links, in-app-browser sign-in fallback. |
+| v0.4.1 | Jul 20 | Fix: public View link visibility for non-publishers and saved copies. |
+
+That is **12 releases in 16 calendar days**. Two failed to deploy at all (v0.3.0, v0.3.4). Three were immediate hotfixes for the release that preceded them (v0.3.1, v0.3.5, v0.3.6). The remainder are incremental corrections — each individually reasonable, collectively a signal that the frontend architecture does not absorb change cleanly.
+
+Compare to the Backend over the same period: its changes landed as part of the cookbook releases but required no dedicated hotfix cycle. The modular blueprint architecture meant that an SSR template change, a new API endpoint, or a cache integration each landed in isolation without cascading regressions.
+
+---
+
+## Exhibit C: Spec Drift (v0.2.0 → v0.4.1)
+
+The v0.2.0 release (Apr 29) was titled **"Anti-Recipe Site"** and established the product vision that still drives the backlog:
+
+- Sub-500ms SSR public recipe pages at `/r/<slug>`
+- JSON-LD structured data for SEO
+- "Save to Your Cookbook" CTA converting anonymous visitors into SPA users
+- `/browse` page with paginated public recipe grid
+- Honest, crawlable URLs
+
+This vision is documented in `specs/roadmap.md` (strategic phases), `specs/plan.md` (tactical checklist with wireframes), and `specs/design-plan.md` (template architecture and CSS tokens). These documents were written during the v0.2.x cycle and reference v0.2.0 conventions throughout.
+
+The codebase is now at v0.4.1. The SSR pages exist and work. The CTA exists and works. But the backlog items that remain open — the ones filed against the original v0.2.0 vision — are still written in v0.2.0 language, reference v0.2.0 architecture assumptions, and carry v0.2.0 acceptance criteria. The specs have not been updated to reflect what was built, what changed, and what "done" means at the current version.
+
+This is not a documentation problem. It is a planning problem. When the spec artifacts belong to v0.2.x and the codebase is at v0.4.x, every planning session starts with implicit translation work: what did this ticket mean when it was written, what does the codebase look like now, and what would "done" actually mean today? That translation burns agent sessions, produces ambiguous acceptance criteria, and creates the conditions for the patch treadmill described above.
+
+---
+
+## Why Now
+
+Three forces converge:
+
+1. **The Backend sets the standard.** The Flask backend is modular, testable, and deploys cleanly. The Express proxy layer is production-grade. The Angular SPA is the only tier that has not been through a deliberate architecture upgrade. The system's weakest link determines its overall development velocity, and that link is now clearly identified.
+
+2. **The cost of incremental patching has exceeded the cost of restructuring.** Twelve releases in sixteen days, two deploy failures, three hotfix chains, and a persistent UX issue that resists resolution because the architecture cannot give it a proper component home. The next feature that requires precise UX placement — and there will be one — will repeat this cycle.
+
+3. **The spec-to-code gap is widening, not closing.** Planning artifacts reference a v0.2.0 world. The codebase is at v0.4.1. Each planning session spends tokens bridging that gap instead of advancing the product. An architecture upgrade is the forcing function that resets the specs to match the system as built and establishes the component vocabulary that future tickets can reference unambiguously.
+
+---
+
+## What This Document Is Not
+
+This is not a retrospective. It is not a critique of any individual decision — the prototype shipped, found users, and proved the product. This document records the observable cost of operating a prototype architecture at production scale, and establishes the developer experience case for the upgrade plan defined in the companion document.

--- a/docs/ANGULAR-SPA-ARCH-UPGRADE/angular-arch-upgrade-prompt.md
+++ b/docs/ANGULAR-SPA-ARCH-UPGRADE/angular-arch-upgrade-prompt.md
@@ -1,0 +1,91 @@
+# Angular SPA Architecture Upgrade — Review & PRD Planning Prompt
+
+## Context
+
+You are reviewing **Vegangenius Chef**, a vegan recipe generator and personal cookbook app. The system has three tiers: an Angular 22 SPA, an Express reverse proxy, and a Flask API backend. The Flask backend has already been through a rigorous refactoring — from a 1,200-line monolithic `app.py` to a ~100-line composition root with modular blueprints, service/repository layers, validators, and proper separation of concerns. It is production-grade, deployed on Cloud Run, and hardened.
+
+The Angular SPA has not undergone the same transformation. It remains in the state it was originally generated as a Gemini AI Studio prototype. The frontend needs to be "graduated" to match the architectural quality of the backend.
+
+## Current SPA State (Verified)
+
+| Dimension | Current State |
+|---|---|
+| Components | **1** — the entire app is a single `AppComponent` (1,096 lines TS, 2,028 lines HTML) |
+| Services | 3 (`GeminiService`, `AuthService`, `PersistenceService`) + 1 mapper utility |
+| Routing | **None** — no `@angular/router`; view switching via a `signal<'generator' \| 'kitchen'>` and manual `pushState`/`popstate` |
+| State management | Angular Signals on `AppComponent` + `AuthService`; ~30 independent UI-state signals, minimal `computed()` derivations |
+| HTTP layer | Raw `fetch()` — no `HttpClient`, no interceptors, no centralized error handling |
+| Forms | Template-driven (`FormsModule`, `[(ngModel)]`); no validation beyond name-not-empty |
+| Code splitting | None — single bundle, no lazy loading |
+| Polling | Unbounded `setInterval(2000)` with no timeout cap |
+| Config | Hardcoded values; environment files contain only `production` and `flaskApiUrl` (both empty strings) |
+| Tests | Service/utility tests exist; component testing blocked by monolith size |
+| Express proxy | **Already production-grade** — separated concerns, graceful shutdown, validation, distributed rate limiting, proper error handling |
+
+## What the Backend Got Right (The Quality Bar)
+
+The Flask backend refactoring established patterns the frontend should match in spirit:
+
+- **Composition root** — `app.py:create_app()` registers blueprints and extensions; no business logic in the entry point
+- **Modular blueprints** — each domain (auth, recipes, collections, generation, worker) has its own blueprint with focused routes
+- **Service layer** — business logic in `services/` (Gemini, image, stock images), decoupled from HTTP handling
+- **Repository layer** — data access with file locking and DB abstraction
+- **Validators** — JSON Schema Draft 7 validation at system boundaries
+- **Configuration** — env-driven config with fail-fast on missing production secrets
+
+## Task
+
+Produce two deliverables:
+
+### 1. Codebase Review
+
+Assess the Angular SPA against production readiness. For each area, state the current condition, the gap, and the severity (critical / significant / minor):
+
+- **Component architecture** — decomposition, single responsibility, reusability
+- **Routing and navigation** — URL-driven state, deep linking, route guards, lazy loading
+- **State management** — signal architecture, derived state, cross-component communication
+- **HTTP and API layer** — client abstraction, interceptors, error handling, retry/timeout
+- **Forms and validation** — reactive forms, field-level validation, user feedback
+- **Performance** — bundle size, code splitting, change detection strategy
+- **Testability** — component isolation, service mocking, coverage gaps
+- **Configuration and environment** — externalized config, feature flags
+- **Accessibility and UX patterns** — keyboard nav, screen readers, loading states, error states
+
+### 2. PRD: Angular Architecture Upgrade
+
+Structure the PRD as follows:
+
+**Objective:** Graduate the Angular SPA from a single-component prototype to a production-grade Angular 22 application with proper decomposition, routing, state management, and operational readiness — matching the quality standard already established by the Flask backend.
+
+**Scope boundaries:**
+- IN: Architectural refactoring, component decomposition, routing, state management, HTTP layer, forms, testing infrastructure
+- OUT: New features, backend API changes, Express proxy changes, UI redesign (visual design stays the same)
+- CONSTRAINT: The Express proxy layer is already production-grade and should not be modified. The Flask API surface is stable — the frontend adapts to it, not the reverse.
+
+**Phased approach:** Break the upgrade into sequenced phases where each phase produces a deployable, non-regressing state. No big-bang rewrite. Each phase should identify:
+- What changes
+- What the acceptance criteria are
+- What risks exist and how they are mitigated
+- Dependencies on prior phases
+
+**Key architectural decisions to address:**
+- Component decomposition strategy (feature modules vs. standalone component tree)
+- Routing architecture (flat vs. nested, lazy loading boundaries)
+- State management pattern (pure Signals vs. signal store vs. lightweight library)
+- HTTP client strategy (Angular HttpClient + interceptors vs. current fetch)
+- Form strategy (reactive forms, validation schema)
+- Testing strategy (component harness, service testing, E2E)
+
+**Non-functional requirements:**
+- Bundle size targets
+- Lighthouse performance score targets
+- Test coverage minimums per phase
+- Accessibility compliance level (WCAG)
+
+## Constraints on the Output
+
+- Reference the actual project files and structure — do not produce generic Angular advice
+- Use the Backend architecture as the quality reference, not as a template to copy (different framework, different patterns)
+- Each recommendation must be actionable with a clear "done" state
+- Respect the existing technology choices: Angular 22 standalone components, Signals API (no RxJS), TypeScript 6, Tailwind CSS, Vitest
+- The three services are well-structured and should be preserved in spirit — the refactoring wraps them in proper Angular patterns, not replaces them

--- a/docs/ANGULAR-SPA-ARCH-UPGRADE/angular-arch-upgrade-session-transcript.md
+++ b/docs/ANGULAR-SPA-ARCH-UPGRADE/angular-arch-upgrade-session-transcript.md
@@ -1,0 +1,202 @@
+# Session Transcript: Angular SPA Architecture Upgrade Planning Documents
+
+**Date:** 2026-07-23
+**Session:** Claude Code (Opus 4.6)
+**Repos:** `adamtasteslikegood/tasteslikegoodtheangularsvegancookbook`, `adamtasteslikegood/tasteslikegood.com`
+**PR:** [#3205](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3205)
+
+---
+
+## 1. User Request
+
+The user described — via informal voice-to-text notes to a girlfriend — the story of how the Flask backend went from a 1,200-line `app.py` monolith to a ~100-line composition root with modular blueprints in two steps (`/refactor app.py` + senior backend engineer review), producing a production-grade system. The Angular SPA never had that transformation.
+
+The request: invoke `/senior-prompt-engineer` to clean up the conversational notes and produce a meta-prompt for a codebase review and PRD planning session to "graduate" the Angular SPA from a Gemini AI Studio prototype to a production-grade Angular application.
+
+Constraints:
+- Remove all filler words, "like", vibe language
+- Scope: turn the conversation into a planning session prompt, nothing more
+- Reference the actual project structure
+
+---
+
+## 2. Codebase Exploration
+
+An Explore agent surveyed the Angular SPA and reported:
+
+### Current SPA State (Verified)
+
+| Dimension | Current State |
+|---|---|
+| Components | **1** -- `AppComponent` (1,096 lines TS, 2,028 lines HTML) |
+| Services | 3 (`GeminiService`, `AuthService`, `PersistenceService`) + 1 mapper |
+| Routing | **None** -- no `@angular/router`; view switching via `signal<'generator' \| 'kitchen'>` and manual `pushState`/`popstate` |
+| State management | Angular Signals on `AppComponent` + `AuthService`; ~30 independent UI-state signals |
+| HTTP layer | Raw `fetch()` -- no `HttpClient`, no interceptors |
+| Forms | Template-driven (`FormsModule`, `[(ngModel)]`); minimal validation |
+| Code splitting | None -- single bundle, no lazy loading |
+| Polling | Unbounded `setInterval(2000)` with no timeout cap |
+| Tests | Service/utility tests exist; component testing blocked by monolith size |
+| Express proxy | **Already production-grade** |
+
+### Key Gaps vs Production Angular
+
+1. Monolithic single-component architecture
+2. No Angular Router (no route guards, lazy loading, deep linking)
+3. No lazy loading / code splitting
+4. No HTTP interceptors or centralized error handling
+5. No reactive forms
+6. Unbounded polling without timeout
+7. Minimal `computed()` derivations
+8. Hardcoded configuration
+9. Partial test coverage
+
+---
+
+## 3. Deliverable 1: Architecture Upgrade Planning Prompt
+
+**File:** `angular-arch-upgrade-prompt.md`
+
+Defines the WHAT and GOAL:
+- Documents the current SPA state in a verified table
+- Sets the Flask backend's modular architecture as the quality bar
+- Structures a codebase review across 9 dimensions (component architecture, routing, state management, HTTP/API layer, forms, performance, testability, configuration, accessibility)
+- Defines PRD format: phased approach, key architectural decisions, non-functional requirements
+- Constraints: reference actual files, respect existing tech choices (Angular 22, Signals, no RxJS, Tailwind, Vitest)
+
+---
+
+## 4. User Request: Companion DevEx Document
+
+The user then described the developer experience pain that motivates the upgrade, citing:
+
+1. **The Public Link UX failure (v0.3.8 to v0.4.1):** A plaintext link next to the public recipe toggle cannot be found by users without prior knowledge. Despite ~6 issues, ~12 agent sessions, 30-49M cached tokens, the link remains inaccessible because the architecture cannot give it a proper component home.
+
+2. **Spec drift (v0.2.0 to v0.4.1):** Planning artifacts reference v0.2.0 "Anti-Recipe Site" specs while the codebase is at v0.4.1. Backlog items carry stale acceptance criteria.
+
+Request: create a NEW companion document (the WHY and WHY NOW) that leaves the first document untouched.
+
+---
+
+## 5. Research: Version History and Project Artifacts
+
+An Explore agent researched the actual project history:
+
+### Version History (v0.3.0 to v0.4.1)
+
+| Version | Date | What happened |
+|---|---|---|
+| v0.3.0 | Jul 4 | SSR recipe/browse pages, Angular 22. **Failed to deploy** -- 14 missing deps. |
+| v0.3.1 | Jul 4 | Hotfix for v0.3.0 deploy failure. |
+| v0.3.2 | Jul 5 | SSR styling fix, async retry, sitemap unshadow. |
+| v0.3.3 | Jul 11 | Editing regressions, auth-gated publishing, monitoring. |
+| v0.3.4 | Jul 15 | Security, Datadog, CSP, Express validation. **Never reached prod** -- Dockerfile parse error. |
+| v0.3.5 | Jul 15 | Deploy repair for v0.3.4. |
+| v0.3.6 | Jul 15 | Google OAuth CSP regression fix. |
+| v0.3.7 | Jul 17 | Removed free-form slug input; slug server-derived. |
+| v0.3.8 | Jul 18 | Apex-to-www redirect, robots.txt, favicon. |
+| v0.3.9 | Jul 19 | Valkey cache fix, double-save guard, mobile hero clip. |
+| v0.4.0 | Jul 20 | SSR crawlable home-shell links, in-app-browser sign-in fallback. |
+| v0.4.1 | Jul 20 | Fix: public View link visibility for non-publishers and saved copies. |
+
+**12 releases in 16 days.** 2 failed to deploy. 3 were immediate hotfixes for the prior release.
+
+### Public Link UI Structure
+
+The public toggle and View link are **inline in the recipe detail article** (not in a modal), but the monolithic single-component architecture makes them effectively invisible:
+- Toggle: `@if (canPublish())` block with a `<button role="switch">` at line ~370 of `app.component.html`
+- View link: `@if (isPublicViewable(r))` block at line ~408, renders `/r/<slug>` anchor with `target="_blank"`
+- No routing means no URL leads to a specific recipe's detail view
+
+### Spec Documents (v0.2.x)
+
+Located under `specs/`:
+- `roadmap.md` -- Strategic v0.2 "Anti-Recipe Site" roadmap
+- `plan.md` -- Tactical execution checklist with wireframes
+- `design-plan.md` -- Implementation bridge from Claude Design to Flask SSR templates
+- `planning_notes.md` -- CEO/Eng/Design review session notes
+
+All reference v0.2.0 conventions; none updated for v0.4.x.
+
+---
+
+## 6. Deliverable 2: DevEx WHY Document
+
+**File:** `angular-arch-upgrade-devex-why.md`
+
+Three exhibits:
+
+**Exhibit A: The Public Link (v0.3.8 to v0.4.1)**
+- 4 production deploys
+- ~6 GitHub/Linear/Jira issues
+- ~12 Claude Code sessions
+- 30-49M cached tokens + 10-12M output tokens
+- Root cause: no component architecture to give the link a proper home
+
+**Exhibit B: The Patch Treadmill (v0.3.0 to v0.4.1)**
+- 12 releases in 16 days
+- 2 deploy failures, 3 hotfix chains
+- Backend absorbed equivalent changes with zero hotfix cycles
+
+**Exhibit C: Spec Drift (v0.2.0 to v0.4.1)**
+- Planning artifacts reference v0.2.0 world
+- Every planning session burns tokens bridging the gap
+
+**Why Now:** Backend sets the standard, patching costs exceed restructuring costs, spec-to-code gap is widening.
+
+---
+
+## 7. Independent Corroboration: GitHub Issue #3164
+
+The user pointed to [#3164](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3164) -- a production crawl audit (75 URLs, curl-based, Jul 18) that independently confirmed the same architectural findings:
+
+| DevEx Doc Finding | #3164 Audit Finding |
+|---|---|
+| No Angular Router | Audit explicitly notes: "the Angular SPA has **no Angular Router**" |
+| Public link buried in monolith | Item 7: "the compiled bundle contains zero references to `/browse`" |
+| Patch treadmill | Audit filed at v0.3.8, issues persisted through v0.4.1 |
+| Architecture resists every fix | Items 1, 5, 6, 7 are simple requirements cascading across 12+ files across 3 layers |
+| Spec drift from v0.2.0 | Audit title references "v0.2's thesis is the public anti-recipe site" |
+
+Additional finding from the audit not in the DevEx doc: **SPA bundle is 765KB with 7-20s observed load times** -- another consequence of zero code splitting.
+
+---
+
+## 8. Commit and PR
+
+Both documents committed to `docs/ANGULAR-SPA-ARCH-UPGRADE/` on branch `claude/angular-spa-arch-upgrade-ctmyrr` and pushed. PR #3205 opened against `dev`.
+
+### Commit Message
+
+```
+docs(arch): add Angular SPA architecture upgrade planning documents
+
+Two companion documents for the Angular SPA graduation from prototype
+to production-grade application:
+
+- angular-arch-upgrade-prompt.md: codebase review template and PRD
+  planning prompt (the WHAT and GOAL)
+- angular-arch-upgrade-devex-why.md: developer experience case study
+  documenting the cost of operating a prototype architecture at
+  production scale (the WHY and WHY NOW)
+
+Findings independently corroborated by the production crawl audit
+in #3164.
+```
+
+### CI Status
+
+- Dependency Review: passed
+- GitGuardian: passed
+- Independent Claude Review (Opus 4.7): passed -- confirmed factual claims against codebase, no changes needed
+- Remaining checks: in progress at time of transcript
+
+---
+
+## Files Produced This Session
+
+| File | Location | Purpose |
+|---|---|---|
+| `angular-arch-upgrade-prompt.md` | `docs/ANGULAR-SPA-ARCH-UPGRADE/` | WHAT and GOAL -- codebase review + PRD planning prompt |
+| `angular-arch-upgrade-devex-why.md` | `docs/ANGULAR-SPA-ARCH-UPGRADE/` | WHY and WHY NOW -- developer experience case study |
+| `angular-arch-upgrade-session-transcript.md` | (this file) | Session transcript |


### PR DESCRIPTION
## Summary

- Adds two planning documents under `docs/ANGULAR-SPA-ARCH-UPGRADE/` for the Angular SPA graduation from Gemini AI Studio prototype to production-grade Angular application
- **`angular-arch-upgrade-prompt.md`** — codebase review template and PRD planning prompt (the WHAT and GOAL): defines the current SPA state (1 component, no router, raw fetch, no code splitting), sets the Backend's modular blueprint architecture as the quality bar, and structures the review across 9 dimensions with a phased PRD format
- **`angular-arch-upgrade-devex-why.md`** — developer experience case study (the WHY and WHY NOW): documents three exhibits — the public link UX failure (4 deploys, ~12 agent sessions, 30-49M tokens to address a link at line 408 of a 2,028-line template), the patch treadmill (12 releases in 16 days, v0.3.0→v0.4.1), and spec drift (v0.2.0 planning artifacts still driving v0.4.1 backlog)
- Findings independently corroborated by the production crawl audit in #3164

## Test plan

- [ ] Documents render correctly in GitHub markdown preview
- [ ] No changes to application code — docs only



---
_Generated by [Claude Code](https://claude.ai/code/session_014zM6DRSS3fC6MAhi6okaXy)_






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

