### PR TITLE
fix(ux): saved-copy view/publish state cluster — differentiated View link, publish confirm, isSaved fix, guest publish affordance [KAN-137]

### DIFF
--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -203,11 +203,9 @@
                   [href]="'/r/' + publicSlugOf(r)"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold transition-colors animate-[fadeIn_0.2s]"
-                  [class.text-stone-500]="linkKind === 'own'"
+                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold text-stone-500 transition-colors animate-[fadeIn_0.2s]"
                   [class.hover:text-green-600]="linkKind === 'own'"
-                  [class.text-stone-300]="linkKind === 'source'"
-                  [class.hover:text-stone-400]="linkKind === 'source'"
+                  [class.hover:text-stone-700]="linkKind === 'source'"
                   [class.italic]="linkKind === 'source'"
                   [title]="
                     linkKind === 'source'

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -195,13 +195,26 @@
                   Sign in to publish
                 </button>
               }
-              @if (isPublicViewable(r)) {
+              @if (publicLinkKind(r); as linkKind) {
+                <!-- KAN-137: a 'source' link opens the page this copy was
+                     saved FROM — muted so it never reads as this recipe's own
+                     published page while the toggle is off. -->
                 <a
                   [href]="'/r/' + publicSlugOf(r)"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold text-stone-500 hover:text-green-600 transition-colors animate-[fadeIn_0.2s]"
-                  [title]="'View public page: /r/' + publicSlugOf(r)"
+                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold transition-colors animate-[fadeIn_0.2s]"
+                  [class.text-stone-500]="linkKind === 'own'"
+                  [class.hover:text-green-600]="linkKind === 'own'"
+                  [class.text-stone-300]="linkKind === 'source'"
+                  [class.hover:text-stone-400]="linkKind === 'source'"
+                  [class.italic]="linkKind === 'source'"
+                  [title]="
+                    linkKind === 'source'
+                      ? 'This recipe was saved from a public recipe — opens the original: /r/' +
+                        publicSlugOf(r)
+                      : 'View public page: /r/' + publicSlugOf(r)
+                  "
                 >
                   View
                   <svg

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -6,7 +6,7 @@ import { AuthService } from '../../services/auth.service';
 import { PersistenceService } from '../../services/persistence.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ModalService } from '../../services/modal.service';
-import { isPublicViewable, publicSlugOf } from '../../utils/public-link';
+import { isPublicViewable, publicLinkKind, publicSlugOf } from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
@@ -190,6 +190,21 @@ export class GeneratorComponent {
       return;
     }
     const nextState = !recipe.is_public;
+
+    // KAN-137: first publish of a copy saved from a public recipe would mint
+    // a near-identical second public page (name collision → -N slug). Make
+    // that an informed choice instead of a silent side effect.
+    if (
+      nextState &&
+      !recipe.slug &&
+      recipe.sourceSlug &&
+      !confirm(
+        `This recipe was saved from a public recipe that may still be live at /r/${recipe.sourceSlug}. Publish your copy as a separate public page?`
+      )
+    ) {
+      return;
+    }
+
     recipe.is_public = nextState;
 
     if (nextState && !recipe.slug) {
@@ -210,6 +225,10 @@ export class GeneratorComponent {
 
   isPublicViewable(recipe: Recipe): boolean {
     return isPublicViewable(recipe);
+  }
+
+  publicLinkKind(recipe: Recipe): 'own' | 'source' | null {
+    return publicLinkKind(recipe);
   }
 
   publicSlugOf(recipe: Recipe): string | null {

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -107,11 +107,9 @@
                   [href]="'/r/' + publicSlugOf(r)"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold transition-colors animate-[fadeIn_0.2s]"
-                  [class.text-stone-500]="linkKind === 'own'"
+                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold text-stone-500 transition-colors animate-[fadeIn_0.2s]"
                   [class.hover:text-green-600]="linkKind === 'own'"
-                  [class.text-stone-300]="linkKind === 'source'"
-                  [class.hover:text-stone-400]="linkKind === 'source'"
+                  [class.hover:text-stone-700]="linkKind === 'source'"
                   [class.italic]="linkKind === 'source'"
                   [title]="
                     linkKind === 'source'

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -87,14 +87,38 @@
                     ></span>
                   </button>
                 </div>
+              } @else if (isSaved()) {
+                <!-- GH #3211: guests get the same publish affordance as the
+                     generator — a sign-in prompt instead of silence. -->
+                <button
+                  type="button"
+                  (click)="openAuthModal()"
+                  class="text-[10px] font-bold uppercase text-stone-400 hover:text-green-600 underline underline-offset-2 transition-colors"
+                  aria-label="Sign in to publish this recipe"
+                >
+                  Sign in to publish
+                </button>
               }
-              @if (isPublicViewable(r)) {
+              @if (publicLinkKind(r); as linkKind) {
+                <!-- KAN-137: a 'source' link opens the page this copy was
+                     saved FROM — muted so it never reads as this recipe's own
+                     published page while the toggle is off. -->
                 <a
                   [href]="'/r/' + publicSlugOf(r)"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold text-stone-500 hover:text-green-600 transition-colors animate-[fadeIn_0.2s]"
-                  [title]="'View public page: /r/' + publicSlugOf(r)"
+                  class="inline-flex items-center gap-1 ml-1 text-xs font-semibold transition-colors animate-[fadeIn_0.2s]"
+                  [class.text-stone-500]="linkKind === 'own'"
+                  [class.hover:text-green-600]="linkKind === 'own'"
+                  [class.text-stone-300]="linkKind === 'source'"
+                  [class.hover:text-stone-400]="linkKind === 'source'"
+                  [class.italic]="linkKind === 'source'"
+                  [title]="
+                    linkKind === 'source'
+                      ? 'This recipe was saved from a public recipe — opens the original: /r/' +
+                        publicSlugOf(r)
+                      : 'View public page: /r/' + publicSlugOf(r)
+                  "
                 >
                   View
                   <svg

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -27,11 +27,12 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
     vi.restoreAllMocks();
   });
 
-  const createComponent = () => {
+  const createComponent = (opts: { isGuest?: boolean } = {}) => {
     const recipeState = runInInjectionContext(
       Injector.create({ providers: [] }),
       () => new RecipeStateService()
     );
+    const persistenceSaveRecipe = vi.fn().mockResolvedValue(true);
 
     const injector = Injector.create({
       providers: [
@@ -43,10 +44,11 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
         {
           provide: AuthService,
           useValue: {
-            currentUser: () => ({ isGuest: true, savedRecipes: [] }),
+            currentUser: () => ({ isGuest: opts.isGuest ?? true, savedRecipes: [] }),
+            saveRecipe: vi.fn(),
           },
         },
-        { provide: PersistenceService, useValue: { saveRecipe: vi.fn() } },
+        { provide: PersistenceService, useValue: { saveRecipe: persistenceSaveRecipe } },
         { provide: GeminiService, useValue: {} },
         { provide: RecipeStateService, useValue: recipeState },
         { provide: ToastService, useValue: { show: toastShow } },
@@ -54,7 +56,7 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       ],
     });
     const component = runInInjectionContext(injector, () => new RecipeDetailComponent());
-    return component;
+    return { component, persistenceSaveRecipe };
   };
 
   const emitId = (id: string) => {
@@ -99,5 +101,75 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
 
     expect(toastShow).toHaveBeenCalledWith('Connection error. Check your network and try again.');
     expect(routerNavigate).toHaveBeenCalledWith(['/kitchen'], { replaceUrl: true });
+  });
+
+  // KAN-137 confirm-guard: first publish of a copy saved from a public recipe
+  // must be an informed choice — and "no" must leave the recipe untouched.
+  describe('togglePublic confirm-guard', () => {
+    const savedCopy = () =>
+      ({
+        id: 'copy-1',
+        name: 'Vegan Cornbread',
+        ingredients: { wet: [], dry: [], other: [] },
+        instructions: [],
+        sourceSlug: 'vegan-cornbread',
+      }) as never;
+
+    it('prompts before first publish of a sourceSlug copy and aborts on "no"', async () => {
+      const confirmMock = vi.fn().mockReturnValue(false);
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = savedCopy() as { is_public?: boolean; sourceSlug: string };
+      await component.togglePublic(recipe as never);
+
+      expect(confirmMock).toHaveBeenCalledOnce();
+      expect(confirmMock.mock.calls[0][0]).toContain('/r/vegan-cornbread');
+      expect(recipe.is_public).toBeFalsy();
+      expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+    });
+
+    it('publishes the copy when confirmed', async () => {
+      vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = savedCopy() as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(recipe.is_public).toBe(true);
+      expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+    });
+
+    it('does not prompt when publishing an own recipe (no sourceSlug)', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = { ...(savedCopy() as object), sourceSlug: undefined } as {
+        is_public?: boolean;
+      };
+      await component.togglePublic(recipe as never);
+
+      expect(confirmMock).not.toHaveBeenCalled();
+      expect(recipe.is_public).toBe(true);
+      expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+    });
+
+    it('does not prompt on unpublish', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = {
+        ...(savedCopy() as object),
+        is_public: true,
+        slug: 'vegan-cornbread-2',
+      } as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(confirmMock).not.toHaveBeenCalled();
+      expect(recipe.is_public).toBe(false);
+      expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -9,6 +9,7 @@ import { PersistenceService } from '../../services/persistence.service';
 import { GeminiService } from '../../services/gemini.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ToastService } from '../../services/toast.service';
+import { ModalService } from '../../services/modal.service';
 
 describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
   let toastShow: ReturnType<typeof vi.fn>;
@@ -49,6 +50,7 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
         { provide: GeminiService, useValue: {} },
         { provide: RecipeStateService, useValue: recipeState },
         { provide: ToastService, useValue: { show: toastShow } },
+        { provide: ModalService, useValue: { openAuth: vi.fn() } },
       ],
     });
     const component = runInInjectionContext(injector, () => new RecipeDetailComponent());

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -7,7 +7,8 @@ import { PersistenceService } from '../../services/persistence.service';
 import { GeminiService } from '../../services/gemini.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ToastService } from '../../services/toast.service';
-import { isPublicViewable, publicSlugOf } from '../../utils/public-link';
+import { ModalService } from '../../services/modal.service';
+import { isPublicViewable, publicLinkKind, publicSlugOf } from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
@@ -25,6 +26,7 @@ export class RecipeDetailComponent {
   private readonly geminiService = inject(GeminiService);
   private readonly recipeState = inject(RecipeStateService);
   private readonly toastService = inject(ToastService);
+  private readonly modalService = inject(ModalService);
 
   readonly recipe = this.recipeState.currentRecipe;
   readonly generatedImageUrl = this.recipeState.generatedImageUrl;
@@ -101,7 +103,8 @@ export class RecipeDetailComponent {
         return;
       }
       const recipe: Recipe = await resp.json();
-      this.recipeState.viewRecipe(recipe);
+      // Not in the user's cookbook (cold deep link) — keep Save enabled (#3210).
+      this.recipeState.viewRecipe(recipe, false);
     } catch {
       this.toastService.show('Connection error. Check your network and try again.');
       this.router.navigate(['/kitchen'], { replaceUrl: true });
@@ -165,6 +168,21 @@ export class RecipeDetailComponent {
   async togglePublic(recipe: Recipe) {
     if (!this.canPublish()) return;
     const nextState = !recipe.is_public;
+
+    // KAN-137: first publish of a copy saved from a public recipe would mint
+    // a near-identical second public page (name collision → -N slug). Make
+    // that an informed choice instead of a silent side effect.
+    if (
+      nextState &&
+      !recipe.slug &&
+      recipe.sourceSlug &&
+      !confirm(
+        `This recipe was saved from a public recipe that may still be live at /r/${recipe.sourceSlug}. Publish your copy as a separate public page?`
+      )
+    ) {
+      return;
+    }
+
     recipe.is_public = nextState;
 
     if (nextState && !recipe.slug) {
@@ -189,6 +207,14 @@ export class RecipeDetailComponent {
 
   publicSlugOf(recipe: Recipe): string | null {
     return publicSlugOf(recipe);
+  }
+
+  publicLinkKind(recipe: Recipe): 'own' | 'source' | null {
+    return publicLinkKind(recipe);
+  }
+
+  openAuthModal() {
+    this.modalService.openAuth();
   }
 
   private slugFromTitle = slugFromTitle;

--- a/src/services/recipe-state.service.test.ts
+++ b/src/services/recipe-state.service.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RecipeStateService } from './recipe-state.service';
+import type { Recipe } from '../recipe.types';
+
+const recipe = (over: Partial<Recipe> = {}): Recipe =>
+  ({
+    id: 'r1',
+    name: 'Vegan Cornbread',
+    ingredients: { wet: [], dry: [], other: [] },
+    instructions: [],
+    prepTime: 5,
+    cookTime: 20,
+    servings: 8,
+    description: '',
+    tags: [],
+    notes: '',
+    ...over,
+  }) as Recipe;
+
+// GH #3210 / KAN-137: viewRecipe unconditionally set isSaved=true, so a
+// recipe fetched via cold deep link (not in the user's cookbook) misreported
+// as saved and disabled the Save button.
+describe('RecipeStateService.viewRecipe', () => {
+  let service: RecipeStateService;
+
+  beforeEach(() => {
+    // No deps — construct directly, same as recipe-detail.component.test.ts.
+    service = new RecipeStateService();
+  });
+
+  it('marks the recipe saved by default (cookbook navigation path)', () => {
+    service.viewRecipe(recipe());
+    expect(service.isSaved()).toBe(true);
+    expect(service.currentRecipe()?.id).toBe('r1');
+  });
+
+  it('leaves the recipe unsaved when told so (deep-link API fetch path)', () => {
+    service.viewRecipe(recipe(), false);
+    expect(service.isSaved()).toBe(false);
+    expect(service.currentRecipe()?.id).toBe('r1');
+  });
+
+  it('clearRecipe resets the saved flag', () => {
+    service.viewRecipe(recipe());
+    service.clearRecipe();
+    expect(service.isSaved()).toBe(false);
+    expect(service.currentRecipe()).toBeNull();
+  });
+});

--- a/src/services/recipe-state.service.ts
+++ b/src/services/recipe-state.service.ts
@@ -7,10 +7,12 @@ export class RecipeStateService {
   readonly generatedImageUrl = signal<string | null>(null);
   readonly isSaved = signal(false);
 
-  viewRecipe(r: Recipe) {
+  // saved=false is the cold deep-link path (GH #3210): the recipe came from
+  // the API, not the user's cookbook, so the Save button must stay live.
+  viewRecipe(r: Recipe, saved = true) {
     this.currentRecipe.set(r);
     this.generatedImageUrl.set(r.ai_image_url || null);
-    this.isSaved.set(true);
+    this.isSaved.set(saved);
   }
 
   clearRecipe() {

--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPublicViewable, publicSlugOf } from './public-link';
+import { isPublicViewable, publicLinkKind, publicSlugOf } from './public-link';
 
 // KAN-119: the View link to /r/<slug> must not depend on auth state — a
 // published recipe's public page is viewable by anyone, so the link renders
@@ -33,6 +33,53 @@ describe('publicSlugOf', () => {
     expect(publicSlugOf({ is_public: true })).toBeNull();
     expect(publicSlugOf({ is_public: true, slug: '' })).toBeNull();
     expect(publicSlugOf({ sourceSlug: '' })).toBeNull();
+  });
+});
+
+// KAN-137: the public toggle must never read OFF while an undifferentiated
+// View link is present. The link stays (guests need the sourceSlug fallback),
+// but the UI must know WHICH public page it points at: the recipe's own
+// published page ('own') or the original it was saved from ('source').
+describe('publicLinkKind', () => {
+  it("is 'own' for a published recipe with its own slug", () => {
+    expect(publicLinkKind({ is_public: true, slug: 'vegan-cornbread' })).toBe('own');
+  });
+
+  it("is 'own' when both own slug and sourceSlug exist — own page wins", () => {
+    expect(
+      publicLinkKind({ is_public: true, slug: 'my-remix', sourceSlug: 'vegan-cornbread' })
+    ).toBe('own');
+  });
+
+  it("is 'source' for a copy saved from a public page (no own publish state)", () => {
+    expect(publicLinkKind({ sourceSlug: 'vegan-cornbread' })).toBe('source');
+  });
+
+  it("is 'source' after the copy is unpublished — own slug kept but toggle off", () => {
+    // The unpublish leg of the KAN-137 cycle: is_public flips false, the row
+    // keeps its slug, and the link must degrade to the differentiated
+    // saved-from state instead of impersonating a live own page.
+    expect(
+      publicLinkKind({ is_public: false, slug: 'my-remix-2', sourceSlug: 'vegan-cornbread' })
+    ).toBe('source');
+  });
+
+  it('is null when there is no public page at all', () => {
+    expect(publicLinkKind({})).toBeNull();
+    expect(publicLinkKind({ is_public: false, slug: 'draft' })).toBeNull();
+    expect(publicLinkKind({ is_public: true })).toBeNull();
+  });
+
+  it('agrees with publicSlugOf/isPublicViewable on visibility', () => {
+    const cases = [
+      {},
+      { is_public: true, slug: 'a' },
+      { sourceSlug: 'b' },
+      { is_public: false, slug: 'a', sourceSlug: 'b' },
+    ];
+    for (const r of cases) {
+      expect(publicLinkKind(r) !== null).toBe(isPublicViewable(r));
+    }
   });
 });
 

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -33,3 +33,26 @@ export function isPublicViewable(recipe: {
 }): boolean {
   return publicSlugOf(recipe) !== null;
 }
+
+/**
+ * KAN-137 — which public page the View link points at.
+ *
+ * 'own'    — the recipe's own published page (is_public + slug): the publish
+ *            toggle and the link agree, render the link normally.
+ * 'source' — only the sourceSlug fallback resolves: the link opens the page
+ *            this copy was saved FROM, not a page this recipe owns. The UI
+ *            must render it visibly differently (muted + explanatory title),
+ *            otherwise a publish-capable user sees "toggle off + View
+ *            present" and reads it as an inconsistency.
+ * null     — no public page; no link.
+ */
+export function publicLinkKind(recipe: {
+  is_public?: boolean;
+  slug?: string;
+  sourceSlug?: string;
+}): 'own' | 'source' | null {
+  if (recipe.is_public === true && recipe.slug) {
+    return 'own';
+  }
+  return recipe.sourceSlug ? 'source' : null;
+}


### PR DESCRIPTION
## Summary

Sprint 3 item B, first cluster (Jira **KAN-137**, epic KAN-136). Fixes the cross-author save→publish→view cycle Adam reproduced live, enforcing his invariant: **the public toggle must never read OFF next to an undifferentiated View link.**

### Root causes (systematic-debugging pass)
1. The KAN-119 `sourceSlug` fallback makes a saved copy's View link (which opens the *original's* page) indistinguishable from an own-published View link — so publish-capable users see toggle-off + View-present.
2. Publishing a saved copy silently mints a near-identical second public page (name collision → `-N` slug). Unpublishing keeps the slug but drops `is_public`, falling back to the sourceSlug link — cycling back to state 1.
3. GH #3210: `viewRecipe` unconditionally set `isSaved=true` on cold deep-link fetches.
4. GH #3211: recipe-detail had no publish affordance for guests.

### Changes
- `publicLinkKind()` ('own' | 'source' | null) in `public-link.ts`; both generator and recipe-detail render 'source' View links **muted + italic** with tooltip *"This recipe was saved from a public recipe — opens the original"* (Adam's chosen option: differentiated, not hidden — guests keep their KAN-119 link).
- `togglePublic` (both components): first publish of a `sourceSlug` copy requires a `confirm()` acknowledging the original may still be live (same pattern as kitchen's delete confirm).
- `viewRecipe(r, saved = false)` on the API-fetch path — closes #3210.
- Recipe-detail mirrors generator's *Sign in to publish* button via ModalService — closes #3211.

### Tests
- `public-link.spec.ts`: full `publicLinkKind` matrix incl. the unpublish-leg regression case, and a visibility-agreement property with `isPublicViewable`.
- New `recipe-state.service.test.ts`: saved-default, deep-link-unsaved, clear-reset.
- Existing recipe-detail error-handling tests updated for the ModalService provider.
- Suite: 162/163 (the 1 failure is `server/redirects.test.ts` favicon — an artifact of running from a `.claude/worktrees/` path where Express `send` ignores dot-segments; passes in the main checkout and CI).

### Verification for Adam
Walkthrough: save someone else's public recipe → copy shows muted italic View (source) + toggle OFF (consistent) → toggle ON asks confirmation → after publish, View turns normal (own page) → unpublish → link degrades back to muted source style, toggle OFF. No silent duplicate pages.

Closes #3210. Closes #3211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA









<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

