### PR TITLE
docs(claude): correct gbrain Backend sync + src test-glob claims (KAN-130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,7 @@ bare `/sync-gbrain` run from inside `Backend/`.
 
 **Why not `/sync-gbrain` from `Backend/`:** it does not no-op there. `Backend/`
 has no `.gbrain-source` pin, so the orchestrator's code stage falls back to
-registering the cwd as a *new* federated source (`gstack-code-com-<hash>`
+registering the cwd as a _new_ federated source (`gstack-code-com-<hash>`
 `--path .../Backend`), duplicating the 197 pages already indexed as
 `gstack-code-backend`. The nested-path guard does not catch this, because
 `gstack-code-backend` lives in gbrain's managed clone directory rather than at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,7 @@ Other workflows: `ci.yml` (push-only Prettier auto-commit safety net), `release.
 
 ## Testing
 
-- **Express/server + Angular units:** Vitest (`npm test`). `vitest.config.ts` includes `server/**/*.{test,spec}.ts` AND `src/**/*.{test,spec}.ts`, so any `*.spec.ts` under `src/` (currently `src/utils/public-link.spec.ts`, `src/services/gemini.service.spec.ts`) runs in the same suite. Coverage thresholds apply to `server/**/*.ts` only; `src/**` coverage is not gated.
+- **Express/server + Angular units:** Vitest (`npm test`). `vitest.config.ts` includes `server/**/*.{test,spec}.ts` AND `src/**/*.{test,spec}.ts`, so **both** `*.test.ts` and `*.spec.ts` under `src/` run in the same suite — 9 files today, and `.test.ts` is the majority spelling (only `src/utils/public-link.spec.ts` and `src/services/gemini.service.spec.ts` use `.spec.ts`). Either extension works; don't assume `.test.ts` under `src/` is excluded. Coverage thresholds apply to `server/**/*.ts` only and `src/**` coverage is not gated — and note `vitest.config.ts` further excludes `server/index.ts`, `server/proxy.ts`, and `server/types.ts` from the coverage denominator, so the 60% line/statement gate does not cover all of `server/`.
 - **Backend/Flask:** pytest (`cd Backend && uv run pytest`). Tests in `Backend/tests/`.
 - **Angular components/E2E:** No component or browser-driven test harness (Karma/Jest/Playwright) is wired up. UI changes still need to be verified by running the dev server and testing in the browser — but plain unit-level Angular logic can and should be covered via the Vitest suite above.
 
@@ -418,8 +418,24 @@ clone directory (sidesteps the path-overlap check entirely). It is **not
 federated** — every `code-def`/`code-refs`/`code-callers`/`code-callees`/
 `search`/`query` call against Backend Python needs an explicit
 `--source gstack-code-backend` flag, or it silently misses. Re-sync it with
-`gbrain sync --source gstack-code-backend --strategy code`, not `/sync-gbrain`
-(which only touches this worktree's pinned source).
+`gbrain sync --source gstack-code-backend --strategy code`, and never with a
+bare `/sync-gbrain` run from inside `Backend/`.
+
+**Why not `/sync-gbrain` from `Backend/`:** it does not no-op there. `Backend/`
+has no `.gbrain-source` pin, so the orchestrator's code stage falls back to
+registering the cwd as a *new* federated source (`gstack-code-com-<hash>`
+`--path .../Backend`), duplicating the 197 pages already indexed as
+`gstack-code-backend`. The nested-path guard does not catch this, because
+`gstack-code-backend` lives in gbrain's managed clone directory rather than at
+the `Backend/` path, so there is no path overlap to detect. Verified with
+`--dry-run` on 2026-07-24. If you want the memory + brain-sync stages while in
+`Backend/`, run `gstack-gbrain-sync.ts --no-code`. From a submodule cwd, always
+`--dry-run` first and read the `would:` line before letting the code stage run.
+
+The `/sync-gbrain` skill also rewrites the block below from a fixed template
+that asserts the worktree is pinned via `.gbrain-source`. That assertion is
+false in `Backend/`, and a verbatim rewrite there would delete this paragraph —
+so do not let the skill write its guidance block into `Backend/CLAUDE.md`.
 
 Prefer gbrain when:
 


### PR DESCRIPTION
## What

Two claims in `CLAUDE.md` were wrong in ways that actively misdirect agents. Found while running `/sync-gbrain` from `Backend/`.

## 1. `/sync-gbrain` from `Backend/` duplicates the source

The GBrain Search Guidance block said to re-sync Backend explicitly, "not `/sync-gbrain` (which only touches this worktree's pinned source)."

That parenthetical is false. `Backend/` has **no** `.gbrain-source` pin, so a bare `/sync-gbrain` there does not no-op — the orchestrator's code stage falls back to registering the cwd as a **new federated source**, duplicating the 197 pages already indexed as `gstack-code-backend`:

```
SKIP  code  would: gbrain sources add gstack-code-com-7163da53-13dc8f \
                     --path .../Backend --federated
```

The nested-path guard doesn't catch it because `gstack-code-backend` lives in gbrain's managed clone directory, not at the `Backend/` path — no path overlap to detect. Confirmed via `gstack-gbrain-sync.ts --dry-run` on 2026-07-24. I read the `would:` line and refreshed the existing source instead, so no duplicate was created.

Also documents that the skill's Step 4 rewrites the guidance block from a fixed template asserting a `.gbrain-source` pin. That assertion is false in `Backend/`, and a verbatim rewrite there would delete the Backend paragraph.

## 2. `src/` test glob undercounts 2 vs 9

Testing section said "any `*.spec.ts` under `src/` (currently `public-link.spec.ts`, `gemini.service.spec.ts`)".

`vitest.config.ts` includes `src/**/*.{test,spec}.ts`, and there are **9** such files today — 7 of them `.test.ts`. As written it implies `.test.ts` under `src/` isn't collected, which would lead someone to rename a working test or skip adding one.

Also notes that `vitest.config.ts` excludes `server/{index,proxy,types}.ts` from the coverage denominator, so the 60% line/statement gate does not span all of `server/**/*.ts` as the table implies.

## Verification

Checked the rest of the recent CLAUDE.md doc-enhance series against the tree. Accurate and left alone: pr-gate 9 job names + triggers, Backend CI 5 job names, `services/`/`utils/` file lists, all 10 named Backend test files, `templates/public/`, SSR routes (`/r/*splat`, `/browse`, `/sitemap.xml`, `/static/*splat`, `/browse/` 301), GET-only + shared `staticPageLimiter` (`server/index.ts:166`), vitest thresholds 60/60/50/40, `package.json` v0.4.1, `AGENTS.md`, `scripts/seo/check_canonical_recipes.sh`.

Docs only. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATxCCQEB75iMHG1V1HAgXo






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

