### PR TITLE
docs(claude): drop point-in-time page count from gbrain warning (KAN-130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,8 +424,8 @@ bare `/sync-gbrain` run from inside `Backend/`.
 **Why not `/sync-gbrain` from `Backend/`:** it does not no-op there. `Backend/`
 has no `.gbrain-source` pin, so the orchestrator's code stage falls back to
 registering the cwd as a _new_ federated source (`gstack-code-com-<hash>`
-`--path .../Backend`), duplicating the 197 pages already indexed as
-`gstack-code-backend`. The nested-path guard does not catch this, because
+`--path .../Backend`), re-indexing the whole repo alongside the pages already
+held by `gstack-code-backend`. The nested-path guard does not catch this, because
 `gstack-code-backend` lives in gbrain's managed clone directory rather than at
 the `Backend/` path, so there is no path overlap to detect. Verified with
 `--dry-run` on 2026-07-24. If you want the memory + brain-sync stages while in


### PR DESCRIPTION
Follow-up to #3231, which merged before this review comment came in.

## What

#3231 said a stray `/sync-gbrain` from `Backend/` would duplicate "the 197 pages already indexed as `gstack-code-backend`". The [review comment](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3231#discussion_r3645231949) flagged the hardcoded count as a point-in-time metric that goes stale on every re-index.

Correct, and observable: during the session that produced these docs, `gstack-code-575c47df-9dc431` moved from 296 to 297 pages between two commands.

The sentence now describes the duplication by source name rather than by size:

> …re-indexing the whole repo alongside the pages already held by `gstack-code-backend`.

Kept the `2026-07-24` verification date — that one is deliberately a point-in-time stamp so a reader can judge how old the `--dry-run` evidence is.

Companion Backend PR: [tasteslikegood.com#235](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/235).

Docs only, one sentence. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATxCCQEB75iMHG1V1HAgXo






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

