### PR TITLE
feat(seo): canonical recipes Phase 0/1 — data file + CI gate + 7 anchors [KAN-118] (KAN-116)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -140,6 +140,15 @@ jobs:
           fi
           echo "✅ CHANGELOG.md has an entry for v$VERSION"
 
+  # ── SEO ───────────────────────────────────────────────────────────────────
+
+  canonical-recipes:
+    name: SEO — canonical recipes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: bash scripts/seo/check_canonical_recipes.sh
+
   # ── Gate ──────────────────────────────────────────────────────────────────
   # Single required check for branch protection. Fails if ANY job above fails.
 
@@ -153,6 +162,7 @@ jobs:
       - backend-test
       - docker-build
       - changelog-check
+      - canonical-recipes
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/index.html
+++ b/index.html
@@ -134,6 +134,11 @@
         <a href="/browse">Browse all vegan recipes</a>
         <a href="/r/classic-vegan-margherita-pizza">Classic Vegan Margherita Pizza</a>
         <a href="/r/vegan-cornbread">Vegan Cornbread</a>
+        <a href="/r/vegan-seitan-fried-chicken-and-waffles">Vegan Seitan Fried Chicken and Waffles</a>
+        <a href="/r/vegan-spaghetti-and-meatballs">Vegan Spaghetti and Meatballs</a>
+        <a href="/r/classic-vegan-chocolate-chip-cookies">Classic Vegan Chocolate Chip Cookies</a>
+        <a href="/r/maple-smoked-tempeh-blt">Maple Smoked Tempeh BLT</a>
+        <a href="/r/vegan-street-style-tofu-tacos">Vegan Street Style Tofu Tacos</a>
       </nav>
     </noscript>
   </body>

--- a/scripts/seo/check_canonical_recipes.sh
+++ b/scripts/seo/check_canonical_recipes.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# CI gate: validate canonical recipe list against index.html anchors.
+# Reads specs/canonical-recipes.json and checks:
+#   1. JSON is valid
+#   2. 3–5 recipes listed (Phase 0/1 bound)
+#   3. Every slug has a matching <a href="/r/{slug}"> in index.html <noscript>
+#   4. No anchors in index.html that aren't in the canonical list
+#
+# Usage: scripts/seo/check_canonical_recipes.sh [--live URL]
+#   --live URL  Also curl each /r/<slug> on the given base URL and assert 200.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CANONICAL_FILE="$REPO_ROOT/specs/canonical-recipes.json"
+INDEX_FILE="$REPO_ROOT/index.html"
+
+LIVE_BASE=""
+if [[ "${1:-}" == "--live" ]] && [[ -n "${2:-}" ]]; then
+  LIVE_BASE="${2%/}"
+fi
+
+errors=0
+
+if ! command -v jq &>/dev/null; then
+  echo "FAIL: jq is required but not installed"
+  exit 1
+fi
+
+# 1. Valid JSON
+if ! jq empty "$CANONICAL_FILE" 2>/dev/null; then
+  echo "FAIL: $CANONICAL_FILE is not valid JSON"
+  exit 1
+fi
+
+# 2. Count check (3–7)
+count=$(jq '.recipes | length' "$CANONICAL_FILE")
+if (( count < 3 || count > 7 )); then
+  echo "FAIL: canonical list has $count recipes (must be 3–7)"
+  errors=$((errors + 1))
+fi
+
+# Extract slugs from JSON
+mapfile -t json_slugs < <(jq -r '.recipes[].slug' "$CANONICAL_FILE")
+
+# Extract slugs from index.html noscript anchors
+mapfile -t html_slugs < <(grep -oP '(?<=href="/r/)[^"]+' "$INDEX_FILE" || true)
+
+# 3. Every JSON slug must appear in index.html
+for slug in "${json_slugs[@]}"; do
+  found=0
+  for hs in "${html_slugs[@]}"; do
+    if [[ "$hs" == "$slug" ]]; then
+      found=1
+      break
+    fi
+  done
+  if (( found == 0 )); then
+    echo "FAIL: slug '$slug' is in canonical-recipes.json but missing from index.html"
+    errors=$((errors + 1))
+  fi
+done
+
+# 4. Every index.html anchor must be in JSON (no orphaned anchors)
+for hs in "${html_slugs[@]}"; do
+  found=0
+  for slug in "${json_slugs[@]}"; do
+    if [[ "$slug" == "$hs" ]]; then
+      found=1
+      break
+    fi
+  done
+  if (( found == 0 )); then
+    echo "FAIL: anchor '/r/$hs' is in index.html but not in canonical-recipes.json"
+    errors=$((errors + 1))
+  fi
+done
+
+# 5. Optional live check
+if [[ -n "$LIVE_BASE" ]]; then
+  for slug in "${json_slugs[@]}"; do
+    status=$(curl -s -o /dev/null -w '%{http_code}' "$LIVE_BASE/r/$slug" 2>/dev/null || echo "000")
+    if [[ "$status" != "200" ]]; then
+      echo "FAIL: $LIVE_BASE/r/$slug returned HTTP $status (expected 200)"
+      errors=$((errors + 1))
+    else
+      echo "OK: $LIVE_BASE/r/$slug → 200"
+    fi
+  done
+fi
+
+if (( errors > 0 )); then
+  echo ""
+  echo "FAILED: $errors error(s) found"
+  exit 1
+fi
+
+echo "OK: $count canonical recipes validated (JSON ↔ index.html consistent)"

--- a/scripts/seo/check_canonical_recipes.sh
+++ b/scripts/seo/check_canonical_recipes.sh
@@ -2,7 +2,7 @@
 # CI gate: validate canonical recipe list against index.html anchors.
 # Reads specs/canonical-recipes.json and checks:
 #   1. JSON is valid
-#   2. 3–5 recipes listed (Phase 0/1 bound)
+#   2. 3–7 recipes listed (Phase 0/1 bound)
 #   3. Every slug has a matching <a href="/r/{slug}"> in index.html <noscript>
 #   4. No anchors in index.html that aren't in the canonical list
 #
@@ -16,7 +16,11 @@ CANONICAL_FILE="$REPO_ROOT/specs/canonical-recipes.json"
 INDEX_FILE="$REPO_ROOT/index.html"
 
 LIVE_BASE=""
-if [[ "${1:-}" == "--live" ]] && [[ -n "${2:-}" ]]; then
+if [[ "${1:-}" == "--live" ]]; then
+  if [[ -z "${2:-}" ]]; then
+    echo "FAIL: --live requires a base URL, e.g. --live https://www.tasteslikegood.org"
+    exit 1
+  fi
   LIVE_BASE="${2%/}"
 fi
 
@@ -79,7 +83,7 @@ done
 # 5. Optional live check
 if [[ -n "$LIVE_BASE" ]]; then
   for slug in "${json_slugs[@]}"; do
-    status=$(curl -s -o /dev/null -w '%{http_code}' "$LIVE_BASE/r/$slug" 2>/dev/null || echo "000")
+    status=$(curl -s -o /dev/null -w '%{http_code}' "$LIVE_BASE/r/$slug" 2>/dev/null || true)
     if [[ "$status" != "200" ]]; then
       echo "FAIL: $LIVE_BASE/r/$slug returned HTTP $status (expected 200)"
       errors=$((errors + 1))

--- a/specs/CANONICAL_RECIPES_ROLLOUT.md
+++ b/specs/CANONICAL_RECIPES_ROLLOUT.md
@@ -1,7 +1,7 @@
 # Canonical `r/<recipe>` Promotion — Rollout Kickoff
 
 _Origin:_ Adam's 2026-07-20 comment on PR #3185 · _Jira:_ KAN-116 (child of KAN-110) · _Owner:_ Adam
-_Status:_ **KICKOFF — candidates drafted, pending Adam's approval for v0.4.0**
+_Status:_ **APPROVED — all 7 slugs confirmed by Adam 2026-07-23; CI gate + data file live in PR**
 
 ## The directive (paraphrased from PR #3185)
 

--- a/specs/canonical-recipes.json
+++ b/specs/canonical-recipes.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "./canonical-recipes.schema.json",
+  "version": 1,
+  "updated": "2026-07-23",
+  "recipes": [
+    {
+      "slug": "classic-vegan-margherita-pizza",
+      "title": "Classic Vegan Margherita Pizza",
+      "rationale": "Signature showcase dish, high-recognition query, strong representativeness",
+      "added": "2026-07-20",
+      "score": {
+        "representativeness": 5,
+        "breadth": 4,
+        "search_intent": 5,
+        "content_quality": 4
+      }
+    },
+    {
+      "slug": "vegan-cornbread",
+      "title": "Vegan Cornbread",
+      "rationale": "Baking breadth, settles cornbread-variants question (canonical pick)",
+      "added": "2026-07-20",
+      "score": {
+        "representativeness": 3,
+        "breadth": 4,
+        "search_intent": 4,
+        "content_quality": 4
+      }
+    },
+    {
+      "slug": "vegan-seitan-fried-chicken-and-waffles",
+      "title": "Vegan Seitan Fried Chicken and Waffles",
+      "rationale": "Signature showcase dish, strong representativeness, distinctive",
+      "added": "2026-07-23",
+      "score": {
+        "representativeness": 5,
+        "breadth": 5,
+        "search_intent": 4,
+        "content_quality": 4
+      }
+    },
+    {
+      "slug": "vegan-spaghetti-and-meatballs",
+      "title": "Vegan Spaghetti and Meatballs",
+      "rationale": "High-recognition mains query, evergreen search demand",
+      "added": "2026-07-23",
+      "score": {
+        "representativeness": 4,
+        "breadth": 4,
+        "search_intent": 5,
+        "content_quality": 4
+      }
+    },
+    {
+      "slug": "classic-vegan-chocolate-chip-cookies",
+      "title": "Classic Vegan Chocolate Chip Cookies",
+      "rationale": "Baking breadth, evergreen search demand",
+      "added": "2026-07-23",
+      "score": {
+        "representativeness": 4,
+        "breadth": 4,
+        "search_intent": 5,
+        "content_quality": 4
+      }
+    },
+    {
+      "slug": "maple-smoked-tempeh-blt",
+      "title": "Maple Smoked Tempeh BLT",
+      "rationale": "Sandwiches/lunch breadth, distinctive recipe",
+      "added": "2026-07-23",
+      "score": {
+        "representativeness": 4,
+        "breadth": 5,
+        "search_intent": 3,
+        "content_quality": 4
+      }
+    },
+    {
+      "slug": "vegan-street-style-tofu-tacos",
+      "title": "Vegan Street Style Tofu Tacos",
+      "rationale": "Mexican/street-food breadth, strong search intent",
+      "added": "2026-07-23",
+      "score": {
+        "representativeness": 4,
+        "breadth": 5,
+        "search_intent": 4,
+        "content_quality": 4
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- **Phase 0/1** of canonical `r/<recipe>` promotion per `specs/CANONICAL_RECIPES_ROLLOUT.md`
- **`specs/canonical-recipes.json`** — tracked data file with slug, title, rationale, and rubric scores for all 7 Adam-approved recipes
- **`scripts/seo/check_canonical_recipes.sh`** — CI validator: checks JSON validity, 3-7 count bound, bidirectional consistency between JSON and `index.html` `<noscript>` anchors, and optional `--live URL` 200 check
- **`pr-gate.yml`** — new `SEO — canonical recipes` job wired into the Gate aggregate
- **`index.html`** — 5 new `<noscript>` anchors added (7 total canonical recipes)
- All 7 slugs verified live at `www.tasteslikegood.org` (200, content checked by Adam)

## Proving gate
- [x] Candidate file exists (`specs/canonical-recipes.json`)
- [x] CI check green (`scripts/seo/check_canonical_recipes.sh` passes)
- [x] All 7 anchors serve live (`--live` check: all 200)
- [x] Adam approved all slugs (confirmed in conversation 2026-07-23)

## Test plan
- [x] `bash scripts/seo/check_canonical_recipes.sh` — "OK: 7 canonical recipes validated"
- [x] `bash scripts/seo/check_canonical_recipes.sh --live https://www.tasteslikegood.org` — all 7 → 200
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 146/146 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

