### PR TITLE
chore(release): bump v0.4.4 + changelog [KAN-138]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [Unreleased]
+## [0.4.4] - 2026-07-24
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@angular/build": "22.0.8",
         "@angular/cli": "22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
Release-train step (KAN-138 flow): version bump to 0.4.4 + CHANGELOG section on dev before the dev→main release PR.

Scope shipping in v0.4.4 (all merged to dev today):
- **KAN-139** — publish state resolves to one DB row: `is_canonical` lock (7 curated slugs) + `source_slug` column, greyed toggle states, repeat-save trap fix (#3250, Backend #239)
- **KAN-140** — security: manual-entry publish gate (`origin` column) + notes two-field split closing the live-verified publish-notes abuse loop (#3252, Backend #240)
- **KAN-141** — scheduled image repair: `flask-backend-image-repair` deploy-only Cloud Run Job + enqueuer script (#3257, Backend #241)
- **KAN-104** — publish failures no longer silent (#3251)
- **KAN-136** — migrate job gets `VALKEY_CA_CERT` (#3253)
- Backend Dependabot: python-production group + uv image (#242/#244)

**Two migrations ship**: `c8d2f6a1e9b3` → `d1e5a9c3f7b2` (single head verified). Backend pointer `50cdbbb` = Backend dev tip, promoting to main via [tasteslikegood.com#245](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

