### PR TITLE
release: v0.4.4 — canonical locks, manual-publish gate + notes split, image repair [KAN-138]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [Unreleased]
+## [0.4.4] - 2026-07-24
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   server's 400 silently, and a publish/unpublish that fails to sync now
   reverts _and_ tells the user (previously it only reverted).
 
+### Security
+
+- **Manually entered recipes can no longer be published** (KAN-140): the
+  manual-entry form is unmediated free text, and the notes-abuse walkthrough
+  (live-verified) showed post-publish edits reach the public page instantly.
+  New Backend `origin` column ('manual' | 'generated' | 'saved', backfilled
+  from the manual-entry blob signature, immutable once set) with a publish
+  gate returning 400; SPA disables the toggle for manual recipes and stamps
+  provenance at creation. **Notes are split into two fields**: generated
+  notes are now read-only (they render on the public page) and the editor
+  writes a new private `personalNotes` field that the public payload
+  allowlist never exposes — closing the edit-notes-after-publish loop
+  (live-verified on /r/vegan-zucchini-poppers). Requires Backend
+  [tasteslikegood.com#240](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/240).
+
 ### Added
 
 - **Publish state resolves to one DB row** (KAN-139,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Publish failures are no longer silent** (KAN-104,
+  [#3146](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3146)):
+  titles with no ASCII letters/numbers (all-emoji, pure-CJK/Cyrillic) are
+  pre-checked client-side with an explanatory toast instead of hitting the
+  server's 400 silently, and a publish/unpublish that fails to sync now
+  reverts _and_ tells the user (previously it only reverted).
+
 ### Added
 
 - **Publish state resolves to one DB row** (KAN-139,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Publish state resolves to one DB row** (KAN-139,
+  [#3217](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3217)):
+  Backend migration adds `is_canonical` (locks the 7 curated canonical
+  recipes — unpublish/re-slug/delete return 400; content edits still allowed)
+  and `source_slug` (server-side mirror of the blob's `sourceSlug`,
+  backfilled). SPA renders the publish toggle greyed while the initial server
+  sync is pending and for copies saved from a public recipe (tooltip names
+  the source page), disables it outright for canonical recipes, and disables
+  delete for canonical recipes in the Kitchen. The SSR CTA's repeat-save
+  dedup now waits for the server recipe list, so copies that exist only
+  server-side (or with stale local blobs) are caught instead of re-saved.
+  Requires the Backend pointer bump to
+  [tasteslikegood.com#239](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/239).
+
 ---
 
 ## [0.4.3] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Scheduled image repair** (KAN-141): new deploy-only Cloud Run Job
+  `flask-backend-image-repair` — detects recipes with no image bytes
+  (canonical first, then published, then oldest; the blank-hero
+  URL-without-bytes rows count as imageless) and enqueues regeneration
+  through the existing Pub/Sub worker path, capped per run
+  (`IMAGE_REPAIR_LIMIT=10`). Runs daily via a one-time Cloud Scheduler
+  trigger created after the first deploy. Backend script:
+  [tasteslikegood.com#241](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/241).
 - **Publish state resolves to one DB row** (KAN-139,
   [#3217](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3217)):
   Backend migration adds `is_canonical` (locks the 7 curated canonical

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -131,7 +131,12 @@ steps:
       - --parallelism=1
       - --tasks=1
       - --set-env-vars=FLASK_APP=app.py,FLASK_ENV=production,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
-      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest
+      # VALKEY_CA_CERT: without it the app factory's Valkey client fails TLS
+      # verification (CERTIFICATE_VERIFY_FAILED) on every Job run and falls
+      # back to SimpleCache — harmless for a migration, but it spams error
+      # logs and masks real Valkey regressions (KAN-136 dedupe-run finding).
+      # Same secret the flask-backend service receives below.
+      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest,VALKEY_CA_CERT=VALKEY_CA_CERT:latest
       # The DATABASE_URL secret is configured for Cloud SQL Unix-socket
       # connection (postgresql://...?host=/cloudsql/<instance>), matching
       # the Flask service. Without this flag the socket path doesn't exist

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -163,6 +163,40 @@ steps:
       - --wait
       - --quiet
 
+  # KAN-141: scheduled image-repair Job. Deploy-only — builds never execute
+  # it; a Cloud Scheduler trigger (created once, out of band) runs it daily.
+  # It detects recipes with no image bytes (canonical first, then published)
+  # and enqueues regeneration through the same Pub/Sub path as the SPA's
+  # regenerate button; the flask-backend worker does the Imagen work, so the
+  # Job needs no Gemini credentials. Env/secrets mirror the migrate Job
+  # (same create_app boot) plus IMAGE_REPAIR_LIMIT.
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: 'Deploy Image Repair Job'
+    waitFor: ['Push Flask Backend Image']
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - deploy
+      - flask-backend-image-repair
+      - --image=$_IMAGE_REGISTRY/flask-backend:$SHORT_SHA
+      - --region=$_REGION
+      - --command=python
+      - --args=scripts/repair_missing_images.py
+      - --max-retries=1
+      - --task-timeout=600
+      - --cpu=1
+      - --memory=1Gi
+      - --parallelism=1
+      - --tasks=1
+      - --set-env-vars=FLASK_APP=app.py,FLASK_ENV=production,IMAGE_REPAIR_LIMIT=10,VALKEY_HOST=10.128.0.11,VALKEY_AUTH_MODE=iam,GOOGLE_CLIENT_ID=746675616486-ssnh50hs4fls688m7bvjqtpak7ob8qu1.apps.googleusercontent.com,FRONTEND_URL=https://www.tasteslikegood.org,SESSION_COOKIE_DOMAIN=.tasteslikegood.org,GCS_BUCKET_NAME=tasteslikegood-recipe-images,GCP_PROJECT_ID=comdottasteslikegood,PUBSUB_INVOKER_SA=pubsub-pusher@comdottasteslikegood.iam.gserviceaccount.com
+      - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest,VALKEY_CA_CERT=VALKEY_CA_CERT:latest
+      - --set-cloudsql-instances=comdottasteslikegood:us-central1:vegangenius-db
+      - --network=default
+      - --subnet=default
+      - --vpc-egress=private-ranges-only
+      - --quiet
+
   # ── Deploy ───────────────────────────────────────────────────────────────────
   # KAN-30: Flask backend deploys first; Express frontend waits on its completion
   # so the new frontend never serves against the old API during rollout.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@angular/build": "22.0.8",
         "@angular/cli": "22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "ng serve",

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -532,9 +532,14 @@
           </div>
 
           @if (isEditingNotes()) {
-            <p class="text-yellow-900 italic whitespace-pre-wrap">
-              {{ r.notes || 'No notes added yet.' }}
-            </p>
+            <!-- Only real generated notes render here: the "No notes added
+                 yet." fallback above an empty personal-notes textarea reads
+                 as the textarea's own empty state (review of #3252). -->
+            @if (r.notes) {
+              <p class="text-yellow-900 italic whitespace-pre-wrap">
+                {{ r.notes }}
+              </p>
+            }
             <div class="mt-3">
               <label class="block text-xs font-bold text-yellow-800 mb-1"
                 >My notes (private — never published)</label

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -168,15 +168,22 @@
                     class="text-[10px] font-bold uppercase text-stone-400"
                     >Public</span
                   >
+                  <!-- KAN-139: greyed while the initial server sync is pending
+                       and for copies saved from a public recipe; disabled
+                       outright when the recipe is canonical (server-locked). -->
                   <button
                     type="button"
                     role="switch"
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
+                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
+                    [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
+                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -177,13 +177,19 @@
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
-                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [disabled]="
+                      publishToggleKind(r) === 'locked' ||
+                      publishToggleKind(r) === 'manual' ||
+                      publishTogglePending()
+                    "
                     [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
                     [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
-                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
+                    [class.cursor-not-allowed]="
+                      publishToggleKind(r) === 'locked' || publishToggleKind(r) === 'manual'
+                    "
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"
@@ -498,11 +504,14 @@
               </svg>
               Chef's Notes
             </h4>
+            <!-- KAN-140: generated notes are read-only (they render on the
+                 public page); the pencil edits the private personalNotes
+                 field, which the public payload allowlist never exposes. -->
             @if (!isEditingNotes()) {
               <button
                 (click)="startEditNotes()"
                 class="text-yellow-700 hover:text-yellow-900 opacity-0 group-hover:opacity-100 transition-opacity"
-                title="Edit Notes"
+                title="Edit my private notes"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -523,7 +532,13 @@
           </div>
 
           @if (isEditingNotes()) {
+            <p class="text-yellow-900 italic whitespace-pre-wrap">
+              {{ r.notes || 'No notes added yet.' }}
+            </p>
             <div class="mt-3">
+              <label class="block text-xs font-bold text-yellow-800 mb-1"
+                >My notes (private — never published)</label
+              >
               <textarea
                 [(ngModel)]="editedNotes"
                 rows="4"
@@ -548,6 +563,13 @@
             <p class="text-yellow-900 italic whitespace-pre-wrap">
               {{ r.notes || 'No notes added yet.' }}
             </p>
+            @if (r.personalNotes) {
+              <p
+                class="mt-3 pt-3 border-t border-yellow-100 text-yellow-900/80 italic whitespace-pre-wrap text-sm"
+              >
+                <span class="font-bold not-italic">My notes (private): </span>{{ r.personalNotes }}
+              </p>
+            }
           }
         </div>
       </div>

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -87,7 +87,12 @@ export class GeneratorComponent {
     this.servingsMultiplier.set(1);
 
     try {
-      const generatedRecipe = await this.geminiService.generateRecipe(this.prompt());
+      const generatedRecipe: Recipe = {
+        ...(await this.geminiService.generateRecipe(this.prompt())),
+        // KAN-140: provenance label; lets the server distinguish
+        // AI-mediated content from manual entry.
+        origin: 'generated',
+      };
       this.recipe.set(generatedRecipe);
       this.isSaved.set(true);
       await this.persistenceService.saveRecipe(generatedRecipe);
@@ -150,10 +155,11 @@ export class GeneratorComponent {
 
   startEditNotes() {
     const r = this.recipe();
-    if (r) {
-      this.editedNotes.set(r.notes || '');
-      this.isEditingNotes.set(true);
-    }
+    if (!r) return;
+    // KAN-140: the editor only ever touches personalNotes — the generated
+    // notes render on the public page and must not be user-writable.
+    this.editedNotes.set(r.personalNotes || '');
+    this.isEditingNotes.set(true);
   }
 
   cancelEditNotes() {
@@ -164,7 +170,7 @@ export class GeneratorComponent {
   async saveNotes() {
     const r = this.recipe();
     if (r) {
-      const updatedRecipe = { ...r, notes: this.editedNotes() };
+      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
       this.recipe.set(updatedRecipe);
       await this.persistenceService.saveRecipe(updatedRecipe);
       this.isEditingNotes.set(false);
@@ -202,6 +208,13 @@ export class GeneratorComponent {
     // this guard backstops it.
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
+
+    // KAN-140: manually entered recipes cannot be published — the server
+    // rejects with 400; the template disables the toggle, this backstops it.
+    if (nextState && recipe.origin === 'manual') {
+      this.toastService.show("Manually entered recipes can't be published.");
+      return;
+    }
 
     // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
     // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
@@ -265,7 +278,7 @@ export class GeneratorComponent {
     return publicSlugOf(recipe);
   }
 
-  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+  publishToggleKind(recipe: Recipe): 'locked' | 'manual' | 'source' | 'normal' {
     return publishToggleKind(recipe);
   }
 
@@ -277,6 +290,7 @@ export class GeneratorComponent {
     if (this.publishTogglePending()) return 'Checking publish state…';
     const kind = publishToggleKind(recipe);
     if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'manual') return "Manually entered recipes can't be published.";
     if (kind === 'source') {
       return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
     }

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from '../../services/auth.service';
 import { PersistenceService } from '../../services/persistence.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ModalService } from '../../services/modal.service';
+import { ToastService } from '../../services/toast.service';
 import {
   isPublicViewable,
   publicLinkKind,
@@ -27,6 +28,7 @@ export class GeneratorComponent {
   readonly authService = inject(AuthService);
   private readonly recipeState = inject(RecipeStateService);
   private readonly modalService = inject(ModalService);
+  private readonly toastService = inject(ToastService);
 
   readonly recipe = this.recipeState.currentRecipe;
   readonly generatedImageUrl = this.recipeState.generatedImageUrl;
@@ -201,6 +203,17 @@ export class GeneratorComponent {
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
+    // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
+    // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
+    // with 400. Same derivation as the server (parity is spec-pinned), so
+    // catch it before the round trip and say why instead of failing silently.
+    if (nextState && !recipe.slug && !this.slugFromTitle(recipe.name)) {
+      this.toastService.show(
+        "This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."
+      );
+      return;
+    }
+
     // KAN-137: first publish of a copy saved from a public recipe would mint
     // a near-identical second public page (name collision → -N slug). Make
     // that an informed choice instead of a silent side effect.
@@ -230,6 +243,13 @@ export class GeneratorComponent {
       console.error('Failed to toggle public state:', err);
       recipe.is_public = !nextState;
       this.authService.saveRecipe(recipe);
+      // KAN-104 (#3146): the revert already worked; without a message the
+      // user just sees the switch snap back with no explanation.
+      this.toastService.show(
+        nextState
+          ? 'Publishing failed to sync to the server. Check your connection and try again.'
+          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
+      );
     }
   }
 

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -6,7 +6,12 @@ import { AuthService } from '../../services/auth.service';
 import { PersistenceService } from '../../services/persistence.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ModalService } from '../../services/modal.service';
-import { isPublicViewable, publicLinkKind, publicSlugOf } from '../../utils/public-link';
+import {
+  isPublicViewable,
+  publicLinkKind,
+  publicSlugOf,
+  publishToggleKind,
+} from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
@@ -189,6 +194,11 @@ export class GeneratorComponent {
       this.modalService.openAuth();
       return;
     }
+    // KAN-139: the server rejects publish-state changes on canonical recipes
+    // (400), and while the initial sync is pending we don't yet know the
+    // authoritative state — the template disables the toggle in both cases;
+    // this guard backstops it.
+    if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
     // KAN-137: first publish of a copy saved from a public recipe would mint
@@ -233,6 +243,24 @@ export class GeneratorComponent {
 
   publicSlugOf(recipe: Recipe): string | null {
     return publicSlugOf(recipe);
+  }
+
+  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+    return publishToggleKind(recipe);
+  }
+
+  publishTogglePending(): boolean {
+    return this.persistenceService.publishStateSync() === 'pending';
+  }
+
+  publishToggleTitle(recipe: Recipe): string {
+    if (this.publishTogglePending()) return 'Checking publish state…';
+    const kind = publishToggleKind(recipe);
+    if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'source') {
+      return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
+    }
+    return recipe.is_public ? 'Unpublish this recipe' : 'Publish this recipe';
   }
 
   private slugFromTitle = slugFromTitle;

--- a/src/components/kitchen/kitchen.component.html
+++ b/src/components/kitchen/kitchen.component.html
@@ -380,10 +380,16 @@
                       />
                     </svg>
                   </button>
+                  <!-- KAN-139: canonical recipes are server-locked — DELETE returns 400. -->
                   <button
                     (click)="promptDeleteRecipe(r, $event)"
-                    class="p-1.5 bg-white/90 rounded-full text-stone-600 hover:text-red-600 shadow-sm backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
-                    title="Delete Recipe"
+                    [disabled]="r.is_canonical"
+                    class="p-1.5 bg-white/90 rounded-full text-stone-600 shadow-sm backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity"
+                    [class.hover:text-red-600]="!r.is_canonical"
+                    [class.cursor-not-allowed]="r.is_canonical"
+                    [title]="
+                      r.is_canonical ? 'Canonical recipe — cannot be deleted' : 'Delete Recipe'
+                    "
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/kitchen/kitchen.component.ts
+++ b/src/components/kitchen/kitchen.component.ts
@@ -84,6 +84,9 @@ export class KitchenComponent {
 
   promptDeleteRecipe(recipe: Recipe, event: Event) {
     event.stopPropagation();
+    // KAN-139: canonical recipes are server-locked (DELETE returns 400);
+    // the template disables the button — this backstops it.
+    if (recipe.is_canonical) return;
     this.recipeToDelete.set(recipe);
     this.showDeleteConfirmation.set(true);
   }

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -79,13 +79,19 @@
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
-                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [disabled]="
+                      publishToggleKind(r) === 'locked' ||
+                      publishToggleKind(r) === 'manual' ||
+                      publishTogglePending()
+                    "
                     [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
                     [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
-                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
+                    [class.cursor-not-allowed]="
+                      publishToggleKind(r) === 'locked' || publishToggleKind(r) === 'manual'
+                    "
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"
@@ -401,11 +407,14 @@
               </svg>
               Chef's Notes
             </h4>
+            <!-- KAN-140: generated notes are read-only (they render on the
+                 public page); the pencil edits the private personalNotes
+                 field, which the public payload allowlist never exposes. -->
             @if (!isEditingNotes()) {
               <button
                 (click)="startEditNotes()"
                 class="text-yellow-700 hover:text-yellow-900 opacity-0 group-hover:opacity-100 transition-opacity"
-                title="Edit Notes"
+                title="Edit my private notes"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -426,7 +435,13 @@
           </div>
 
           @if (isEditingNotes()) {
+            <p class="text-yellow-900 italic whitespace-pre-wrap">
+              {{ r.notes || 'No notes added yet.' }}
+            </p>
             <div class="mt-3">
+              <label class="block text-xs font-bold text-yellow-800 mb-1"
+                >My notes (private — never published)</label
+              >
               <textarea
                 [(ngModel)]="editedNotes"
                 rows="4"
@@ -451,6 +466,13 @@
             <p class="text-yellow-900 italic whitespace-pre-wrap">
               {{ r.notes || 'No notes added yet.' }}
             </p>
+            @if (r.personalNotes) {
+              <p
+                class="mt-3 pt-3 border-t border-yellow-100 text-yellow-900/80 italic whitespace-pre-wrap text-sm"
+              >
+                <span class="font-bold not-italic">My notes (private): </span>{{ r.personalNotes }}
+              </p>
+            }
           }
         </div>
       </div>

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -70,15 +70,22 @@
                     class="text-[10px] font-bold uppercase text-stone-400"
                     >Public</span
                   >
+                  <!-- KAN-139: greyed while the initial server sync is pending
+                       and for copies saved from a public recipe; disabled
+                       outright when the recipe is canonical (server-locked). -->
                   <button
                     type="button"
                     role="switch"
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
+                    [disabled]="publishToggleKind(r) === 'locked' || publishTogglePending()"
+                    [title]="publishToggleTitle(r)"
                     class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none shadow-inner"
                     [class.bg-green-600]="r.is_public"
                     [class.bg-stone-300]="!r.is_public"
+                    [class.opacity-40]="publishToggleKind(r) !== 'normal' || publishTogglePending()"
+                    [class.cursor-not-allowed]="publishToggleKind(r) === 'locked'"
                   >
                     <span
                       class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -435,9 +435,14 @@
           </div>
 
           @if (isEditingNotes()) {
-            <p class="text-yellow-900 italic whitespace-pre-wrap">
-              {{ r.notes || 'No notes added yet.' }}
-            </p>
+            <!-- Only real generated notes render here: the "No notes added
+                 yet." fallback above an empty personal-notes textarea reads
+                 as the textarea's own empty state (review of #3252). -->
+            @if (r.notes) {
+              <p class="text-yellow-900 italic whitespace-pre-wrap">
+                {{ r.notes }}
+              </p>
+            }
             <div class="mt-3">
               <label class="block text-xs font-bold text-yellow-800 mb-1"
                 >My notes (private — never published)</label

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -48,7 +48,10 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
             saveRecipe: vi.fn(),
           },
         },
-        { provide: PersistenceService, useValue: { saveRecipe: persistenceSaveRecipe } },
+        {
+          provide: PersistenceService,
+          useValue: { saveRecipe: persistenceSaveRecipe, publishStateSync: () => 'synced' },
+        },
         { provide: GeminiService, useValue: {} },
         { provide: RecipeStateService, useValue: recipeState },
         { provide: ToastService, useValue: { show: toastShow } },
@@ -153,6 +156,26 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       expect(confirmMock).not.toHaveBeenCalled();
       expect(recipe.is_public).toBe(true);
       expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+    });
+
+    // KAN-139: canonical recipes are server-locked — the toggle must be inert.
+    it('ignores toggle attempts on a canonical recipe', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = {
+        ...(savedCopy() as object),
+        sourceSlug: undefined,
+        is_canonical: true,
+        is_public: true,
+        slug: 'vegan-cornbread',
+      } as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(confirmMock).not.toHaveBeenCalled();
+      expect(recipe.is_public).toBe(true);
+      expect(persistenceSaveRecipe).not.toHaveBeenCalled();
     });
 
     it('does not prompt on unpublish', async () => {

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -158,6 +158,40 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
     });
 
+    // KAN-104 (#3146): empty-slug titles are pre-checked client-side with an
+    // explanatory toast instead of a silent server 400.
+    it('blocks publishing a title that derives an empty slug and says why', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = {
+        ...(savedCopy() as object),
+        name: '🌮🌮🌮',
+        sourceSlug: undefined,
+      } as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/can't be published/i));
+      expect(confirmMock).not.toHaveBeenCalled();
+      expect(recipe.is_public).toBeFalsy();
+      expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+    });
+
+    it('reverts and surfaces a toast when the publish fails to sync', async () => {
+      vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+      persistenceSaveRecipe.mockResolvedValue(false);
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const recipe = savedCopy() as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(recipe.is_public).toBeFalsy();
+      expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/publishing failed to sync/i));
+      expect(consoleError).toHaveBeenCalled();
+    });
+
     // KAN-139: canonical recipes are server-locked — the toggle must be inert.
     it('ignores toggle attempts on a canonical recipe', async () => {
       const confirmMock = vi.fn();

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -108,6 +108,50 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
 
   // KAN-137 confirm-guard: first publish of a copy saved from a public recipe
   // must be an informed choice — and "no" must leave the recipe untouched.
+  // KAN-140: generated notes render live on /r/<slug> unmoderated, so the
+  // editor only ever touches the private personalNotes field.
+  describe('notes editor edits personalNotes only', () => {
+    it('opens with personalNotes, not the generated notes', () => {
+      const { component } = createComponent({ isGuest: false });
+      component.recipe.set({
+        id: 'pub-1',
+        name: 'Vegan Cornbread',
+        is_public: true,
+        slug: 'vegan-cornbread',
+        notes: 'generated public notes',
+        personalNotes: 'my private tweaks',
+      } as never);
+
+      component.startEditNotes();
+
+      expect(component.isEditingNotes()).toBe(true);
+      expect(component.editedNotes()).toBe('my private tweaks');
+    });
+
+    it('saveNotes writes personalNotes and leaves the generated notes untouched', async () => {
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+      component.recipe.set({
+        id: 'pub-1',
+        name: 'Vegan Cornbread',
+        is_public: true,
+        slug: 'vegan-cornbread',
+        notes: 'generated public notes',
+      } as never);
+
+      component.startEditNotes();
+      component.editedNotes.set('do not tell the internet');
+      await component.saveNotes();
+
+      const saved = component.recipe() as {
+        notes?: string;
+        personalNotes?: string;
+      } | null;
+      expect(saved?.notes).toBe('generated public notes');
+      expect(saved?.personalNotes).toBe('do not tell the internet');
+      expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('togglePublic confirm-guard', () => {
     const savedCopy = () =>
       ({
@@ -190,6 +234,24 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       expect(recipe.is_public).toBeFalsy();
       expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/publishing failed to sync/i));
       expect(consoleError).toHaveBeenCalled();
+    });
+
+    // KAN-140: manually entered recipes cannot be published.
+    it('blocks publishing a manually entered recipe with a toast', async () => {
+      const confirmMock = vi.fn();
+      vi.stubGlobal('confirm', confirmMock);
+      const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+      const recipe = {
+        ...(savedCopy() as object),
+        sourceSlug: undefined,
+        origin: 'manual',
+      } as { is_public?: boolean };
+      await component.togglePublic(recipe as never);
+
+      expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/manually entered/i));
+      expect(recipe.is_public).toBeFalsy();
+      expect(persistenceSaveRecipe).not.toHaveBeenCalled();
     });
 
     // KAN-139: canonical recipes are server-locked — the toggle must be inert.

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -8,7 +8,12 @@ import { GeminiService } from '../../services/gemini.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ToastService } from '../../services/toast.service';
 import { ModalService } from '../../services/modal.service';
-import { isPublicViewable, publicLinkKind, publicSlugOf } from '../../utils/public-link';
+import {
+  isPublicViewable,
+  publicLinkKind,
+  publicSlugOf,
+  publishToggleKind,
+} from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
@@ -167,6 +172,11 @@ export class RecipeDetailComponent {
 
   async togglePublic(recipe: Recipe) {
     if (!this.canPublish()) return;
+    // KAN-139: the server rejects publish-state changes on canonical recipes
+    // (400), and while the initial sync is pending we don't yet know the
+    // authoritative state — the template disables the toggle in both cases;
+    // this guard backstops it.
+    if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
     // KAN-137: first publish of a copy saved from a public recipe would mint
@@ -211,6 +221,24 @@ export class RecipeDetailComponent {
 
   publicLinkKind(recipe: Recipe): 'own' | 'source' | null {
     return publicLinkKind(recipe);
+  }
+
+  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+    return publishToggleKind(recipe);
+  }
+
+  publishTogglePending(): boolean {
+    return this.persistenceService.publishStateSync() === 'pending';
+  }
+
+  publishToggleTitle(recipe: Recipe): string {
+    if (this.publishTogglePending()) return 'Checking publish state…';
+    const kind = publishToggleKind(recipe);
+    if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'source') {
+      return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
+    }
+    return recipe.is_public ? 'Unpublish this recipe' : 'Publish this recipe';
   }
 
   openAuthModal() {

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -179,6 +179,17 @@ export class RecipeDetailComponent {
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
 
+    // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
+    // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
+    // with 400. Same derivation as the server (parity is spec-pinned), so
+    // catch it before the round trip and say why instead of failing silently.
+    if (nextState && !recipe.slug && !this.slugFromTitle(recipe.name)) {
+      this.toastService.show(
+        "This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."
+      );
+      return;
+    }
+
     // KAN-137: first publish of a copy saved from a public recipe would mint
     // a near-identical second public page (name collision → -N slug). Make
     // that an informed choice instead of a silent side effect.
@@ -208,6 +219,13 @@ export class RecipeDetailComponent {
       console.error('Failed to toggle public state:', err);
       recipe.is_public = !nextState;
       this.authService.saveRecipe(recipe);
+      // KAN-104 (#3146): the revert already worked; without a message the
+      // user just sees the switch snap back with no explanation.
+      this.toastService.show(
+        nextState
+          ? 'Publishing failed to sync to the server. Check your connection and try again.'
+          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
+      );
     }
   }
 

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -145,10 +145,11 @@ export class RecipeDetailComponent {
 
   startEditNotes() {
     const r = this.recipe();
-    if (r) {
-      this.editedNotes.set(r.notes || '');
-      this.isEditingNotes.set(true);
-    }
+    if (!r) return;
+    // KAN-140: the editor only ever touches personalNotes — the generated
+    // notes render on the public page and must not be user-writable.
+    this.editedNotes.set(r.personalNotes || '');
+    this.isEditingNotes.set(true);
   }
 
   cancelEditNotes() {
@@ -159,7 +160,7 @@ export class RecipeDetailComponent {
   async saveNotes() {
     const r = this.recipe();
     if (r) {
-      const updatedRecipe = { ...r, notes: this.editedNotes() };
+      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
       this.recipe.set(updatedRecipe);
       await this.persistenceService.saveRecipe(updatedRecipe);
       this.isEditingNotes.set(false);
@@ -178,6 +179,13 @@ export class RecipeDetailComponent {
     // this guard backstops it.
     if (recipe.is_canonical || this.publishTogglePending()) return;
     const nextState = !recipe.is_public;
+
+    // KAN-140: manually entered recipes cannot be published — the server
+    // rejects with 400; the template disables the toggle, this backstops it.
+    if (nextState && recipe.origin === 'manual') {
+      this.toastService.show("Manually entered recipes can't be published.");
+      return;
+    }
 
     // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
     // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
@@ -241,7 +249,7 @@ export class RecipeDetailComponent {
     return publicLinkKind(recipe);
   }
 
-  publishToggleKind(recipe: Recipe): 'locked' | 'source' | 'normal' {
+  publishToggleKind(recipe: Recipe): 'locked' | 'manual' | 'source' | 'normal' {
     return publishToggleKind(recipe);
   }
 
@@ -253,6 +261,7 @@ export class RecipeDetailComponent {
     if (this.publishTogglePending()) return 'Checking publish state…';
     const kind = publishToggleKind(recipe);
     if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'manual') return "Manually entered recipes can't be published.";
     if (kind === 'source') {
       return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
     }

--- a/src/modals/manual-entry/manual-entry-modal.component.ts
+++ b/src/modals/manual-entry/manual-entry-modal.component.ts
@@ -130,6 +130,10 @@ export class ManualEntryModalComponent {
         .map((t) => t.trim())
         .filter((t) => t),
       image_keywords: [info.name, 'homemade'],
+      // KAN-140: manually entered recipes are not publishable — the server
+      // gates on this label (and backfills legacy rows via the
+      // image_keywords signature above).
+      origin: 'manual',
     };
 
     await this.persistenceService.saveRecipe(newRecipe);

--- a/src/recipe.types.ts
+++ b/src/recipe.types.ts
@@ -27,6 +27,13 @@ export interface Recipe {
   ingredients: IngredientGroup;
   instructions: (string | InstructionStep)[];
   notes?: string;
+  /**
+   * KAN-140 — the user's private notes. The only notes field the SPA editor
+   * writes; never rendered publicly (the Backend public payload/template
+   * allowlist exposes `notes` only). `notes` above is generated content and
+   * is read-only in the UI.
+   */
+  personalNotes?: string;
   tags?: string[];
   image_keywords?: string[];
   stock_image_url?: string;
@@ -48,4 +55,10 @@ export interface Recipe {
    * locked recipe with 400. The UI disables those controls up front.
    */
   is_canonical?: boolean;
+  /**
+   * KAN-140 — how the recipe entered the system. Manually entered recipes
+   * cannot be published (server rejects with 400; the toggle is disabled).
+   * Server-side the column is settable while NULL and immutable once set.
+   */
+  origin?: 'manual' | 'generated' | 'saved';
 }

--- a/src/recipe.types.ts
+++ b/src/recipe.types.ts
@@ -41,4 +41,11 @@ export interface Recipe {
    * tapping Save again surfaces the existing copy instead of adding another.
    */
   sourceSlug?: string;
+  /**
+   * KAN-139 — server-owned lock for the canonical recipes curated in
+   * specs/canonical-recipes.json. Read-only in the SPA: the API strips it on
+   * create and pins it on update, and rejects unpublish/re-slug/delete of a
+   * locked recipe with 400. The UI disables those controls up front.
+   */
+  is_canonical?: boolean;
 }

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -268,6 +268,7 @@ export class PersistenceService {
             is_public?: boolean;
             is_canonical?: boolean;
             source_slug?: string | null;
+            origin?: Recipe['origin'] | null;
           }) => {
             if (r.is_canonical === undefined) return r.data;
             return {
@@ -276,6 +277,7 @@ export class PersistenceService {
               is_public: r.is_public,
               is_canonical: r.is_canonical,
               sourceSlug: r.data.sourceSlug ?? r.source_slug ?? undefined,
+              origin: r.origin ?? r.data.origin,
             };
           }
         );

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, effect, untracked, inject } from '@angular/core';
+import { Injectable, effect, signal, untracked, inject } from '@angular/core';
 import { AuthService } from './auth.service';
 import { Recipe } from '../recipe.types';
 import { Cookbook } from '../auth.types';
@@ -22,7 +22,25 @@ export class PersistenceService {
   private _apiSynced = false;
   private readonly auth = inject(AuthService);
 
+  /**
+   * KAN-139 — publish state is server-owned, so the publish toggle renders
+   * greyed until the first API load settles: 'pending' while the initial
+   * sync is in flight, 'synced' once server rows have been merged in,
+   * 'failed' when all retries were exhausted (local state is then the best
+   * we have and the toggle re-enables rather than staying dead).
+   */
+  readonly publishStateSync = signal<'pending' | 'synced' | 'failed'>('pending');
+
+  /** Resolves when the first loadFromApi() settles (success OR exhausted
+   *  retries) — lets flows that must see server rows (the SSR CTA's
+   *  repeat-save dedup) wait for the merge instead of racing it. */
+  readonly firstSyncSettled: Promise<void>;
+  private _settleFirstSync!: () => void;
+
   constructor() {
+    this.firstSyncSettled = new Promise<void>((resolve) => {
+      this._settleFirstSync = resolve;
+    });
     // Auto-load from API when a logged-in user's session is confirmed.
     // Uses untracked() so signal writes inside loadFromApi() don't
     // create a reactive dependency in the effect.
@@ -236,11 +254,30 @@ export class PersistenceService {
         const recipesData = await recipesRes.json();
         const collectionsData = await collectionsRes.json();
 
-        // With the backend fix, data.id and the outer id are now consistent.
-        // We use the data field directly since it contains the complete recipe
-        // with the correct ID already set by the backend.
+        // The blob (r.data) is the complete recipe, but its slug/is_public
+        // copies can lag the DB columns on rows written before the backend
+        // synced blob and column on every write — Adam's repeat-save trap
+        // miss (KAN-139) was exactly such a row. When the backend exposes
+        // the columns (is_canonical present = new contract), they win,
+        // including nulls; older backends fall back to the blob unchanged.
         const recipes: Recipe[] = (recipesData.recipes ?? []).map(
-          (r: { id: string; data: Recipe }) => r.data
+          (r: {
+            id: string;
+            data: Recipe;
+            slug?: string | null;
+            is_public?: boolean;
+            is_canonical?: boolean;
+            source_slug?: string | null;
+          }) => {
+            if (r.is_canonical === undefined) return r.data;
+            return {
+              ...r.data,
+              slug: r.slug ?? undefined,
+              is_public: r.is_public,
+              is_canonical: r.is_canonical,
+              sourceSlug: r.data.sourceSlug ?? r.source_slug ?? undefined,
+            };
+          }
         );
 
         const cookbooks: Cookbook[] = (collectionsData.collections ?? []).map(this._toCookbook);
@@ -249,6 +286,8 @@ export class PersistenceService {
           `[PersistenceService] Hydrating ${recipes.length} recipes, ${cookbooks.length} cookbooks`
         );
         this.auth.hydrate(recipes, cookbooks);
+        this.publishStateSync.set('synced');
+        this._settleFirstSync();
         return;
       } catch (err) {
         console.warn('[PersistenceService] loadFromApi attempt failed:', err);
@@ -258,6 +297,8 @@ export class PersistenceService {
       '[PersistenceService] loadFromApi failed after all retries, will retry on next auth change'
     );
     this._apiSynced = false;
+    this.publishStateSync.set('failed');
+    this._settleFirstSync();
   }
 
   /** POST a recipe to Flask; the endpoint upserts same-owner recipes, so

--- a/src/services/public-recipe.mapper.ts
+++ b/src/services/public-recipe.mapper.ts
@@ -29,5 +29,6 @@ export function buildSavedRecipeFromPublic(recipeData: Partial<Recipe>): Recipe 
     // cookbook" can detect the duplicate and point the user at the copy they
     // already have instead of silently adding another.
     sourceSlug: recipeData.slug,
+    origin: 'saved',
   };
 }

--- a/src/services/ssr-entry.service.test.ts
+++ b/src/services/ssr-entry.service.test.ts
@@ -22,6 +22,7 @@ describe('SsrEntryService', () => {
     savedRecipes?: unknown[];
     synced?: boolean;
     fetchResponse?: { ok: boolean; json: () => Promise<unknown> };
+    firstSyncSettled?: Promise<void>;
   }) => {
     const saveRecipe = vi.fn().mockResolvedValue(opts.synced ?? true);
     const injector = Injector.create({
@@ -37,7 +38,10 @@ describe('SsrEntryService', () => {
             }),
           },
         },
-        { provide: PersistenceService, useValue: { saveRecipe } },
+        {
+          provide: PersistenceService,
+          useValue: { saveRecipe, firstSyncSettled: opts.firstSyncSettled ?? Promise.resolve() },
+        },
         { provide: ToastService, useValue: { show: toastShow } },
       ],
     });
@@ -59,6 +63,32 @@ describe('SsrEntryService', () => {
     expect(toastShow).toHaveBeenCalledWith(
       expect.stringMatching(/already have this recipe/i),
       expect.objectContaining({ id: 'r1' })
+    );
+  });
+
+  it('waits for the first server sync so server-only copies are deduped (KAN-139)', async () => {
+    // savedRecipes is empty until the sync settles — the matching copy only
+    // exists server-side (another device, or a stale local blob).
+    const savedRecipes: unknown[] = [];
+    let settleSync!: () => void;
+    const firstSyncSettled = new Promise<void>((resolve) => {
+      settleSync = resolve;
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { service, saveRecipe } = createService({ savedRecipes, firstSyncSettled });
+
+    const save = service.handleSave('thai-peanut-noodles');
+    savedRecipes.push({ id: 'server-copy', sourceSlug: 'thai-peanut-noodles' });
+    settleSync();
+    await save;
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(saveRecipe).not.toHaveBeenCalled();
+    expect(toastShow).toHaveBeenCalledWith(
+      expect.stringMatching(/already have this recipe/i),
+      expect.objectContaining({ id: 'server-copy' })
     );
   });
 

--- a/src/services/ssr-entry.service.ts
+++ b/src/services/ssr-entry.service.ts
@@ -27,6 +27,16 @@ export class SsrEntryService {
       return;
     }
 
+    // KAN-139: the dedup check below must see the server's rows, not just
+    // whatever localStorage happens to hold — a copy saved on another
+    // device (or one whose local blob predates the slug-column sync) is
+    // otherwise invisible and gets saved again. Bounded so a hanging API
+    // degrades to the old local-only check instead of blocking the save.
+    await Promise.race([
+      this.persistence.firstSyncSettled,
+      new Promise<void>((resolve) => setTimeout(resolve, 8_000)),
+    ]);
+
     const alreadySaved = this.auth
       .currentUser()
       ?.savedRecipes.find(

--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPublicViewable, publicLinkKind, publicSlugOf } from './public-link';
+import { isPublicViewable, publicLinkKind, publicSlugOf, publishToggleKind } from './public-link';
 
 // KAN-119: the View link to /r/<slug> must not depend on auth state — a
 // published recipe's public page is viewable by anyone, so the link renders
@@ -102,5 +102,38 @@ describe('isPublicViewable', () => {
     expect(isPublicViewable({ is_public: false, slug: 'vegan-cornbread' })).toBe(false);
     expect(isPublicViewable({ is_public: true })).toBe(false);
     expect(isPublicViewable({})).toBe(false);
+  });
+});
+
+// KAN-139: canonical recipes are server-locked (unpublish/re-slug/delete →
+// 400), and copies saved from a public page render the toggle greyed so their
+// off-state never reads as "this recipe's own page is down".
+describe('publishToggleKind', () => {
+  it('is locked for canonical recipes, regardless of everything else', () => {
+    expect(publishToggleKind({ is_canonical: true, is_public: true, slug: 'a' })).toBe('locked');
+    expect(publishToggleKind({ is_canonical: true, sourceSlug: 'b' })).toBe('locked');
+    expect(publishToggleKind({ is_canonical: true })).toBe('locked');
+  });
+
+  it('is source for an unpublished copy that carries only sourceSlug', () => {
+    expect(publishToggleKind({ sourceSlug: 'vegan-cornbread' })).toBe('source');
+    expect(publishToggleKind({ is_public: false, sourceSlug: 'vegan-cornbread' })).toBe('source');
+  });
+
+  it('is normal once the copy has published its own page', () => {
+    expect(
+      publishToggleKind({
+        is_public: true,
+        slug: 'vegan-cornbread-2',
+        sourceSlug: 'vegan-cornbread',
+      })
+    ).toBe('normal');
+  });
+
+  it('is normal for ordinary own recipes, published or not', () => {
+    expect(publishToggleKind({})).toBe('normal');
+    expect(publishToggleKind({ is_public: true, slug: 'a' })).toBe('normal');
+    expect(publishToggleKind({ is_public: false, slug: 'a' })).toBe('normal');
+    expect(publishToggleKind({ is_canonical: false, is_public: true, slug: 'a' })).toBe('normal');
   });
 });

--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -130,6 +130,28 @@ describe('publishToggleKind', () => {
     ).toBe('normal');
   });
 
+  // KAN-140: manually entered recipes can't be published — toggle disabled
+  // while unpublished; legacy published manual rows stay unpublish-able.
+  it('is manual for an unpublished manually entered recipe', () => {
+    expect(publishToggleKind({ origin: 'manual' })).toBe('manual');
+    expect(publishToggleKind({ origin: 'manual', is_public: false })).toBe('manual');
+    // Manual wins over the source rendering — the gate matters more.
+    expect(publishToggleKind({ origin: 'manual', sourceSlug: 'x' })).toBe('manual');
+  });
+
+  it('is normal for a legacy published manual recipe (so it can be unpublished)', () => {
+    expect(publishToggleKind({ origin: 'manual', is_public: true, slug: 'legacy' })).toBe('normal');
+  });
+
+  it('canonical lock wins over manual origin', () => {
+    expect(publishToggleKind({ origin: 'manual', is_canonical: true })).toBe('locked');
+  });
+
+  it('is normal for generated and saved origins', () => {
+    expect(publishToggleKind({ origin: 'generated' })).toBe('normal');
+    expect(publishToggleKind({ origin: 'saved', sourceSlug: 'x' })).toBe('source');
+  });
+
   it('is normal for ordinary own recipes, published or not', () => {
     expect(publishToggleKind({})).toBe('normal');
     expect(publishToggleKind({ is_public: true, slug: 'a' })).toBe('normal');

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -63,6 +63,11 @@ export function publicLinkKind(recipe: {
  * 'locked' — canonical recipe: the server rejects unpublish/re-slug/delete
  *            with 400, so the toggle is disabled outright with an
  *            explanatory title.
+ * 'manual' — a manually entered, unpublished recipe (KAN-140): the server
+ *            rejects publishing it with 400, so the toggle is disabled.
+ *            Published manual rows (legacy, pre-gate) fall through to
+ *            'normal' — they must stay unpublishable-off but
+ *            unpublish-able.
  * 'source' — a copy saved from a public recipe that is not itself
  *            published: rendered greyed by default (its publish state
  *            belongs to the source page), but still clickable — the
@@ -75,9 +80,13 @@ export function publishToggleKind(recipe: {
   slug?: string;
   sourceSlug?: string;
   is_canonical?: boolean;
-}): 'locked' | 'source' | 'normal' {
+  origin?: string;
+}): 'locked' | 'manual' | 'source' | 'normal' {
   if (recipe.is_canonical === true) {
     return 'locked';
+  }
+  if (recipe.origin === 'manual' && recipe.is_public !== true) {
+    return 'manual';
   }
   return publicLinkKind(recipe) === 'source' ? 'source' : 'normal';
 }

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -56,3 +56,28 @@ export function publicLinkKind(recipe: {
   }
   return recipe.sourceSlug ? 'source' : null;
 }
+
+/**
+ * KAN-139 — how the publish toggle should render.
+ *
+ * 'locked' — canonical recipe: the server rejects unpublish/re-slug/delete
+ *            with 400, so the toggle is disabled outright with an
+ *            explanatory title.
+ * 'source' — a copy saved from a public recipe that is not itself
+ *            published: rendered greyed by default (its publish state
+ *            belongs to the source page), but still clickable — the
+ *            KAN-137 confirm gate makes publishing a separate copy an
+ *            informed choice.
+ * 'normal' — everything else.
+ */
+export function publishToggleKind(recipe: {
+  is_public?: boolean;
+  slug?: string;
+  sourceSlug?: string;
+  is_canonical?: boolean;
+}): 'locked' | 'source' | 'normal' {
+  if (recipe.is_canonical === true) {
+    return 'locked';
+  }
+  return publicLinkKind(recipe) === 'source' ? 'source' : 'normal';
+}


### PR DESCRIPTION
## v0.4.4 release (dev → main)

Ships the Sprint 3 item-B security/integrity train (epic KAN-136):

- **KAN-139** — publish state resolves to one DB row: `is_canonical` locks the 7 curated canonical slugs (unpublish/re-slug/delete → 400), `source_slug` server column, greyed toggle while sync pending / for saved copies, SSR-CTA repeat-save trap fixed (#3250, Backend #239)
- **KAN-140 (security)** — manual-entry recipes unpublishable (`origin` column + gate) and the live-verified publish-notes abuse loop closed via the notes split: generated `notes` read-only, private `personalNotes` never published (#3252, Backend #240)
- **KAN-141** — `flask-backend-image-repair` deploy-only Cloud Run Job + imageless-recipe enqueuer script (#3257, Backend #241)
- **KAN-104** — publish failures surface to the user (empty-slug pre-check + revert toast) (#3251)
- **KAN-136** — migrate job wired with `VALKEY_CA_CERT` (#3253)
- Backend Dependabot: python-production group, uv image (#242/#244)

**Migrations (2, single head `d1e5a9c3f7b2` verified):** `c8d2f6a1e9b3` (is_canonical + source_slug + canonical seed) → `d1e5a9c3f7b2` (origin + manual backfill). Run by the migrate Job before the Flask deploy, per standard flow.

**Backend pointer:** `50cdbbb` = Backend dev tip, promoted to Backend main via [tasteslikegood.com#245](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/245) (merged, main `dfc5cad`).

**Post-deploy manual follow-ups (tracked on KAN-141):** one-time Cloud Scheduler daily trigger for `flask-backend-image-repair` + `gcloud run jobs execute flask-backend-image-repair --wait` sanity run; then Adam's walkthrough round 2 (KAN-137/139/140 gates).

On merge, release.yml tags `v0.4.4` → Cloud Build trigger deploys (migrate Job → Flask → Express).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

