### PR TITLE
feat(spa): manual-entry publish lock + private personalNotes split [KAN-140]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   server's 400 silently, and a publish/unpublish that fails to sync now
   reverts _and_ tells the user (previously it only reverted).
 
+### Security
+
+- **Manually entered recipes can no longer be published** (KAN-140): the
+  manual-entry form is unmediated free text, and the notes-abuse walkthrough
+  (live-verified) showed post-publish edits reach the public page instantly.
+  New Backend `origin` column ('manual' | 'generated' | 'saved', backfilled
+  from the manual-entry blob signature, immutable once set) with a publish
+  gate returning 400; SPA disables the toggle for manual recipes and stamps
+  provenance at creation. **Notes are split into two fields**: generated
+  notes are now read-only (they render on the public page) and the editor
+  writes a new private `personalNotes` field that the public payload
+  allowlist never exposes — closing the edit-notes-after-publish loop
+  (live-verified on /r/vegan-zucchini-poppers). Requires Backend
+  [tasteslikegood.com#240](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/240).
+
 ### Added
 
 - **Publish state resolves to one DB row** (KAN-139,

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -532,9 +532,14 @@
           </div>
 
           @if (isEditingNotes()) {
-            <p class="text-yellow-900 italic whitespace-pre-wrap">
-              {{ r.notes || 'No notes added yet.' }}
-            </p>
+            <!-- Only real generated notes render here: the "No notes added
+                 yet." fallback above an empty personal-notes textarea reads
+                 as the textarea's own empty state (review of #3252). -->
+            @if (r.notes) {
+              <p class="text-yellow-900 italic whitespace-pre-wrap">
+                {{ r.notes }}
+              </p>
+            }
             <div class="mt-3">
               <label class="block text-xs font-bold text-yellow-800 mb-1"
                 >My notes (private — never published)</label

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -177,13 +177,19 @@
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
-                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [disabled]="
+                      publishToggleKind(r) === 'locked' ||
+                      publishToggleKind(r) === 'manual' ||
+                      publishTogglePending()
+                    "
                     [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
                     [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
-                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
+                    [class.cursor-not-allowed]="
+                      publishToggleKind(r) === 'locked' || publishToggleKind(r) === 'manual'
+                    "
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"
@@ -498,11 +504,14 @@
               </svg>
               Chef's Notes
             </h4>
+            <!-- KAN-140: generated notes are read-only (they render on the
+                 public page); the pencil edits the private personalNotes
+                 field, which the public payload allowlist never exposes. -->
             @if (!isEditingNotes()) {
               <button
                 (click)="startEditNotes()"
                 class="text-yellow-700 hover:text-yellow-900 opacity-0 group-hover:opacity-100 transition-opacity"
-                title="Edit Notes"
+                title="Edit my private notes"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -523,7 +532,13 @@
           </div>
 
           @if (isEditingNotes()) {
+            <p class="text-yellow-900 italic whitespace-pre-wrap">
+              {{ r.notes || 'No notes added yet.' }}
+            </p>
             <div class="mt-3">
+              <label class="block text-xs font-bold text-yellow-800 mb-1"
+                >My notes (private — never published)</label
+              >
               <textarea
                 [(ngModel)]="editedNotes"
                 rows="4"
@@ -548,6 +563,13 @@
             <p class="text-yellow-900 italic whitespace-pre-wrap">
               {{ r.notes || 'No notes added yet.' }}
             </p>
+            @if (r.personalNotes) {
+              <p
+                class="mt-3 pt-3 border-t border-yellow-100 text-yellow-900/80 italic whitespace-pre-wrap text-sm"
+              >
+                <span class="font-bold not-italic">My notes (private): </span>{{ r.personalNotes }}
+              </p>
+            }
           }
         </div>
       </div>

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -87,7 +87,12 @@ export class GeneratorComponent {
     this.servingsMultiplier.set(1);
 
     try {
-      const generatedRecipe = await this.geminiService.generateRecipe(this.prompt());
+      const generatedRecipe: Recipe = {
+        ...(await this.geminiService.generateRecipe(this.prompt())),
+        // KAN-140: provenance label; lets the server distinguish
+        // AI-mediated content from manual entry.
+        origin: 'generated',
+      };
       this.recipe.set(generatedRecipe);
       this.isSaved.set(true);
       await this.persistenceService.saveRecipe(generatedRecipe);
@@ -150,10 +155,11 @@ export class GeneratorComponent {
 
   startEditNotes() {
     const r = this.recipe();
-    if (r) {
-      this.editedNotes.set(r.notes || '');
-      this.isEditingNotes.set(true);
-    }
+    if (!r) return;
+    // KAN-140: the editor only ever touches personalNotes — the generated
+    // notes render on the public page and must not be user-writable.
+    this.editedNotes.set(r.personalNotes || '');
+    this.isEditingNotes.set(true);
   }
 
   cancelEditNotes() {
@@ -164,7 +170,7 @@ export class GeneratorComponent {
   async saveNotes() {
     const r = this.recipe();
     if (r) {
-      const updatedRecipe = { ...r, notes: this.editedNotes() };
+      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
       this.recipe.set(updatedRecipe);
       await this.persistenceService.saveRecipe(updatedRecipe);
       this.isEditingNotes.set(false);
@@ -202,6 +208,13 @@ export class GeneratorComponent {
     // this guard backstops it.
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
+
+    // KAN-140: manually entered recipes cannot be published — the server
+    // rejects with 400; the template disables the toggle, this backstops it.
+    if (nextState && recipe.origin === 'manual') {
+      this.toastService.show("Manually entered recipes can't be published.");
+      return;
+    }
 
     // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
     // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
@@ -265,7 +278,7 @@ export class GeneratorComponent {
     return publicSlugOf(recipe);
   }
 
-  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+  publishToggleKind(recipe: Recipe): 'locked' | 'manual' | 'source' | 'normal' {
     return publishToggleKind(recipe);
   }
 
@@ -277,6 +290,7 @@ export class GeneratorComponent {
     if (this.publishTogglePending()) return 'Checking publish state…';
     const kind = publishToggleKind(recipe);
     if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'manual') return "Manually entered recipes can't be published.";
     if (kind === 'source') {
       return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
     }

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -79,13 +79,19 @@
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
-                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [disabled]="
+                      publishToggleKind(r) === 'locked' ||
+                      publishToggleKind(r) === 'manual' ||
+                      publishTogglePending()
+                    "
                     [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
                     [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
-                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
+                    [class.cursor-not-allowed]="
+                      publishToggleKind(r) === 'locked' || publishToggleKind(r) === 'manual'
+                    "
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"
@@ -401,11 +407,14 @@
               </svg>
               Chef's Notes
             </h4>
+            <!-- KAN-140: generated notes are read-only (they render on the
+                 public page); the pencil edits the private personalNotes
+                 field, which the public payload allowlist never exposes. -->
             @if (!isEditingNotes()) {
               <button
                 (click)="startEditNotes()"
                 class="text-yellow-700 hover:text-yellow-900 opacity-0 group-hover:opacity-100 transition-opacity"
-                title="Edit Notes"
+                title="Edit my private notes"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -426,7 +435,13 @@
           </div>
 
           @if (isEditingNotes()) {
+            <p class="text-yellow-900 italic whitespace-pre-wrap">
+              {{ r.notes || 'No notes added yet.' }}
+            </p>
             <div class="mt-3">
+              <label class="block text-xs font-bold text-yellow-800 mb-1"
+                >My notes (private — never published)</label
+              >
               <textarea
                 [(ngModel)]="editedNotes"
                 rows="4"
@@ -451,6 +466,13 @@
             <p class="text-yellow-900 italic whitespace-pre-wrap">
               {{ r.notes || 'No notes added yet.' }}
             </p>
+            @if (r.personalNotes) {
+              <p
+                class="mt-3 pt-3 border-t border-yellow-100 text-yellow-900/80 italic whitespace-pre-wrap text-sm"
+              >
+                <span class="font-bold not-italic">My notes (private): </span>{{ r.personalNotes }}
+              </p>
+            }
           }
         </div>
       </div>

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -435,9 +435,14 @@
           </div>
 
           @if (isEditingNotes()) {
-            <p class="text-yellow-900 italic whitespace-pre-wrap">
-              {{ r.notes || 'No notes added yet.' }}
-            </p>
+            <!-- Only real generated notes render here: the "No notes added
+                 yet." fallback above an empty personal-notes textarea reads
+                 as the textarea's own empty state (review of #3252). -->
+            @if (r.notes) {
+              <p class="text-yellow-900 italic whitespace-pre-wrap">
+                {{ r.notes }}
+              </p>
+            }
             <div class="mt-3">
               <label class="block text-xs font-bold text-yellow-800 mb-1"
                 >My notes (private — never published)</label

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -108,6 +108,50 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
 
   // KAN-137 confirm-guard: first publish of a copy saved from a public recipe
   // must be an informed choice — and "no" must leave the recipe untouched.
+  // KAN-140: generated notes render live on /r/<slug> unmoderated, so the
+  // editor only ever touches the private personalNotes field.
+  describe('notes editor edits personalNotes only', () => {
+    it('opens with personalNotes, not the generated notes', () => {
+      const { component } = createComponent({ isGuest: false });
+      component.recipe.set({
+        id: 'pub-1',
+        name: 'Vegan Cornbread',
+        is_public: true,
+        slug: 'vegan-cornbread',
+        notes: 'generated public notes',
+        personalNotes: 'my private tweaks',
+      } as never);
+
+      component.startEditNotes();
+
+      expect(component.isEditingNotes()).toBe(true);
+      expect(component.editedNotes()).toBe('my private tweaks');
+    });
+
+    it('saveNotes writes personalNotes and leaves the generated notes untouched', async () => {
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+      component.recipe.set({
+        id: 'pub-1',
+        name: 'Vegan Cornbread',
+        is_public: true,
+        slug: 'vegan-cornbread',
+        notes: 'generated public notes',
+      } as never);
+
+      component.startEditNotes();
+      component.editedNotes.set('do not tell the internet');
+      await component.saveNotes();
+
+      const saved = component.recipe() as {
+        notes?: string;
+        personalNotes?: string;
+      } | null;
+      expect(saved?.notes).toBe('generated public notes');
+      expect(saved?.personalNotes).toBe('do not tell the internet');
+      expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('togglePublic confirm-guard', () => {
     const savedCopy = () =>
       ({
@@ -190,6 +234,24 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       expect(recipe.is_public).toBeFalsy();
       expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/publishing failed to sync/i));
       expect(consoleError).toHaveBeenCalled();
+    });
+
+    // KAN-140: manually entered recipes cannot be published.
+    it('blocks publishing a manually entered recipe with a toast', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = {
+        ...(savedCopy() as object),
+        sourceSlug: undefined,
+        origin: 'manual',
+      } as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/manually entered/i));
+      expect(recipe.is_public).toBeFalsy();
+      expect(persistenceSaveRecipe).not.toHaveBeenCalled();
     });
 
     // KAN-139: canonical recipes are server-locked — the toggle must be inert.

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -145,10 +145,11 @@ export class RecipeDetailComponent {
 
   startEditNotes() {
     const r = this.recipe();
-    if (r) {
-      this.editedNotes.set(r.notes || '');
-      this.isEditingNotes.set(true);
-    }
+    if (!r) return;
+    // KAN-140: the editor only ever touches personalNotes — the generated
+    // notes render on the public page and must not be user-writable.
+    this.editedNotes.set(r.personalNotes || '');
+    this.isEditingNotes.set(true);
   }
 
   cancelEditNotes() {
@@ -159,7 +160,7 @@ export class RecipeDetailComponent {
   async saveNotes() {
     const r = this.recipe();
     if (r) {
-      const updatedRecipe = { ...r, notes: this.editedNotes() };
+      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
       this.recipe.set(updatedRecipe);
       await this.persistenceService.saveRecipe(updatedRecipe);
       this.isEditingNotes.set(false);
@@ -178,6 +179,13 @@ export class RecipeDetailComponent {
     // this guard backstops it.
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
+
+    // KAN-140: manually entered recipes cannot be published — the server
+    // rejects with 400; the template disables the toggle, this backstops it.
+    if (nextState && recipe.origin === 'manual') {
+      this.toastService.show("Manually entered recipes can't be published.");
+      return;
+    }
 
     // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
     // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
@@ -241,7 +249,7 @@ export class RecipeDetailComponent {
     return publicLinkKind(recipe);
   }
 
-  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+  publishToggleKind(recipe: Recipe): 'locked' | 'manual' | 'source' | 'normal' {
     return publishToggleKind(recipe);
   }
 
@@ -253,6 +261,7 @@ export class RecipeDetailComponent {
     if (this.publishTogglePending()) return 'Checking publish state…';
     const kind = publishToggleKind(recipe);
     if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'manual') return "Manually entered recipes can't be published.";
     if (kind === 'source') {
       return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
     }

--- a/src/modals/manual-entry/manual-entry-modal.component.ts
+++ b/src/modals/manual-entry/manual-entry-modal.component.ts
@@ -130,6 +130,10 @@ export class ManualEntryModalComponent {
         .map((t) => t.trim())
         .filter((t) => t),
       image_keywords: [info.name, 'homemade'],
+      // KAN-140: manually entered recipes are not publishable — the server
+      // gates on this label (and backfills legacy rows via the
+      // image_keywords signature above).
+      origin: 'manual',
     };
 
     await this.persistenceService.saveRecipe(newRecipe);

--- a/src/recipe.types.ts
+++ b/src/recipe.types.ts
@@ -27,6 +27,13 @@ export interface Recipe {
   ingredients: IngredientGroup;
   instructions: (string | InstructionStep)[];
   notes?: string;
+  /**
+   * KAN-140 — the user's private notes. The only notes field the SPA editor
+   * writes; never rendered publicly (the Backend public payload/template
+   * allowlist exposes `notes` only). `notes` above is generated content and
+   * is read-only in the UI.
+   */
+  personalNotes?: string;
   tags?: string[];
   image_keywords?: string[];
   stock_image_url?: string;
@@ -48,4 +55,10 @@ export interface Recipe {
    * locked recipe with 400. The UI disables those controls up front.
    */
   is_canonical?: boolean;
+  /**
+   * KAN-140 — how the recipe entered the system. Manually entered recipes
+   * cannot be published (server rejects with 400; the toggle is disabled).
+   * Server-side the column is settable while NULL and immutable once set.
+   */
+  origin?: 'manual' | 'generated' | 'saved';
 }

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -268,6 +268,7 @@ export class PersistenceService {
             is_public?: boolean;
             is_canonical?: boolean;
             source_slug?: string | null;
+            origin?: Recipe['origin'] | null;
           }) => {
             if (r.is_canonical === undefined) return r.data;
             return {
@@ -276,6 +277,7 @@ export class PersistenceService {
               is_public: r.is_public,
               is_canonical: r.is_canonical,
               sourceSlug: r.data.sourceSlug ?? r.source_slug ?? undefined,
+              origin: r.origin ?? r.data.origin,
             };
           }
         );

--- a/src/services/public-recipe.mapper.ts
+++ b/src/services/public-recipe.mapper.ts
@@ -29,5 +29,6 @@ export function buildSavedRecipeFromPublic(recipeData: Partial<Recipe>): Recipe 
     // cookbook" can detect the duplicate and point the user at the copy they
     // already have instead of silently adding another.
     sourceSlug: recipeData.slug,
+    origin: 'saved',
   };
 }

--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -130,6 +130,28 @@ describe('publishToggleKind', () => {
     ).toBe('normal');
   });
 
+  // KAN-140: manually entered recipes can't be published — toggle disabled
+  // while unpublished; legacy published manual rows stay unpublish-able.
+  it('is manual for an unpublished manually entered recipe', () => {
+    expect(publishToggleKind({ origin: 'manual' })).toBe('manual');
+    expect(publishToggleKind({ origin: 'manual', is_public: false })).toBe('manual');
+    // Manual wins over the source rendering — the gate matters more.
+    expect(publishToggleKind({ origin: 'manual', sourceSlug: 'x' })).toBe('manual');
+  });
+
+  it('is normal for a legacy published manual recipe (so it can be unpublished)', () => {
+    expect(publishToggleKind({ origin: 'manual', is_public: true, slug: 'legacy' })).toBe('normal');
+  });
+
+  it('canonical lock wins over manual origin', () => {
+    expect(publishToggleKind({ origin: 'manual', is_canonical: true })).toBe('locked');
+  });
+
+  it('is normal for generated and saved origins', () => {
+    expect(publishToggleKind({ origin: 'generated' })).toBe('normal');
+    expect(publishToggleKind({ origin: 'saved', sourceSlug: 'x' })).toBe('source');
+  });
+
   it('is normal for ordinary own recipes, published or not', () => {
     expect(publishToggleKind({})).toBe('normal');
     expect(publishToggleKind({ is_public: true, slug: 'a' })).toBe('normal');

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -63,6 +63,11 @@ export function publicLinkKind(recipe: {
  * 'locked' — canonical recipe: the server rejects unpublish/re-slug/delete
  *            with 400, so the toggle is disabled outright with an
  *            explanatory title.
+ * 'manual' — a manually entered, unpublished recipe (KAN-140): the server
+ *            rejects publishing it with 400, so the toggle is disabled.
+ *            Published manual rows (legacy, pre-gate) fall through to
+ *            'normal' — they must stay unpublishable-off but
+ *            unpublish-able.
  * 'source' — a copy saved from a public recipe that is not itself
  *            published: rendered greyed by default (its publish state
  *            belongs to the source page), but still clickable — the
@@ -75,9 +80,13 @@ export function publishToggleKind(recipe: {
   slug?: string;
   sourceSlug?: string;
   is_canonical?: boolean;
-}): 'locked' | 'source' | 'normal' {
+  origin?: string;
+}): 'locked' | 'manual' | 'source' | 'normal' {
   if (recipe.is_canonical === true) {
     return 'locked';
+  }
+  if (recipe.origin === 'manual' && recipe.is_public !== true) {
+    return 'manual';
   }
   return publicLinkKind(recipe) === 'source' ? 'source' : 'normal';
 }


### PR DESCRIPTION
SPA half of KAN-140, pairs with Backend [tasteslikegood.com#240](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/240) (merged — pointer bump `0e1cf91 → 8409e3c` included here). Closes the two abuse loops from Adam's walkthrough, live-verified on `/r/vegan-zucchini-poppers`.

## What

**Manual recipes can't be published:**
- Manual-entry modal stamps `origin: 'manual'` (server backfills legacy rows via the `image_keywords` signature and gates publish with 400)
- Generator stamps `origin: 'generated'`, saved copies `'saved'` — full provenance going forward
- `publishToggleKind` gains `'manual'`: toggle disabled + tooltip *"Manually entered recipes can't be published."* for unpublished manual recipes. Legacy **published** manual rows deliberately fall through to `'normal'` so they can still be unpublished (re-publish then 400s → the KAN-104 revert+toast fires)
- `togglePublic` backstops the disabled control with a toast

**Notes split (Adam's design — generated vs personal):**
- Generated `notes` are now **read-only** in the UI: they render on the public page, and unreviewed edits must never reach it
- The pencil now edits a new private `personalNotes` blob field — labeled *"My notes (private — never published)"* — shown beneath the chef's notes. `_save_recipe_payload` and the SSR template are explicit **allowlists**, so `personalNotes` can never leak through `/api/recipes/public/<slug>` or `/r/<slug>`; no Backend change needed for the split
- Both generator and recipe-detail

**Known limit (accepted, same trust model as the guest gate):** a raw API caller can still write the `notes` blob field directly — this closes the UI loop; server-side field-level write protection would be the follow-up if needed.

## Verification

- src Vitest **97/97** (new: publishToggleKind manual matrix incl. legacy-published fallthrough + canonical-wins, togglePublic manual toast, notes editor opens with personalNotes on a published recipe, saveNotes preserves generated notes)
- lint / format / type-check / build clean
- Backend 327/327 on #240 (origin gate, immutability/laundering, backfill smoke test)

## Gate

Ships with the next release (same wave as KAN-139's migration — heads chain `c8d2f6a1e9b3 → d1e5a9c3f7b2`, single head). Adam's walkthrough round 2 covers: manual recipe → toggle greyed; published recipe → pencil edits only private notes; `/r/` page unchanged by personal notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

