### PR TITLE
fix(release): address v0.4.2 review feedback — changelog SHA, lockfile version, SSR save toast gap [KAN-118]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,9 @@ No schema migration.
   ([#3226](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3226))
 - `body-parser` 2.2.2 → 2.3.0 (upstream CVE fix) and `brace-expansion` bumped
   ([#3212](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3212))
-- Backend submodule pointer bumped `18a303a` → `a1891b7`, picking up Backend
-  docs + security/cleanup PRs (Backend #229, #230, #232, #233)
+- Backend submodule pointer bumped `18a303a` → `cb218ab` (Backend dev→main
+  promotion #236), picking up Backend docs + security/cleanup PRs (Backend
+  #229, #230, #232, #233)
   ([#3230](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3230))
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Only after these checks: create the branch or worktree and start the work.
 **Vegangenius Chef** — vegan recipe generator and personal cookbook app. Users generate recipes via Google Gemini, get AI food photos via Imagen, and manage cookbooks. Auth via Google OAuth or guest (localStorage).
 
 - **Production:** `https://www.tasteslikegood.org` (canonical host; apex `tasteslikegood.org` 301-redirects to `www`)
-- **Version:** See `package.json` `version` field (currently v0.4.1)
+- **Version:** See `package.json` `version` field (currently v0.4.2)
 - **Other agents:** See @AGENTS.md for OpenCode / non-Claude agent instructions (kept in sync with core sections here)
 
 ## Commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@angular/build": "22.0.8",
         "@angular/cli": "22.0.8",

--- a/src/guards/ssr-entry.guard.test.ts
+++ b/src/guards/ssr-entry.guard.test.ts
@@ -1,0 +1,100 @@
+import '@angular/compiler';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { Router, type ActivatedRouteSnapshot, type UrlTree } from '@angular/router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ssrEntryGuard } from './ssr-entry.guard';
+import { SsrEntryService } from '../services/ssr-entry.service';
+
+describe('ssrEntryGuard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const runGuard = (opts: {
+    queryParams?: Record<string, unknown>;
+    fragment?: string | null;
+    handleSave?: ReturnType<typeof vi.fn>;
+    handleAuth?: ReturnType<typeof vi.fn>;
+  }) => {
+    const handleSave = opts.handleSave ?? vi.fn().mockResolvedValue(undefined);
+    const handleAuth = opts.handleAuth ?? vi.fn().mockResolvedValue(undefined);
+    const createUrlTree = vi.fn((commands: unknown[]) => ({ commands }) as unknown as UrlTree);
+    const injector = Injector.create({
+      providers: [
+        { provide: Router, useValue: { createUrlTree } },
+        { provide: SsrEntryService, useValue: { handleSave, handleAuth } },
+      ],
+    });
+    const route = {
+      queryParams: opts.queryParams ?? {},
+      fragment: opts.fragment ?? null,
+    } as unknown as ActivatedRouteSnapshot;
+    const result = runInInjectionContext(injector, () => ssrEntryGuard(route, {} as never));
+    return { result, handleSave, handleAuth, createUrlTree };
+  };
+
+  it('kicks off the save and redirects to /kitchen without waiting on it', () => {
+    let resolveSave!: () => void;
+    const handleSave = vi.fn(() => new Promise<void>((resolve) => (resolveSave = resolve)));
+
+    const { result, createUrlTree } = runGuard({
+      queryParams: { save: 'thai-peanut-noodles' },
+      handleSave,
+    });
+
+    expect(handleSave).toHaveBeenCalledWith('thai-peanut-noodles');
+    expect(createUrlTree).toHaveBeenCalledWith(['/kitchen']);
+    expect(result).toEqual({ commands: ['/kitchen'] });
+    resolveSave();
+  });
+
+  it('uses the first value when the save param is repeated', () => {
+    const { handleSave } = runGuard({ queryParams: { save: ['first-slug', 'second-slug'] } });
+
+    expect(handleSave).toHaveBeenCalledWith('first-slug');
+  });
+
+  it('still redirects to /kitchen when the save rejects, logging the error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handleSave = vi.fn().mockRejectedValue(new Error('network down'));
+
+    const { result } = runGuard({ queryParams: { save: 'some-recipe' }, handleSave });
+
+    expect(result).toEqual({ commands: ['/kitchen'] });
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith('SSR save failed:', expect.any(Error));
+    });
+  });
+
+  it('handles the OAuth return and redirects to /', async () => {
+    const { result, handleAuth } = runGuard({ queryParams: { auth: 'success' } });
+
+    expect(handleAuth).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ commands: ['/'] });
+  });
+
+  it('lets save take precedence when save and auth=success are both present', () => {
+    const { result, handleSave, handleAuth } = runGuard({
+      queryParams: { save: 'some-recipe', auth: 'success' },
+    });
+
+    expect(handleSave).toHaveBeenCalledWith('some-recipe');
+    expect(handleAuth).not.toHaveBeenCalled();
+    expect(result).toEqual({ commands: ['/kitchen'] });
+  });
+
+  it('redirects the legacy #kitchen fragment to /kitchen', () => {
+    const { result, handleSave, handleAuth } = runGuard({ fragment: 'kitchen' });
+
+    expect(handleSave).not.toHaveBeenCalled();
+    expect(handleAuth).not.toHaveBeenCalled();
+    expect(result).toEqual({ commands: ['/kitchen'] });
+  });
+
+  it('activates normally when no SSR entry params are present', () => {
+    const { result, createUrlTree } = runGuard({});
+
+    expect(result).toBe(true);
+    expect(createUrlTree).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/ssr-entry.service.test.ts
+++ b/src/services/ssr-entry.service.test.ts
@@ -180,6 +180,29 @@ describe('SsrEntryService', () => {
     expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/something went wrong/i));
   });
 
+  it('shows an error toast when auth initialization fails before the save', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const injector = Injector.create({
+      providers: [
+        {
+          provide: AuthService,
+          useValue: { ready: Promise.reject(new Error('auth init failed')) },
+        },
+        { provide: PersistenceService, useValue: { saveRecipe: vi.fn() } },
+        { provide: ToastService, useValue: { show: toastShow } },
+      ],
+    });
+    const service = runInInjectionContext(injector, () => new SsrEntryService());
+
+    await service.handleSave('thai-peanut-noodles');
+
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/something went wrong/i));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
   it('handleAuth waits for auth ready', async () => {
     let resolveReady!: () => void;
     const readyPromise = new Promise<void>((r) => {

--- a/src/services/ssr-entry.service.ts
+++ b/src/services/ssr-entry.service.ts
@@ -18,8 +18,14 @@ export class SsrEntryService {
       return;
     }
 
-    await this.auth.ready;
-    this.auth.ensureGuestSession();
+    try {
+      await this.auth.ready;
+      this.auth.ensureGuestSession();
+    } catch (err) {
+      console.error('Failed to initialize session for SSR save:', err);
+      this.toast.show('Something went wrong saving this recipe.');
+      return;
+    }
 
     const alreadySaved = this.auth
       .currentUser()


### PR DESCRIPTION
## Summary

Fixes the actionable review feedback on release PR #3236 (independent Claude review + automated owner review). Targets `dev` so the open dev→main release PR picks these up.

- **CHANGELOG**: the `[0.4.2]` section cited the Backend pointer as `18a303a → a1891b7`, but the release actually pins `cb218ab` (Backend dev→main promotion tasteslikegood.com#236). Now cites the shipped SHA.
- **package-lock.json**: root `version` fields synced `0.4.1` → `0.4.2`.
- **CLAUDE.md**: stale "currently v0.4.1" note bumped.
- **`SsrEntryService.handleSave`**: `await this.auth.ready` / `ensureGuestSession()` ran outside the try/catch, so a rejection there produced no toast (only the guard's `console.error`). Those now surface the generic error toast, closing the one silent-failure path the review found.
- **Tests**: new `src/guards/ssr-entry.guard.test.ts` (7 cases: save redirect, repeated-param handling, rejection logging, auth handoff, save/auth precedence, `#kitchen` fragment, pass-through) plus a service test for the auth-init failure toast. The guard previously had no coverage.

Deliberately **not** changed (rationale posted on #3236): the fire-and-forget save before navigation is the intentional non-blocking design from #3214; `takeUntilDestroyed` on route-scoped subscriptions, `togglePublic` signal hygiene, and the recycle-bin confirm are deferred/product calls.

## Test plan

- [x] `npm test` — 154 tests; only pre-existing environmental failure is `server/redirects.test.ts` favicon check, which 404s because this worktree lives under a dot-directory (`send` hides dot-segments); passes in CI/normal checkouts
- [x] `npx vitest run src/guards/ssr-entry.guard.test.ts src/services/ssr-entry.service.test.ts` — 18/18 pass
- [x] `npm run lint`, `npm run format:check`, `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAetMRYd6cVus6znbWvo21



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

