### PR TITLE
chore(seo): canonical-recipes schema + C2 GSC checkpoint [KAN-118]

### DIFF
--- a/specs/SPRINT_2_PLAN.md
+++ b/specs/SPRINT_2_PLAN.md
@@ -38,8 +38,8 @@ pre-lock in v0.4.1; C9 added 2026-07-23 post-SPA merge, piggybacks C1). Everythi
 
 | #   | Candidate                                                                                                                                                                                                                                                                                  | Source                                       | Proposed proving gate (draft)                                                                                       |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| C1  | **KAN-116 — canonical `r/<recipe>` promotion, Phase 0/1**: Adam picks 3–5 slugs, tracked candidate file + CI validator per `CANONICAL_RECIPES_ROLLOUT.md`; settles the cornbread-variants question (ux-backlog #5)                                                                         | rolled from Sprint 1                         | candidate file exists + CI check green + anchors serve the approved slugs live                                      |
-| C2  | **GSC indexing checkpoint** — 1-week recrawl verification after the 07-19 sitemap submission (59 URLs) + v0.4.0 home anchors                                                                                                                                                               | Sprint-1 parked list                         | GSC "Last update" > 2026-07-20 AND indexed-page delta recorded in this file (finding is the deliverable either way) |
+| C1  | ✅ **KAN-116 — canonical `r/<recipe>` promotion, Phase 0/1**: Adam picks 3–5 slugs, tracked candidate file + CI validator per `CANONICAL_RECIPES_ROLLOUT.md`; settles the cornbread-variants question (ux-backlog #5) — **DONE** PR #3216 merged 2026-07-23; all 7 slugs approved, CI gate green, schema file added | rolled from Sprint 1                         | candidate file exists + CI check green + anchors serve the approved slugs live                                      |
+| C2  | **GSC indexing checkpoint** — 1-week recrawl verification after the 07-19 sitemap submission (59 URLs) + v0.4.0 home anchors — **FINDINGS RECORDED 2026-07-23** (see below)                                                                                                                | Sprint-1 parked list                         | GSC "Last update" > 2026-07-20 AND indexed-page delta recorded in this file (finding is the deliverable either way) |
 | C3  | **Prod content hygiene** — dedupe the race-bug duplicate rows on Adam's personal cookbooks (`Dooypkiitts`, `zzz-racetest-*` are his real cookbook names — dedupe extras only, every deletion his explicit pick), run `unpublish_slugs.py`, fix/unpublish the 2 remaining imageless recipes | ux-backlog #3 + #4                           | no duplicate cookbook rows remain AND zero published recipes with imageless heroes                                  |
 | C4  | **Webview-fallback live verification** — real Pinterest-arrival test of the #3186 panel; optional impression analytics                                                                                                                                                                     | ux-backlog #1 residual                       | documented repro on live site showing fallback panel (screenshot/log)                                               |
 | C5  | **Pinterest Rich Pins** — Recipe Rich Pin metadata + domain verification (`pintrest-research.md`)                                                                                                                                                                                          | Sprint-1 parked list                         | Pinterest validator passes on 2+ recipe URLs                                                                        |
@@ -56,6 +56,28 @@ C3 clears everything a new visitor can see. C4 folds into C1's live-verification
 The SSR save guard blocks the initial navigation with async I/O, leaving the user on a blank page
 for 0.5–2s — directly undercuts C1's canonical-slug promotion where the SSR CTA is the entry path.
 C9 piggybacks on C1's branch/verification; WIP stays ≤ 3 since C8 already shipped.
+
+## C2 — GSC indexing checkpoint findings (2026-07-23)
+
+**External state verified (machine-checkable):**
+
+- Sitemap live at `https://www.tasteslikegood.org/sitemap.xml`: **68 URLs** (up from 59 at sprint start 07-19; +9 new recipes published since)
+- All 7 canonical slugs return HTTP 200 with self-canonical and Recipe JSON-LD
+- Home shell `<noscript>` anchors serve all 7 approved slugs (CI gate green)
+- Sitemap `lastmod` dates span 2026-05-06 through 2026-07-21
+
+**GSC "Last update" — HUMAN GATE (requires Adam's Google login):**
+
+GSC cannot be accessed from headless (requires Google auth). Adam needs to check:
+
+1. Go to GSC → Sitemaps → `https://www.tasteslikegood.org/sitemap.xml`
+2. Record the "Last read" date — proving gate requires this date > 2026-07-20
+3. Go to GSC → Pages (Indexing) → record total indexed pages
+4. Compare to the 07-19 baseline (sitemap had 59 URLs; GSC snapshot was dated 07-09 per prior memory)
+
+**Indexed-page delta:** Pending Adam's GSC check. Sitemap grew from 59 → 68 URLs (+9). Whether Google has indexed the new pages depends on the recrawl date.
+
+**Proving gate status:** External signals all green. GSC "Last update" check is the remaining human gate — finding (either direction) is the deliverable per the charter.
 
 ## Human decisions to front-load (the Sprint-1 lesson)
 

--- a/specs/canonical-recipes.schema.json
+++ b/specs/canonical-recipes.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Canonical Recipes",
+  "description": "Hand-picked canonical recipe slugs for noscript anchors on the home shell. See CANONICAL_RECIPES_ROLLOUT.md.",
+  "type": "object",
+  "required": ["version", "updated", "recipes"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "version": { "type": "integer", "const": 1 },
+    "updated": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "ISO 8601 date of last edit"
+    },
+    "recipes": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": ["slug", "title", "rationale", "added", "score"],
+        "additionalProperties": false,
+        "properties": {
+          "slug": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+            "description": "URL-safe slug, lowercase kebab-case, no dedup suffixes"
+          },
+          "title": { "type": "string", "minLength": 1 },
+          "rationale": { "type": "string", "minLength": 1 },
+          "added": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+          },
+          "score": {
+            "type": "object",
+            "required": ["representativeness", "breadth", "search_intent", "content_quality"],
+            "additionalProperties": false,
+            "properties": {
+              "representativeness": { "type": "integer", "minimum": 1, "maximum": 5 },
+              "breadth": { "type": "integer", "minimum": 1, "maximum": 5 },
+              "search_intent": { "type": "integer", "minimum": 1, "maximum": 5 },
+              "content_quality": { "type": "integer", "minimum": 1, "maximum": 5 }
+            }
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- Adds `specs/canonical-recipes.schema.json` (JSON Schema Draft 2020-12) to resolve the dangling `$schema` reference flagged across multiple reviews on PR #3216. Locks slug format (`^[a-z0-9]+(-[a-z0-9]+)*$`), score ranges (1-5), required fields, and 3-7 count bound.
- Records C2 GSC indexing checkpoint findings in `SPRINT_2_PLAN.md`: sitemap grew 59→68 URLs, all 7 canonical slugs return 200, CI gate green. GSC "Last update" check remains a human gate (requires Adam's Google login).
- Marks C1 DONE in the sprint plan.

## Test plan

- [ ] `specs/canonical-recipes.json` validates against the new schema (verified manually — scores 1-5, slug format, required fields)
- [ ] Existing CI gate (`scripts/seo/check_canonical_recipes.sh`) still passes
- [ ] Sprint plan updates are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

