### PR TITLE
feat(spa): publish-toggle lock states + server-truth recipe columns [KAN-139]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Publish state resolves to one DB row** (KAN-139,
+  [#3217](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3217)):
+  Backend migration adds `is_canonical` (locks the 7 curated canonical
+  recipes — unpublish/re-slug/delete return 400; content edits still allowed)
+  and `source_slug` (server-side mirror of the blob's `sourceSlug`,
+  backfilled). SPA renders the publish toggle greyed while the initial server
+  sync is pending and for copies saved from a public recipe (tooltip names
+  the source page), disables it outright for canonical recipes, and disables
+  delete for canonical recipes in the Kitchen. The SSR CTA's repeat-save
+  dedup now waits for the server recipe list, so copies that exist only
+  server-side (or with stale local blobs) are caught instead of re-saved.
+  Requires the Backend pointer bump to
+  [tasteslikegood.com#239](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/239).
+
 ---
 
 ## [0.4.3] - 2026-07-24

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -168,15 +168,22 @@
                     class="text-[10px] font-bold uppercase text-stone-400"
                     >Public</span
                   >
+                  <!-- KAN-139: greyed while the initial server sync is pending
+                       and for copies saved from a public recipe; disabled
+                       outright when the recipe is canonical (server-locked). -->
                   <button
                     type="button"
                     role="switch"
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
+                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
+                    [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
+                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -6,7 +6,12 @@ import { AuthService } from '../../services/auth.service';
 import { PersistenceService } from '../../services/persistence.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ModalService } from '../../services/modal.service';
-import { isPublicViewable, publicLinkKind, publicSlugOf } from '../../utils/public-link';
+import {
+  isPublicViewable,
+  publicLinkKind,
+  publicSlugOf,
+  publishToggleKind,
+} from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
@@ -189,6 +194,11 @@ export class GeneratorComponent {
       this.modalService.openAuth();
       return;
     }
+    // KAN-139: the server rejects publish-state changes on canonical recipes
+    // (400), and while the initial sync is pending we don't yet know the
+    // authoritative state — the template disables the toggle in both cases;
+    // this guard backstops it.
+    if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
     // KAN-137: first publish of a copy saved from a public recipe would mint
@@ -233,6 +243,24 @@ export class GeneratorComponent {
 
   publicSlugOf(recipe: Recipe): string | null {
     return publicSlugOf(recipe);
+  }
+
+  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+    return publishToggleKind(recipe);
+  }
+
+  publishTogglePending(): boolean {
+    return this.persistenceService.publishStateSync() === 'pending';
+  }
+
+  publishToggleTitle(recipe: Recipe): string {
+    if (this.publishTogglePending()) return 'Checking publish state…';
+    const kind = publishToggleKind(recipe);
+    if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'source') {
+      return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
+    }
+    return recipe.is_public ? 'Unpublish this recipe' : 'Publish this recipe';
   }
 
   private slugFromTitle = slugFromTitle;

--- a/src/components/kitchen/kitchen.component.html
+++ b/src/components/kitchen/kitchen.component.html
@@ -380,10 +380,16 @@
                       />
                     </svg>
                   </button>
+                  <!-- KAN-139: canonical recipes are server-locked — DELETE returns 400. -->
                   <button
                     (click)="promptDeleteRecipe(r, $event)"
-                    class="p-1.5 bg-white/90 rounded-full text-stone-600 hover:text-red-600 shadow-sm backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
-                    title="Delete Recipe"
+                    [disabled]="r.is_canonical"
+                    class="p-1.5 bg-white/90 rounded-full text-stone-600 shadow-sm backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
+                    [class.hover:text-red-600]="!r.is_canonical"
+                    [class.cursor-not-allowed]="r.is_canonical"
+                    [title]="
+                      r.is_canonical ? 'Canonical recipe — cannot be deleted' : 'Delete Recipe'
+                    "
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/kitchen/kitchen.component.ts
+++ b/src/components/kitchen/kitchen.component.ts
@@ -84,6 +84,9 @@ export class KitchenComponent {
 
   promptDeleteRecipe(recipe: Recipe, event: Event) {
     event.stopPropagation();
+    // KAN-139: canonical recipes are server-locked (DELETE returns 400);
+    // the template disables the button — this backstops it.
+    if (recipe.is_canonical) return;
     this.recipeToDelete.set(recipe);
     this.showDeleteConfirmation.set(true);
   }

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -70,15 +70,22 @@
                     class="text-[10px] font-bold uppercase text-stone-400"
                     >Public</span
                   >
+                  <!-- KAN-139: greyed while the initial server sync is pending
+                       and for copies saved from a public recipe; disabled
+                       outright when the recipe is canonical (server-locked). -->
                   <button
                     type="button"
                     role="switch"
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
+                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
+                    [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
+                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -48,7 +48,10 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
             saveRecipe: vi.fn(),
           },
         },
-        { provide: PersistenceService, useValue: { saveRecipe: persistenceSaveRecipe } },
+        {
+          provide: PersistenceService,
+          useValue: { saveRecipe: persistenceSaveRecipe, publishStateSync: () => 'synced' },
+        },
         { provide: GeminiService, useValue: {} },
         { provide: RecipeStateService, useValue: recipeState },
         { provide: ToastService, useValue: { show: toastShow } },
@@ -153,6 +156,26 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       expect(confirmMock).not.toHaveBeenCalled();
       expect(recipe.is_public).toBe(true);
       expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+    });
+
+    // KAN-139: canonical recipes are server-locked — the toggle must be inert.
+    it('ignores toggle attempts on a canonical recipe', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = {
+        ...(savedCopy() as object),
+        sourceSlug: undefined,
+        is_canonical: true,
+        is_public: true,
+        slug: 'vegan-cornbread',
+      } as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(confirmMock).not.toHaveBeenCalled();
+      expect(recipe.is_public).toBe(true);
+      expect(persistenceSaveRecipe).not.toHaveBeenCalled();
     });
 
     it('does not prompt on unpublish', async () => {

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -8,7 +8,12 @@ import { GeminiService } from '../../services/gemini.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ToastService } from '../../services/toast.service';
 import { ModalService } from '../../services/modal.service';
-import { isPublicViewable, publicLinkKind, publicSlugOf } from '../../utils/public-link';
+import {
+  isPublicViewable,
+  publicLinkKind,
+  publicSlugOf,
+  publishToggleKind,
+} from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
@@ -167,6 +172,11 @@ export class RecipeDetailComponent {
 
   async togglePublic(recipe: Recipe) {
     if (!this.canPublish()) return;
+    // KAN-139: the server rejects publish-state changes on canonical recipes
+    // (400), and while the initial sync is pending we don't yet know the
+    // authoritative state — the template disables the toggle in both cases;
+    // this guard backstops it.
+    if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
     // KAN-137: first publish of a copy saved from a public recipe would mint
@@ -211,6 +221,24 @@ export class RecipeDetailComponent {
 
   publicLinkKind(recipe: Recipe): 'own' | 'source' | null {
     return publicLinkKind(recipe);
+  }
+
+  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+    return publishToggleKind(recipe);
+  }
+
+  publishTogglePending(): boolean {
+    return this.persistenceService.publishStateSync() === 'pending';
+  }
+
+  publishToggleTitle(recipe: Recipe): string {
+    if (this.publishTogglePending()) return 'Checking publish state…';
+    const kind = publishToggleKind(recipe);
+    if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'source') {
+      return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
+    }
+    return recipe.is_public ? 'Unpublish this recipe' : 'Publish this recipe';
   }
 
   openAuthModal() {

--- a/src/recipe.types.ts
+++ b/src/recipe.types.ts
@@ -41,4 +41,11 @@ export interface Recipe {
    * tapping Save again surfaces the existing copy instead of adding another.
    */
   sourceSlug?: string;
+  /**
+   * KAN-139 — server-owned lock for the canonical recipes curated in
+   * specs/canonical-recipes.json. Read-only in the SPA: the API strips it on
+   * create and pins it on update, and rejects unpublish/re-slug/delete of a
+   * locked recipe with 400. The UI disables those controls up front.
+   */
+  is_canonical?: boolean;
 }

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, effect, untracked, inject } from '@angular/core';
+import { Injectable, effect, signal, untracked, inject } from '@angular/core';
 import { AuthService } from './auth.service';
 import { Recipe } from '../recipe.types';
 import { Cookbook } from '../auth.types';
@@ -22,7 +22,25 @@ export class PersistenceService {
   private _apiSynced = false;
   private readonly auth = inject(AuthService);
 
+  /**
+   * KAN-139 — publish state is server-owned, so the publish toggle renders
+   * greyed until the first API load settles: 'pending' while the initial
+   * sync is in flight, 'synced' once server rows have been merged in,
+   * 'failed' when all retries were exhausted (local state is then the best
+   * we have and the toggle re-enables rather than staying dead).
+   */
+  readonly publishStateSync = signal<'pending' | 'synced' | 'failed'>('pending');
+
+  /** Resolves when the first loadFromApi() settles (success OR exhausted
+   *  retries) — lets flows that must see server rows (the SSR CTA's
+   *  repeat-save dedup) wait for the merge instead of racing it. */
+  readonly firstSyncSettled: Promise<void>;
+  private _settleFirstSync!: () => void;
+
   constructor() {
+    this.firstSyncSettled = new Promise<void>((resolve) => {
+      this._settleFirstSync = resolve;
+    });
     // Auto-load from API when a logged-in user's session is confirmed.
     // Uses untracked() so signal writes inside loadFromApi() don't
     // create a reactive dependency in the effect.
@@ -236,11 +254,30 @@ export class PersistenceService {
         const recipesData = await recipesRes.json();
         const collectionsData = await collectionsRes.json();
 
-        // With the backend fix, data.id and the outer id are now consistent.
-        // We use the data field directly since it contains the complete recipe
-        // with the correct ID already set by the backend.
+        // The blob (r.data) is the complete recipe, but its slug/is_public
+        // copies can lag the DB columns on rows written before the backend
+        // synced blob and column on every write — Adam's repeat-save trap
+        // miss (KAN-139) was exactly such a row. When the backend exposes
+        // the columns (is_canonical present = new contract), they win,
+        // including nulls; older backends fall back to the blob unchanged.
         const recipes: Recipe[] = (recipesData.recipes ?? []).map(
-          (r: { id: string; data: Recipe }) => r.data
+          (r: {
+            id: string;
+            data: Recipe;
+            slug?: string | null;
+            is_public?: boolean;
+            is_canonical?: boolean;
+            source_slug?: string | null;
+          }) => {
+            if (r.is_canonical === undefined) return r.data;
+            return {
+              ...r.data,
+              slug: r.slug ?? undefined,
+              is_public: r.is_public,
+              is_canonical: r.is_canonical,
+              sourceSlug: r.data.sourceSlug ?? r.source_slug ?? undefined,
+            };
+          }
         );
 
         const cookbooks: Cookbook[] = (collectionsData.collections ?? []).map(this._toCookbook);
@@ -249,6 +286,8 @@ export class PersistenceService {
           `[PersistenceService] Hydrating ${recipes.length} recipes, ${cookbooks.length} cookbooks`
         );
         this.auth.hydrate(recipes, cookbooks);
+        this.publishStateSync.set('synced');
+        this._settleFirstSync();
         return;
       } catch (err) {
         console.warn('[PersistenceService] loadFromApi attempt failed:', err);
@@ -258,6 +297,8 @@ export class PersistenceService {
       '[PersistenceService] loadFromApi failed after all retries, will retry on next auth change'
     );
     this._apiSynced = false;
+    this.publishStateSync.set('failed');
+    this._settleFirstSync();
   }
 
   /** POST a recipe to Flask; the endpoint upserts same-owner recipes, so

--- a/src/services/ssr-entry.service.test.ts
+++ b/src/services/ssr-entry.service.test.ts
@@ -22,6 +22,7 @@ describe('SsrEntryService', () => {
     savedRecipes?: unknown[];
     synced?: boolean;
     fetchResponse?: { ok: boolean; json: () => Promise<unknown> };
+    firstSyncSettled?: Promise<void>;
   }) => {
     const saveRecipe = vi.fn().mockResolvedValue(opts.synced ?? true);
     const injector = Injector.create({
@@ -37,7 +38,10 @@ describe('SsrEntryService', () => {
             }),
           },
         },
-        { provide: PersistenceService, useValue: { saveRecipe } },
+        {
+          provide: PersistenceService,
+          useValue: { saveRecipe, firstSyncSettled: opts.firstSyncSettled ?? Promise.resolve() },
+        },
         { provide: ToastService, useValue: { show: toastShow } },
       ],
     });
@@ -59,6 +63,32 @@ describe('SsrEntryService', () => {
     expect(toastShow).toHaveBeenCalledWith(
       expect.stringMatching(/already have this recipe/i),
       expect.objectContaining({ id: 'r1' })
+    );
+  });
+
+  it('waits for the first server sync so server-only copies are deduped (KAN-139)', async () => {
+    // savedRecipes is empty until the sync settles — the matching copy only
+    // exists server-side (another device, or a stale local blob).
+    const savedRecipes: unknown[] = [];
+    let settleSync!: () => void;
+    const firstSyncSettled = new Promise<void>((resolve) => {
+      settleSync = resolve;
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { service, saveRecipe } = createService({ savedRecipes, firstSyncSettled });
+
+    const save = service.handleSave('thai-peanut-noodles');
+    savedRecipes.push({ id: 'server-copy', sourceSlug: 'thai-peanut-noodles' });
+    settleSync();
+    await save;
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(saveRecipe).not.toHaveBeenCalled();
+    expect(toastShow).toHaveBeenCalledWith(
+      expect.stringMatching(/already have this recipe/i),
+      expect.objectContaining({ id: 'server-copy' })
     );
   });
 

--- a/src/services/ssr-entry.service.ts
+++ b/src/services/ssr-entry.service.ts
@@ -27,6 +27,16 @@ export class SsrEntryService {
       return;
     }
 
+    // KAN-139: the dedup check below must see the server's rows, not just
+    // whatever localStorage happens to hold — a copy saved on another
+    // device (or one whose local blob predates the slug-column sync) is
+    // otherwise invisible and gets saved again. Bounded so a hanging API
+    // degrades to the old local-only check instead of blocking the save.
+    await Promise.race([
+      this.persistence.firstSyncSettled,
+      new Promise<void>((resolve) => setTimeout(resolve, 8_000)),
+    ]);
+
     const alreadySaved = this.auth
       .currentUser()
       ?.savedRecipes.find(

--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPublicViewable, publicLinkKind, publicSlugOf } from './public-link';
+import { isPublicViewable, publicLinkKind, publicSlugOf, publishToggleKind } from './public-link';
 
 // KAN-119: the View link to /r/<slug> must not depend on auth state — a
 // published recipe's public page is viewable by anyone, so the link renders
@@ -102,5 +102,38 @@ describe('isPublicViewable', () => {
     expect(isPublicViewable({ is_public: false, slug: 'vegan-cornbread' })).toBe(false);
     expect(isPublicViewable({ is_public: true })).toBe(false);
     expect(isPublicViewable({})).toBe(false);
+  });
+});
+
+// KAN-139: canonical recipes are server-locked (unpublish/re-slug/delete →
+// 400), and copies saved from a public page render the toggle greyed so their
+// off-state never reads as "this recipe's own page is down".
+describe('publishToggleKind', () => {
+  it('is locked for canonical recipes, regardless of everything else', () => {
+    expect(publishToggleKind({ is_canonical: true, is_public: true, slug: 'a' })).toBe('locked');
+    expect(publishToggleKind({ is_canonical: true, sourceSlug: 'b' })).toBe('locked');
+    expect(publishToggleKind({ is_canonical: true })).toBe('locked');
+  });
+
+  it('is source for an unpublished copy that carries only sourceSlug', () => {
+    expect(publishToggleKind({ sourceSlug: 'vegan-cornbread' })).toBe('source');
+    expect(publishToggleKind({ is_public: false, sourceSlug: 'vegan-cornbread' })).toBe('source');
+  });
+
+  it('is normal once the copy has published its own page', () => {
+    expect(
+      publishToggleKind({
+        is_public: true,
+        slug: 'vegan-cornbread-2',
+        sourceSlug: 'vegan-cornbread',
+      })
+    ).toBe('normal');
+  });
+
+  it('is normal for ordinary own recipes, published or not', () => {
+    expect(publishToggleKind({})).toBe('normal');
+    expect(publishToggleKind({ is_public: true, slug: 'a' })).toBe('normal');
+    expect(publishToggleKind({ is_public: false, slug: 'a' })).toBe('normal');
+    expect(publishToggleKind({ is_canonical: false, is_public: true, slug: 'a' })).toBe('normal');
   });
 });

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -56,3 +56,28 @@ export function publicLinkKind(recipe: {
   }
   return recipe.sourceSlug ? 'source' : null;
 }
+
+/**
+ * KAN-139 — how the publish toggle should render.
+ *
+ * 'locked' — canonical recipe: the server rejects unpublish/re-slug/delete
+ *            with 400, so the toggle is disabled outright with an
+ *            explanatory title.
+ * 'source' — a copy saved from a public recipe that is not itself
+ *            published: rendered greyed by default (its publish state
+ *            belongs to the source page), but still clickable — the
+ *            KAN-137 confirm gate makes publishing a separate copy an
+ *            informed choice.
+ * 'normal' — everything else.
+ */
+export function publishToggleKind(recipe: {
+  is_public?: boolean;
+  slug?: string;
+  sourceSlug?: string;
+  is_canonical?: boolean;
+}): 'locked' | 'source' | 'normal' {
+  if (recipe.is_canonical === true) {
+    return 'locked';
+  }
+  return publicLinkKind(recipe) === 'source' ? 'source' : 'normal';
+}


### PR DESCRIPTION
SPA half of KAN-139 / #3217 — pairs with Backend PR [tasteslikegood.com#239](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/239) (degrades cleanly against older backends). #239 is merged (Backend dev @ 0e1cf91) and the pointer bump is included in this PR.

## What

**Publish toggle states** (`publishToggleKind` in `src/utils/public-link.ts`):
- **locked** — canonical recipe: toggle disabled with tooltip "Canonical recipe — publish state is locked" (server rejects unpublish/re-slug/delete with 400)
- **source** — a copy saved from a public recipe that hasn't published its own page: toggle rendered greyed with a tooltip naming `/r/<sourceSlug>`, but still clickable — the KAN-137 confirm gate (Adam verified it in walkthrough round 1) stays the decision point
- **normal** — everything else

**Greyed while loading** (Adam's KAN-139 ask): the toggle is greyed + disabled until the first `/api/recipes` sync settles (`PersistenceService.publishStateSync`: pending → synced/failed). On failure it re-enables so localStorage-only mode keeps working.

**Server truth over stale blobs:** `loadFromApi` now merges the DB columns (`slug`, `is_public`, `is_canonical`, `source_slug`) over the blob's own copies, which can lag on rows written before the backend synced blob and column. When the fields are absent (old backend), the blob is used unchanged.

**Repeat-save trap fix** (the *vegan english breakfast* miss): the SSR CTA dedup check now awaits `firstSyncSettled` (bounded at 8s) before scanning `savedRecipes`, so copies that exist only server-side — or whose local blob lacks the published slug — are caught and surfaced instead of duplicated.

**Kitchen:** delete button disabled for canonical recipes with an explanatory tooltip; `promptDeleteRecipe` backstops it.

## Verification

- `npm run lint`, `npm run format:check`, `npm run type-check`, `npm run build` — clean
- Vitest: **src suite 88/88 green** (new: `publishToggleKind` matrix, canonical-toggle inert test, SSR-CTA waits-for-sync dedup test). The single failing server test locally is the documented `.claude/worktrees/` favicon dot-segment artifact — passes in CI.

## Gate

Adam's walkthrough round 2 (greyed toggle on saved copies, locked canonical, repeat-save trapped) after this + #239 + pointer bump ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA







<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

