### PR TITLE
fix(ux): non-blocking SSR save guard + fetch timeout [KAN-118] (#3208)

### DIFF
--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -1,0 +1,101 @@
+import '@angular/compiler';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecipeDetailComponent } from './recipe-detail.component';
+import { AuthService } from '../../services/auth.service';
+import { PersistenceService } from '../../services/persistence.service';
+import { GeminiService } from '../../services/gemini.service';
+import { RecipeStateService } from '../../services/recipe-state.service';
+import { ToastService } from '../../services/toast.service';
+
+describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
+  let toastShow: ReturnType<typeof vi.fn>;
+  let routerNavigate: ReturnType<typeof vi.fn>;
+  let paramSubject: Subject<Map<string, string>>;
+
+  beforeEach(() => {
+    toastShow = vi.fn();
+    routerNavigate = vi.fn().mockResolvedValue(true);
+    paramSubject = new Subject();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const createComponent = () => {
+    const recipeState = runInInjectionContext(
+      Injector.create({ providers: [] }),
+      () => new RecipeStateService()
+    );
+
+    const injector = Injector.create({
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: paramSubject.asObservable() },
+        },
+        { provide: Router, useValue: { navigate: routerNavigate } },
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser: () => ({ isGuest: true, savedRecipes: [] }),
+          },
+        },
+        { provide: PersistenceService, useValue: { saveRecipe: vi.fn() } },
+        { provide: GeminiService, useValue: {} },
+        { provide: RecipeStateService, useValue: recipeState },
+        { provide: ToastService, useValue: { show: toastShow } },
+      ],
+    });
+    const component = runInInjectionContext(injector, () => new RecipeDetailComponent());
+    return component;
+  };
+
+  const emitId = (id: string) => {
+    const params = new Map([['id', id]]);
+    const paramMap = {
+      keys: ['id'],
+      has: (k: string) => params.has(k),
+      get: (k: string) => params.get(k) ?? null,
+      getAll: (k: string) => (params.has(k) ? [params.get(k)!] : []),
+    };
+    paramSubject.next(paramMap as unknown as Map<string, string>);
+  };
+
+  it('shows "Recipe not found" toast on 404', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    createComponent();
+    emitId('missing-id');
+    await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+    expect(toastShow).toHaveBeenCalledWith('Recipe not found');
+    expect(routerNavigate).toHaveBeenCalledWith(['/kitchen'], { replaceUrl: true });
+  });
+
+  it('shows server error toast on 500', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    createComponent();
+    emitId('broken-id');
+    await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+    expect(toastShow).toHaveBeenCalledWith('Failed to load recipe. Please try again.');
+    expect(routerNavigate).toHaveBeenCalledWith(['/kitchen'], { replaceUrl: true });
+  });
+
+  it('shows connection error toast on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    createComponent();
+    emitId('unreachable-id');
+    await vi.waitFor(() => expect(toastShow).toHaveBeenCalled());
+
+    expect(toastShow).toHaveBeenCalledWith('Connection error. Check your network and try again.');
+    expect(routerNavigate).toHaveBeenCalledWith(['/kitchen'], { replaceUrl: true });
+  });
+});

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -91,11 +91,19 @@ export class RecipeDetailComponent {
     this.isLoading.set(true);
     try {
       const resp = await fetch(`/api/recipes/${encodeURIComponent(id)}`);
-      if (!resp.ok) throw new Error(`Recipe not found (${resp.status})`);
+      if (!resp.ok) {
+        if (resp.status === 404) {
+          this.toastService.show('Recipe not found');
+        } else {
+          this.toastService.show('Failed to load recipe. Please try again.');
+        }
+        this.router.navigate(['/kitchen'], { replaceUrl: true });
+        return;
+      }
       const recipe: Recipe = await resp.json();
       this.recipeState.viewRecipe(recipe);
     } catch {
-      this.toastService.show('Recipe not found');
+      this.toastService.show('Connection error. Check your network and try again.');
       this.router.navigate(['/kitchen'], { replaceUrl: true });
     } finally {
       this.isLoading.set(false);

--- a/src/guards/ssr-entry.guard.ts
+++ b/src/guards/ssr-entry.guard.ts
@@ -13,13 +13,13 @@ export const ssrEntryGuard: CanActivateFn = (route) => {
   if (saveParam) {
     const slug = Array.isArray(saveParam) ? saveParam[0] : saveParam;
     if (typeof slug === 'string') {
-      ssrEntry.handleSave(slug);
+      ssrEntry.handleSave(slug).catch((err) => console.error('SSR save failed:', err));
     }
     return router.createUrlTree(['/kitchen']);
   }
 
   if (queryParams['auth'] === 'success') {
-    ssrEntry.handleAuth();
+    ssrEntry.handleAuth().catch((err) => console.error('SSR auth handoff failed:', err));
     return router.createUrlTree(['/']);
   }
 

--- a/src/guards/ssr-entry.guard.ts
+++ b/src/guards/ssr-entry.guard.ts
@@ -2,7 +2,7 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { SsrEntryService } from '../services/ssr-entry.service';
 
-export const ssrEntryGuard: CanActivateFn = async (route) => {
+export const ssrEntryGuard: CanActivateFn = (route) => {
   const router = inject(Router);
   const ssrEntry = inject(SsrEntryService);
 
@@ -13,13 +13,13 @@ export const ssrEntryGuard: CanActivateFn = async (route) => {
   if (saveParam) {
     const slug = Array.isArray(saveParam) ? saveParam[0] : saveParam;
     if (typeof slug === 'string') {
-      await ssrEntry.handleSave(slug);
+      ssrEntry.handleSave(slug);
     }
     return router.createUrlTree(['/kitchen']);
   }
 
   if (queryParams['auth'] === 'success') {
-    await ssrEntry.handleAuth();
+    ssrEntry.handleAuth();
     return router.createUrlTree(['/']);
   }
 

--- a/src/services/ssr-entry.service.test.ts
+++ b/src/services/ssr-entry.service.test.ts
@@ -157,6 +157,29 @@ describe('SsrEntryService', () => {
     expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/could not save/i));
   });
 
+  it('shows timeout toast when fetch exceeds 10s', async () => {
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+
+    const { service, saveRecipe } = createService({ savedRecipes: [] });
+
+    await service.handleSave('slow-recipe');
+
+    expect(saveRecipe).not.toHaveBeenCalled();
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/timed out/i));
+  });
+
+  it('shows generic error toast on network failure (non-abort)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    const { service, saveRecipe } = createService({ savedRecipes: [] });
+
+    await service.handleSave('unreachable-recipe');
+
+    expect(saveRecipe).not.toHaveBeenCalled();
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/something went wrong/i));
+  });
+
   it('handleAuth waits for auth ready', async () => {
     let resolveReady!: () => void;
     const readyPromise = new Promise<void>((r) => {

--- a/src/services/ssr-entry.service.ts
+++ b/src/services/ssr-entry.service.ts
@@ -31,13 +31,12 @@ export class SsrEntryService {
       return;
     }
 
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 10_000);
       const response = await fetch(`/api/recipes/public/${encodeURIComponent(normalizedSlug)}`, {
         signal: controller.signal,
       });
-      clearTimeout(timeout);
       if (!response.ok) {
         console.warn(`Could not fetch recipe for slug "${normalizedSlug}": ${response.status}`);
         this.toast.show('Could not save this recipe. Please try again.');
@@ -59,6 +58,8 @@ export class SsrEntryService {
       } else {
         this.toast.show('Something went wrong saving this recipe.');
       }
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/src/services/ssr-entry.service.ts
+++ b/src/services/ssr-entry.service.ts
@@ -34,10 +34,9 @@ export class SsrEntryService {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 10_000);
-      const response = await fetch(
-        `/api/recipes/public/${encodeURIComponent(normalizedSlug)}`,
-        { signal: controller.signal }
-      );
+      const response = await fetch(`/api/recipes/public/${encodeURIComponent(normalizedSlug)}`, {
+        signal: controller.signal,
+      });
       clearTimeout(timeout);
       if (!response.ok) {
         console.warn(`Could not fetch recipe for slug "${normalizedSlug}": ${response.status}`);

--- a/src/services/ssr-entry.service.ts
+++ b/src/services/ssr-entry.service.ts
@@ -32,7 +32,13 @@ export class SsrEntryService {
     }
 
     try {
-      const response = await fetch(`/api/recipes/public/${encodeURIComponent(normalizedSlug)}`);
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      const response = await fetch(
+        `/api/recipes/public/${encodeURIComponent(normalizedSlug)}`,
+        { signal: controller.signal }
+      );
+      clearTimeout(timeout);
       if (!response.ok) {
         console.warn(`Could not fetch recipe for slug "${normalizedSlug}": ${response.status}`);
         this.toast.show('Could not save this recipe. Please try again.');
@@ -49,7 +55,11 @@ export class SsrEntryService {
       );
     } catch (err) {
       console.error('Failed to save recipe from SSR CTA:', err);
-      this.toast.show('Something went wrong saving this recipe.');
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        this.toast.show('Save timed out. Check your connection and try again.');
+      } else {
+        this.toast.show('Something went wrong saving this recipe.');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- **Guard no longer blocks navigation**: `ssrEntryGuard` was `await`ing `handleSave()`, which fetches from the API and saves — 500ms-2s of blank page on `/?save=<slug>`. Now fires `handleSave` as fire-and-forget and redirects to `/kitchen` immediately. Toast handles success/failure feedback.
- **10s fetch timeout**: `handleSave` wraps the API fetch with `AbortController` + 10s timeout so it never hangs indefinitely on network issues. Timeout produces a specific "Save timed out" toast.
- **404 vs network error in deep links**: `RecipeDetailComponent.fetchRecipeFromApi` now shows "Recipe not found" for 404, "Failed to load recipe" for other HTTP errors, and "Connection error" for network failures — instead of a generic "Recipe not found" for everything.

## Proving gate
`/?save=<slug>` renders `/kitchen` immediately (no blank page); network failure shows a specific error toast, not "not found".

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean  
- [x] `npm test` — 141/141 pass
- [x] `npm run build` — 5 chunks produced (2 lazy)
- [ ] Manual: visit `/?save=<valid-slug>` — kitchen renders instantly, toast appears when save completes
- [ ] Manual: visit `/?save=<invalid-slug>` — kitchen renders instantly, error toast appears
- [ ] Manual: visit `/recipe/<missing-id>` — "Recipe not found" toast
- [ ] Manual: kill Flask, visit `/recipe/<id>` — "Connection error" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)












<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

