### PR TITLE
fix(spa): surface publish failures — empty-slug pre-check + sync-failure toast [KAN-104]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Publish failures are no longer silent** (KAN-104,
+  [#3146](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3146)):
+  titles with no ASCII letters/numbers (all-emoji, pure-CJK/Cyrillic) are
+  pre-checked client-side with an explanatory toast instead of hitting the
+  server's 400 silently, and a publish/unpublish that fails to sync now
+  reverts _and_ tells the user (previously it only reverted).
+
 ### Added
 
 - **Publish state resolves to one DB row** (KAN-139,

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from '../../services/auth.service';
 import { PersistenceService } from '../../services/persistence.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ModalService } from '../../services/modal.service';
+import { ToastService } from '../../services/toast.service';
 import {
   isPublicViewable,
   publicLinkKind,
@@ -27,6 +28,7 @@ export class GeneratorComponent {
   readonly authService = inject(AuthService);
   private readonly recipeState = inject(RecipeStateService);
   private readonly modalService = inject(ModalService);
+  private readonly toastService = inject(ToastService);
 
   readonly recipe = this.recipeState.currentRecipe;
   readonly generatedImageUrl = this.recipeState.generatedImageUrl;
@@ -201,6 +203,17 @@ export class GeneratorComponent {
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
+    // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
+    // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
+    // with 400. Same derivation as the server (parity is spec-pinned), so
+    // catch it before the round trip and say why instead of failing silently.
+    if (nextState && !recipe.slug && !this.slugFromTitle(recipe.name)) {
+      this.toastService.show(
+        "This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."
+      );
+      return;
+    }
+
     // KAN-137: first publish of a copy saved from a public recipe would mint
     // a near-identical second public page (name collision → -N slug). Make
     // that an informed choice instead of a silent side effect.
@@ -230,6 +243,13 @@ export class GeneratorComponent {
       console.error('Failed to toggle public state:', err);
       recipe.is_public = !nextState;
       this.authService.saveRecipe(recipe);
+      // KAN-104 (#3146): the revert already worked; without a message the
+      // user just sees the switch snap back with no explanation.
+      this.toastService.show(
+        nextState
+          ? 'Publishing failed to sync to the server. Check your connection and try again.'
+          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
+      );
     }
   }
 

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -158,6 +158,40 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
     });
 
+    // KAN-104 (#3146): empty-slug titles are pre-checked client-side with an
+    // explanatory toast instead of a silent server 400.
+    it('blocks publishing a title that derives an empty slug and says why', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = {
+        ...(savedCopy() as object),
+        name: '🌮🌮🌮',
+        sourceSlug: undefined,
+      } as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/can't be published/i));
+      expect(confirmMock).not.toHaveBeenCalled();
+      expect(recipe.is_public).toBeFalsy();
+      expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+    });
+
+    it('reverts and surfaces a toast when the publish fails to sync', async () => {
+      vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+      persistenceSaveRecipe.mockResolvedValue(false);
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const recipe = savedCopy() as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(recipe.is_public).toBeFalsy();
+      expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/publishing failed to sync/i));
+      expect(consoleError).toHaveBeenCalled();
+    });
+
     // KAN-139: canonical recipes are server-locked — the toggle must be inert.
     it('ignores toggle attempts on a canonical recipe', async () => {
       const confirmMock = vi.fn();

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -179,6 +179,17 @@ export class RecipeDetailComponent {
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
+    // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
+    // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
+    // with 400. Same derivation as the server (parity is spec-pinned), so
+    // catch it before the round trip and say why instead of failing silently.
+    if (nextState && !recipe.slug && !this.slugFromTitle(recipe.name)) {
+      this.toastService.show(
+        "This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."
+      );
+      return;
+    }
+
     // KAN-137: first publish of a copy saved from a public recipe would mint
     // a near-identical second public page (name collision → -N slug). Make
     // that an informed choice instead of a silent side effect.
@@ -208,6 +219,13 @@ export class RecipeDetailComponent {
       console.error('Failed to toggle public state:', err);
       recipe.is_public = !nextState;
       this.authService.saveRecipe(recipe);
+      // KAN-104 (#3146): the revert already worked; without a message the
+      // user just sees the switch snap back with no explanation.
+      this.toastService.show(
+        nextState
+          ? 'Publishing failed to sync to the server. Check your connection and try again.'
+          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
+      );
     }
   }
 


### PR DESCRIPTION
Closes #3146.

Two of the issue's three suggested directions, adjusted for what already shipped since it was filed:

1. **Client pre-check** — `togglePublic` (both generator and recipe-detail) runs `slugFromTitle(recipe.name)` before flipping anything: a title with no ASCII alphanumerics gets the toast *"This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."* and no request is made. Client/server derivation parity is pinned by the existing slug spec, so the pre-check is authoritative for this failure class.
2. **Failure surfacing** — the optimistic-revert half of the issue was already fixed (KAN-119 era: `saveRecipe` resolves `false`, `togglePublic` reverts) but the revert was **silent**. It now shows "Publishing/Unpublishing failed to sync to the server. Check your connection and try again."

Not done: propagating the server's `PUBLIC_SLUG_REQUIRED_ERROR` body through `_apiSaveRecipe`'s boolean contract — with the pre-check in place that 400 is unreachable for this failure class, and widening the return type would touch three other call sites for no user-visible gain (YAGNI).

**Related finding** (feeds #3147): the UI currently has **no rename affordance for existing recipes** — the manual-entry modal always creates a new recipe (fresh UUID), and generator/detail only edit notes. So the only way a user hits this toast is at manual-create time, and the only 'fix' is re-creating the recipe with a usable title.

## Verification

- New tests: empty-slug pre-check (blocks, toasts, no save) + failed-sync revert toast — src suite **90/90 green**
- lint / format / type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

