### PR TITLE
docs(gbrain): document Backend submodule as separate gstack-code-backend source (KAN-130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,8 +377,6 @@ Prefer gbrain when:
   `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
 - "What calls Y?" / "What does Y depend on?":
   `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
-- Same two, but for Backend Python — add `--source gstack-code-backend`:
-  `gbrain code-def <symbol> --source gstack-code-backend`
 - "What did we decide last time?" / past plans, retros, learnings:
   `gbrain search "<terms>" --source gstack-brain-<user>`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,19 @@ Two indexed corpora available via the `gbrain` CLI:
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
+**`Backend/` is a separate gbrain source, not part of the pinned corpus above.**
+`Backend/` is a git submodule (a gitlink, not a plain directory), and gbrain's
+code-index sync refuses to register a source whose path is nested inside an
+already-registered source's path — so it can't just be folded into this
+worktree's pin. It's registered instead as `gstack-code-backend`, cloned via
+`--url` from `adamtasteslikegood/tasteslikegood.com` into gbrain's own managed
+clone directory (sidesteps the path-overlap check entirely). It is **not
+federated** — every `code-def`/`code-refs`/`code-callers`/`code-callees`/
+`search`/`query` call against Backend Python needs an explicit
+`--source gstack-code-backend` flag, or it silently misses. Re-sync it with
+`gbrain sync --source gstack-code-backend --strategy code`, not `/sync-gbrain`
+(which only touches this worktree's pinned source).
+
 Prefer gbrain when:
 
 - "Where is X handled?" / semantic intent, no exact string yet:
@@ -364,6 +377,8 @@ Prefer gbrain when:
   `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
 - "What calls Y?" / "What does Y depend on?":
   `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+- Same two, but for Backend Python — add `--source gstack-code-backend`:
+  `gbrain code-def <symbol> --source gstack-code-backend`
 - "What did we decide last time?" / past plans, retros, learnings:
   `gbrain search "<terms>" --source gstack-brain-<user>`
 


### PR DESCRIPTION
## Summary
- `/sync-gbrain` doesn't (and can't) index `Backend/` — it's a git submodule (gitlink, nested path), and gbrain refuses overlapping path-based sources.
- Registered `Backend/` as its own gbrain source via `gbrain sources add gstack-code-backend --url <backend-repo>` (clone-based, sidesteps the overlap check) and synced it (`gbrain sync --source gstack-code-backend --strategy code`) — verified `code-def`, `code-refs`, `code-callers`, `code-callees` all resolve real symbols/edges against Backend Python now (e.g. `get_genai_client` in `services/gemini_service.py`).
- This PR documents that new source in CLAUDE.md's `## GBrain Search Guidance` block so future agents know Backend code queries need `--source gstack-code-backend` — it's unfederated, so it's silently skipped otherwise.

No Jira issue exists for this yet — filing one is a fair follow-up per the PR-lifecycle convention, but this is a small doc-only change riding along with a live /sync-gbrain session. Happy to add a KAN key if you want one filed first.

## Test plan
- [x] `gbrain code-def get_genai_client --source gstack-code-backend` resolves to `services/gemini_service.py:22-60`
- [x] `gbrain code-callers`/`code-callees` return real edges for the same symbol
- [x] Diff is docs-only (CLAUDE.md), no code/behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSEvwhQ5o72M1BWo6Eo8ZN






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

