### PR TITLE
docs: enhance CLAUDE.md with SSR, CI, testing, and behavioral guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Browser → Express :8080 → Flask :5000 → Cloud SQL (PostgreSQL)
 
 ### Layer 3 — Flask API (`Backend/`)
 
-Modular blueprint architecture (the `Backend/CLAUDE.md` is **outdated** — ignore its monolithic description):
+Modular blueprint architecture — `Backend/CLAUDE.md` is the authoritative reference for Backend details:
 
 - `auth.py` + `blueprints/auth_api_bp.py` — Google OAuth 2.0 flow, sessions
 - `blueprints/generation_bp.py` — `/api/generate` (Gemini text), `/api/generate_image` (Imagen)
@@ -114,47 +114,27 @@ Modular blueprint architecture (the `Backend/CLAUDE.md` is **outdated** — igno
 
 In production all secrets come from Google Secret Manager, injected at Cloud Run runtime.
 
-## Three submodules — always keep in sync
+## Submodules
 
-This repo has three git submodules. On every fresh checkout or after pulling:
+`Backend/` is the only **required** submodule — it is the source for the `flask-backend` Cloud Run service. The main repo pins which SHA of `adamtasteslikegood/tasteslikegood.com` (tracked branch `dev`) gets deployed to production alongside the frontend.
 
 ```bash
-git submodule update --init --recursive  # first checkout
-git pull --recurse-submodules            # daily pull
-git submodule foreach "git switch dev && git pull"  # align all to dev tip
+git submodule update --init Backend       # first checkout (Backend only)
 ```
 
-### `Backend/` submodule — CRITICAL
+`alirez-claude-skills/` and `gemstack/` are **optional** skill collections — do not force-init them.
 
-**This is the source for the `flask-backend` Cloud Run service.** The main repo pins which SHA of `adamtasteslikegood/tasteslikegood.com` (tracked branch `dev`) gets deployed to production alongside the frontend. Any drift between the pointer and real Backend state = production risk.
-
-**On every session start or before any merge/release:**
+### Backend submodule checks (before any merge/release)
 
 ```bash
-# Open PRs in the Backend repo (any unlanded work?)
 gh pr list -R adamtasteslikegood/tasteslikegood.com --state open
-
-# Commits on Backend dev not yet reflected in our pinned pointer
 git -C Backend fetch && git -C Backend log --oneline HEAD..origin/dev
-
-# Commits on Backend dev not yet promoted to Backend main
-git -C Backend log --oneline origin/main..origin/dev
-
-# Migration heads — MUST be exactly one line with (head)
-cd Backend && uv run flask db heads
+cd Backend && uv run flask db heads       # must be exactly one line with (head)
 ```
 
 - Two migration heads = unmerged branch: use `flask db merge` to unify before deploying
 - To fast-forward the pinned pointer: `git submodule update --remote Backend`
-- Production deploys whatever SHA the submodule pins when the release tag fires — check the pointer before every release merge
-
-### `alirez-claude-skills/` submodule
-
-Houses the `pm-daemon/` MCP server. The daemon auto-syncs PM planning files to Confluence (see "PM Daemon" section below).
-
-### `gemstack/` submodule
-
-GStack browser tooling. Used by `/browse` skill in Claude Code sessions.
+- Production deploys whatever SHA the submodule pins when the release tag fires
 
 ## PM Daemon (`.mcp.json`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,14 +247,14 @@ The `github.push.tag` field on the matching trigger should print `^v[0-9]+\.[0-9
 
 PR gate (`.github/workflows/pr-gate.yml`) runs on every PR to `main`, `dev`, or `dev/**`. All jobs must pass — the `gate` aggregator is the single required status check:
 
-| Job | What it checks |
-|---|---|
-| `Frontend — lint + format` | ESLint + Prettier (`npm run lint`, `npm run format:check`) |
-| `Frontend — TypeScript` | `tsc --noEmit` on both tsconfigs |
-| `Frontend — build` | Full `npm run build` (Angular + server TS) |
+| Job                                | What it checks                                                                      |
+| ---------------------------------- | ----------------------------------------------------------------------------------- |
+| `Frontend — lint + format`         | ESLint + Prettier (`npm run lint`, `npm run format:check`)                          |
+| `Frontend — TypeScript`            | `tsc --noEmit` on both tsconfigs                                                    |
+| `Frontend — build`                 | Full `npm run build` (Angular + server TS)                                          |
 | `Frontend — unit tests + coverage` | Vitest with coverage thresholds: lines/stmts ≥ 60%, branches ≥ 50%, functions ≥ 40% |
-| `Express — Docker image` | Builds the production Express Docker image |
-| `Gate — all checks passed` | Aggregator — this is the required status check in branch protection |
+| `Express — Docker image`           | Builds the production Express Docker image                                          |
+| `Gate — all checks passed`         | Aggregator — this is the required status check in branch protection                 |
 
 Additional required checks (separate workflows): `Analyze (javascript-typescript)` (CodeQL), `Dependency Review`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Only after these checks: create the branch or worktree and start the work.
 
 **Vegangenius Chef** — vegan recipe generator and personal cookbook app. Users generate recipes via Google Gemini, get AI food photos via Imagen, and manage cookbooks. Auth via Google OAuth or guest (localStorage).
 
+- **Production:** `https://www.tasteslikegood.org` (canonical host; apex `tasteslikegood.org` 301-redirects to `www`)
+- **Version:** See `package.json` `version` field (currently v0.4.1)
+- **Other agents:** See @AGENTS.md for OpenCode / non-Claude agent instructions (kept in sync with core sections here)
+
 ## Commands
 
 ### Frontend + Express proxy (root)
@@ -85,6 +89,17 @@ Browser → Express :8080 → Flask :5000 → Cloud SQL (PostgreSQL)
 - Type definitions: `recipe.types.ts`, `auth.types.ts`
 - Dev server port 3000; `proxy.conf.json` maps `/api` → Flask :5000
 - Entry: `index.tsx` (tsconfig uses `jsx: react-jsx`, hence `.tsx`)
+
+### Public SSR surface (Flask-rendered, proxied through Express)
+
+Express proxies a set of public routes to Flask for server-side rendering **before** the Angular SPA catch-all, so crawlers receive fully rendered HTML instead of an empty shell:
+
+- `/r/<slug>` — individual public recipe page (Schema.org JSON-LD, OG tags, canonical URL)
+- `/browse` — paginated public recipe index (`/browse/` with trailing slash 301-redirects to `/browse`)
+- `/sitemap.xml` — auto-generated sitemap
+- `/static/*` — Flask static assets (CSS tokens, fonts) for SSR templates
+
+These routes are GET-only and share the same rate limiter as the SPA shell. The SSR templates live in `Backend/templates/public/` and use a separate base template (`base_public.html`) from the legacy dev-only Flask UI.
 
 ### Layer 2 — Express reverse proxy (`server/`)
 
@@ -228,6 +243,29 @@ gcloud builds triggers list --filter='name~deploy OR name~release' \
 
 The `github.push.tag` field on the matching trigger should print `^v[0-9]+\.[0-9]+\.[0-9]+$`.
 
+## CI pipeline
+
+PR gate (`.github/workflows/pr-gate.yml`) runs on every PR to `main`, `dev`, or `dev/**`. All jobs must pass — the `gate` aggregator is the single required status check:
+
+| Job | What it checks |
+|---|---|
+| `Frontend — lint + format` | ESLint + Prettier (`npm run lint`, `npm run format:check`) |
+| `Frontend — TypeScript` | `tsc --noEmit` on both tsconfigs |
+| `Frontend — build` | Full `npm run build` (Angular + server TS) |
+| `Frontend — unit tests + coverage` | Vitest with coverage thresholds: lines/stmts ≥ 60%, branches ≥ 50%, functions ≥ 40% |
+| `Express — Docker image` | Builds the production Express Docker image |
+| `Gate — all checks passed` | Aggregator — this is the required status check in branch protection |
+
+Additional required checks (separate workflows): `Analyze (javascript-typescript)` (CodeQL), `Dependency Review`.
+
+Other workflows: `ci.yml` (push-only Prettier auto-commit safety net), `release.yml` (tag + GitHub Release on `main`), `claude-review.yml` / `junie-review.yml` (AI code review on PRs).
+
+## Testing
+
+- **Express/server:** Vitest (`npm test`). Tests in `server/*.test.ts`. Coverage enforced by `vitest.config.ts`.
+- **Backend/Flask:** pytest (`cd Backend && uv run pytest`). Tests in `Backend/tests/`.
+- **Angular:** No unit test suite currently. UI changes must be verified by running the dev server and testing in the browser.
+
 ## Startup (agent sessions)
 
 Project MCP servers are declared in `.mcp.json` at the repo root. When Claude Code (or any compatible agent) starts a session in this directory, it auto-spawns the servers listed there as stdio child processes. Currently registered:
@@ -309,6 +347,17 @@ Key routing rules:
 - Architecture review → invoke plan-eng-review
 - Save progress, checkpoint, resume → invoke checkpoint
 - Code quality, health check → invoke health
+
+## Behavioral Guidelines
+
+Follow the four Karpathy principles when writing or modifying code in this project:
+
+1. **Think Before Coding** — understand the problem fully before writing. Read existing code, check for prior art, verify assumptions.
+2. **Simplicity First** — prefer the simplest solution that works. Avoid premature abstraction, speculative features, and unnecessary indirection.
+3. **Surgical Changes** — make the smallest diff that solves the problem. Don't refactor surrounding code, add unrelated improvements, or "clean up while you're there."
+4. **Goal-Driven Execution** — every action should move toward a verifiable success criterion. State what "done" looks like before starting.
+
+See the `karpathy-guidelines` skill for the full reference.
 
 ## GBrain Configuration (configured by /setup-gbrain)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,14 +247,17 @@ The `github.push.tag` field on the matching trigger should print `^v[0-9]+\.[0-9
 
 PR gate (`.github/workflows/pr-gate.yml`) runs on every PR to `main`, `dev`, or `dev/**`. All jobs must pass — the `gate` aggregator is the single required status check:
 
-| Job                                | What it checks                                                                      |
-| ---------------------------------- | ----------------------------------------------------------------------------------- |
-| `Frontend — lint + format`         | ESLint + Prettier (`npm run lint`, `npm run format:check`)                          |
-| `Frontend — TypeScript`            | `tsc --noEmit` on both tsconfigs                                                    |
-| `Frontend — build`                 | Full `npm run build` (Angular + server TS)                                          |
-| `Frontend — unit tests + coverage` | Vitest with coverage thresholds: lines/stmts ≥ 60%, branches ≥ 50%, functions ≥ 40% |
-| `Express — Docker image`           | Builds the production Express Docker image                                          |
-| `Gate — all checks passed`         | Aggregator — this is the required status check in branch protection                 |
+| Job                                | What it checks                                                                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Frontend — lint + format`         | ESLint + Prettier (`npm run lint`, `npm run format:check`)                                                                                       |
+| `Frontend — TypeScript`            | `tsc --noEmit` on both tsconfigs                                                                                                                 |
+| `Frontend — build`                 | Full `npm run build` (Angular + server TS)                                                                                                       |
+| `Frontend — unit tests + coverage` | Vitest (`npm test`) over `server/**` and `src/**`, with `server/**/*.ts` coverage thresholds: lines/stmts ≥ 60%, branches ≥ 50%, functions ≥ 40% |
+| `Backend — pytest`                 | `uv run pytest` inside `Backend/`                                                                                                                |
+| `Docker — Express image build`     | Builds the production Express Docker image                                                                                                       |
+| `CHANGELOG entry for this version` | Verifies `CHANGELOG.md` has a `## [<version>]` (or `## <version>`) section matching `package.json`                                               |
+| `SEO — canonical recipes`          | Runs `scripts/seo/check_canonical_recipes.sh`                                                                                                    |
+| `Gate — all checks passed`         | Aggregator — this is the required status check in branch protection                                                                              |
 
 Additional required checks (separate workflows): `Analyze (javascript-typescript)` (CodeQL), `Dependency Review`.
 
@@ -262,9 +265,9 @@ Other workflows: `ci.yml` (push-only Prettier auto-commit safety net), `release.
 
 ## Testing
 
-- **Express/server:** Vitest (`npm test`). Tests in `server/*.test.ts`. Coverage enforced by `vitest.config.ts`.
+- **Express/server + Angular units:** Vitest (`npm test`). `vitest.config.ts` includes `server/**/*.{test,spec}.ts` AND `src/**/*.{test,spec}.ts`, so any `*.spec.ts` under `src/` (currently `src/utils/public-link.spec.ts`, `src/services/gemini.service.spec.ts`) runs in the same suite. Coverage thresholds apply to `server/**/*.ts` only; `src/**` coverage is not gated.
 - **Backend/Flask:** pytest (`cd Backend && uv run pytest`). Tests in `Backend/tests/`.
-- **Angular:** No unit test suite currently. UI changes must be verified by running the dev server and testing in the browser.
+- **Angular components/E2E:** No component or browser-driven test harness (Karma/Jest/Playwright) is wired up. UI changes still need to be verified by running the dev server and testing in the browser — but plain unit-level Angular logic can and should be covered via the Vitest suite above.
 
 ## Startup (agent sessions)
 
@@ -357,7 +360,7 @@ Follow the four Karpathy principles when writing or modifying code in this proje
 3. **Surgical Changes** — make the smallest diff that solves the problem. Don't refactor surrounding code, add unrelated improvements, or "clean up while you're there."
 4. **Goal-Driven Execution** — every action should move toward a verifiable success criterion. State what "done" looks like before starting.
 
-See the `karpathy-guidelines` skill for the full reference.
+For the full reference, see the `karpathy-check` slash command / `karpathy-coder` skill / `cs-karpathy-reviewer` agent under the **optional** `alirez-claude-skills/` submodule (not initialized by default — see the Submodules note in the "Session start" section).
 
 ## GBrain Configuration (configured by /setup-gbrain)
 


### PR DESCRIPTION
## Summary
- Add missing architectural docs for public SSR routes (`/r/<slug>`, `/browse`, `/sitemap.xml`), CI pipeline job matrix with coverage thresholds, testing strategy overview, production domain info, and Karpathy behavioral guidelines to CLAUDE.md
- Fix stale AGENTS.md: Backend CLAUDE.md is now authoritative (not "outdated"), and only Backend submodule is required (alirez-claude-skills/gemstack are optional)

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm no functional code changes (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8Rp6PMEGmsFCBCCexBXqR









<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

