### PR TITLE
feat(deploy): image-repair Cloud Run Job wiring + Backend pointer 50cdbbb [KAN-141]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Scheduled image repair** (KAN-141): new deploy-only Cloud Run Job
+  `flask-backend-image-repair` — detects recipes with no image bytes
+  (canonical first, then published, then oldest; the blank-hero
+  URL-without-bytes rows count as imageless) and enqueues regeneration
+  through the existing Pub/Sub worker path, capped per run
+  (`IMAGE_REPAIR_LIMIT=10`). Runs daily via a one-time Cloud Scheduler
+  trigger created after the first deploy. Backend script:
+  [tasteslikegood.com#241](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/241).
 - **Publish state resolves to one DB row** (KAN-139,
   [#3217](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3217)):
   Backend migration adds `is_canonical` (locks the 7 curated canonical

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -163,6 +163,40 @@ steps:
       - --wait
       - --quiet
 
+  # KAN-141: scheduled image-repair Job. Deploy-only — builds never execute
+  # it; a Cloud Scheduler trigger (created once, out of band) runs it daily.
+  # It detects recipes with no image bytes (canonical first, then published)
+  # and enqueues regeneration through the same Pub/Sub path as the SPA's
+  # regenerate button; the flask-backend worker does the Imagen work, so the
+  # Job needs no Gemini credentials. Env/secrets mirror the migrate Job
+  # (same create_app boot) plus IMAGE_REPAIR_LIMIT.
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: 'Deploy Image Repair Job'
+    waitFor: ['Push Flask Backend Image']
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - deploy
+      - flask-backend-image-repair
+      - --image=$_IMAGE_REGISTRY/flask-backend:$SHORT_SHA
+      - --region=$_REGION
+      - --command=python
+      - --args=scripts/repair_missing_images.py
+      - --max-retries=1
+      - --task-timeout=600
+      - --cpu=1
+      - --memory=1Gi
+      - --parallelism=1
+      - --tasks=1
+      - --set-env-vars=FLASK_APP=app.py,FLASK_ENV=production,IMAGE_REPAIR_LIMIT=10,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
+      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest,VALKEY_CA_CERT=VALKEY_CA_CERT:latest
+      - --set-cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db
+      - --network=default
+      - --subnet=default
+      - --vpc-egress=private-ranges-only
+      - --quiet
+
   # ── Deploy ───────────────────────────────────────────────────────────────────
   # KAN-30: Flask backend deploys first; Express frontend waits on its completion
   # so the new frontend never serves against the old API during rollout.


### PR DESCRIPTION
## Summary

Sprint 3 (epic KAN-136), KAN-141 second half: ships the **`flask-backend-image-repair`** Cloud Run Job wiring plus the Backend pointer bump that carries the repair script itself.

### Backend pointer: cb218ab → 50cdbbb
Picks up Backend #241 — `scripts/repair_missing_images.py`: detects recipes whose blob has neither `ai_image_data` nor `ai_image_gcs` (the blank-hero rows — `ai_image_url` alone doesn't count), and enqueues regeneration through the exact Pub/Sub path the SPA's regenerate button uses (`queue_image_generation` + `image-generation` topic; the worker does the Imagen call, so the job needs no Gemini credentials). Priority `is_canonical DESC, is_public DESC, created_at ASC`; capped at `IMAGE_REPAIR_LIMIT` (default 10) per run so a backlog drains without burning Imagen quota. Includes a claude[bot] perf follow-up streaming `select_candidates` via `yield_per(200)` instead of loading the whole ready table. 7 tests; Backend suite green.

### cloudbuild.yaml: new `Deploy Image Repair Job` step
Deploy-only (no execute step — unlike the migrate job, nothing gates the release on it): mirrors the migrate job's env/secrets (+ `IMAGE_REPAIR_LIMIT=10`, `VALKEY_CA_CERT`), same VPC/cloudsql wiring, `waitFor: Push Flask Backend Image`, command overridden to `python scripts/repair_missing_images.py`.

### Post-release follow-up (manual, one-time)
Create the Cloud Scheduler trigger for the job after the first release deploys it — it can't be scheduled before it exists.

### CHANGELOG
Unreleased → Added entry for KAN-141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

