### PR TITLE
chore(deploy): wire VALKEY_CA_CERT into the migrate job [KAN-136]

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -131,7 +131,12 @@ steps:
       - --parallelism=1
       - --tasks=1
       - --set-env-vars=FLASK_APP=app.py,FLASK_ENV=production,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
-      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest
+      # VALKEY_CA_CERT: without it the app factory's Valkey client fails TLS
+      # verification (CERTIFICATE_VERIFY_FAILED) on every Job run and falls
+      # back to SimpleCache — harmless for a migration, but it spams error
+      # logs and masks real Valkey regressions (KAN-136 dedupe-run finding).
+      # Same secret the flask-backend service receives below.
+      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest,VALKEY_CA_CERT=VALKEY_CA_CERT:latest
       # The DATABASE_URL secret is configured for Cloud SQL Unix-socket
       # connection (postgresql://...?host=/cloudsql/<instance>), matching
       # the Flask service. Without this flag the socket path doesn't exist


### PR DESCRIPTION
Closes the migrate-job finding from the Sprint 3 item-A dedupe run: `flask-backend-migrate` mirrors the Flask service's env **except** `VALKEY_CA_CERT`, so every Job execution logs `TLS CERTIFICATE_VERIFY_FAILED` from the Valkey client and falls back to in-process SimpleCache. Harmless for a one-shot migration, but it spams error logs and would mask a real Valkey regression during deploys.

One-line fix: add `VALKEY_CA_CERT=VALKEY_CA_CERT:latest` to the Job's `--set-secrets`, matching the service deploy step below it (same secret the service has had since #3176). Takes effect automatically at the next tag-push Cloud Build.

Verification: `yaml.safe_load` clean; no other steps touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

