### PR TITLE
fix(spa): publish-state cluster — server-owned slugs, deep-link row normalization, View-link overflow (#3262, #3263, #3264) [KAN-149]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **SPA publish-state fix cluster** (KAN-149,
+  [#3262](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3262),
+  [#3263](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3263),
+  [#3264](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3264)),
+  from Adam's post-v0.4.4 zucchini-poppers field test:
+  - The View link no longer renders a client-predicted slug that could 404
+    or point at another recipe on a name collision — the client stops
+    deriving slugs on publish entirely and adopts the server-minted slug
+    (collision → `-N` suffix) once the sync resolves. Root cause was
+    zoneless change detection: the publish flow mutated the recipe object
+    in place, so neither the server's corrected slug nor the failure revert
+    ever re-rendered; the flip now goes through the signal immutably.
+  - Refreshing `/recipe/:id` no longer renders a blank page: the cold
+    deep-link fetch treated the `GET /api/recipes/:id` row shape
+    (`{…columns, data: {…blob}}`) as the recipe blob, leaving
+    ingredients/instructions undefined. The KAN-139 column-over-blob merge
+    is extracted into a shared `recipeFromRow` util (per #3209) used by both
+    the persistence sync and the deep-link fetch.
+  - Toggling publish ON no longer pushes the freshly-mounted View link
+    behind the recipe image: the action rows were non-wrapping flex rows
+    inside a `minmax(0, 1fr)` grid column, so the extra link overflowed
+    under the adjacent `position: relative` image block; the rows now wrap.
+
 ## [0.4.4] - 2026-07-24
 
 ### Fixed

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -72,8 +72,11 @@
             Vegan Recipe
           </div>
 
-          <!-- Action Buttons -->
-          <div class="flex items-center gap-2">
+          <!-- Action Buttons — must wrap (#3264): a non-wrapping flex row
+               can't shrink below its content, so when the View link mounts
+               on publish it overflowed the half-width grid column and
+               painted behind the adjacent (position: relative) image. -->
+          <div class="flex flex-wrap items-center gap-2 min-w-0">
             <button
               (click)="onSaveRecipe()"
               [disabled]="isSaved()"
@@ -160,7 +163,7 @@
             </button>
 
             <!-- v0.2 Anti-Recipe Distribution Controls -->
-            <div class="flex items-center gap-2 ml-2 pl-4 border-l border-stone-200">
+            <div class="flex flex-wrap items-center gap-2 ml-2 pl-4 border-l border-stone-200">
               @if (canPublish()) {
                 <div class="flex items-center gap-2">
                   <span

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -241,21 +241,34 @@ export class GeneratorComponent {
       return;
     }
 
-    recipe.is_public = nextState;
-
-    if (nextState && !recipe.slug) {
-      recipe.slug = this.slugFromTitle(recipe.name);
+    // KAN-149 (#3262): the flip is immutable and goes through the signal —
+    // zoneless change detection never re-renders on in-place mutation, which
+    // both hid the failure-revert below and froze the View link on a
+    // client-predicted slug. The slug itself is server-minted (collision →
+    // -N suffix), so no client-side guess: the View link appears once the
+    // sync merges the server's answer back.
+    const updated: Recipe = { ...recipe, is_public: nextState };
+    if (this.recipe()?.id === recipe.id) {
+      this.recipe.set(updated);
     }
 
     try {
-      const synced = await this.persistenceService.saveRecipe(recipe);
+      const synced = await this.persistenceService.saveRecipe(updated);
       if (!synced) {
         throw new Error('Publish state failed to sync to the server');
       }
+      // Adopt the server-authoritative row (slug included) into the viewed
+      // signal — auth state was just updated by the save's mirror-back.
+      const fresh = this.authService.currentUser()?.savedRecipes.find((r) => r.id === recipe.id);
+      if (fresh && this.recipe()?.id === recipe.id) {
+        this.recipe.set(fresh);
+      }
     } catch (err) {
       console.error('Failed to toggle public state:', err);
-      recipe.is_public = !nextState;
       this.authService.saveRecipe(recipe);
+      if (this.recipe()?.id === recipe.id) {
+        this.recipe.set(recipe);
+      }
       // KAN-104 (#3146): the revert already worked; without a message the
       // user just sees the switch snap back with no explanation.
       this.toastService.show(

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -38,8 +38,11 @@
             Vegan Recipe
           </div>
 
-          <!-- Action Buttons -->
-          <div class="flex items-center gap-2">
+          <!-- Action Buttons — must wrap (#3264): a non-wrapping flex row
+               can't shrink below its content, so when the View link mounts
+               on publish it overflowed the half-width grid column and
+               painted behind the adjacent (position: relative) image. -->
+          <div class="flex flex-wrap items-center gap-2 min-w-0">
             <button
               (click)="exportRecipe(r)"
               class="flex items-center gap-2 px-3 py-2 rounded-lg font-medium text-sm bg-stone-100 text-stone-600 hover:bg-stone-200 transition-colors"
@@ -62,7 +65,7 @@
             </button>
 
             <!-- Publish Controls -->
-            <div class="flex items-center gap-2 ml-2 pl-4 border-l border-stone-200">
+            <div class="flex flex-wrap items-center gap-2 ml-2 pl-4 border-l border-stone-200">
               @if (canPublish()) {
                 <div class="flex items-center gap-2">
                   <span

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -33,6 +33,9 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       () => new RecipeStateService()
     );
     const persistenceSaveRecipe = vi.fn().mockResolvedValue(true);
+    // Mutable so tests can emulate the persistence mirror-back writing the
+    // server-minted slug into auth state mid-save (KAN-149 / #3262).
+    const authUser = { isGuest: opts.isGuest ?? true, savedRecipes: [] as unknown[] };
 
     const injector = Injector.create({
       providers: [
@@ -44,7 +47,7 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
         {
           provide: AuthService,
           useValue: {
-            currentUser: () => ({ isGuest: opts.isGuest ?? true, savedRecipes: [] }),
+            currentUser: () => authUser,
             saveRecipe: vi.fn(),
           },
         },
@@ -59,7 +62,7 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       ],
     });
     const component = runInInjectionContext(injector, () => new RecipeDetailComponent());
-    return { component, persistenceSaveRecipe };
+    return { component, persistenceSaveRecipe, authUser };
   };
 
   const emitId = (id: string) => {
@@ -104,6 +107,51 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
 
     expect(toastShow).toHaveBeenCalledWith('Connection error. Check your network and try again.');
     expect(routerNavigate).toHaveBeenCalledWith(['/kitchen'], { replaceUrl: true });
+  });
+
+  // GH #3263 (KAN-149): GET /api/recipes/:id returns the row shape
+  // ({…columns, data: {…blob}}) — rendering it raw left ingredients and
+  // instructions undefined and blanked the page on refresh.
+  it('normalizes the API row shape before viewing (cold deep link)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 'row-1',
+          name: 'Vegan Zucchini Poppers',
+          slug: 'vegan-zucchini-poppers-2',
+          is_public: true,
+          is_canonical: false,
+          origin: 'generated',
+          data: {
+            id: 'row-1',
+            name: 'Vegan Zucchini Poppers',
+            servings: 4,
+            ingredients: { wet: [], dry: [], other: [] },
+            instructions: ['fry'],
+            slug: 'stale-blob-slug',
+          },
+        }),
+      })
+    );
+
+    const { component } = createComponent();
+    emitId('row-1');
+    await vi.waitFor(() => expect(component.recipe()).not.toBeNull());
+
+    const r = component.recipe() as {
+      ingredients?: unknown;
+      instructions?: unknown;
+      slug?: string;
+    } | null;
+    expect(r?.ingredients).toEqual({ wet: [], dry: [], other: [] });
+    expect(r?.instructions).toEqual(['fry']);
+    // Column beats the lagging blob copy (KAN-139 merge).
+    expect(r?.slug).toBe('vegan-zucchini-poppers-2');
+    // Cold deep link — Save stays enabled (#3210).
+    expect(component.isSaved()).toBe(false);
   });
 
   // KAN-137 confirm-guard: first publish of a copy saved from a public recipe
@@ -183,8 +231,13 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       const recipe = savedCopy() as { is_public?: boolean };
       await component.togglePublic(recipe as never);
 
-      expect(recipe.is_public).toBe(true);
+      // KAN-149 (#3262): the flip is immutable — the passed object stays
+      // untouched; the flipped copy is what goes to the server.
+      expect(recipe.is_public).toBeFalsy();
       expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+      expect(persistenceSaveRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'copy-1', is_public: true })
+      );
     });
 
     it('does not prompt when publishing an own recipe (no sourceSlug)', async () => {
@@ -198,8 +251,37 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       await component.togglePublic(recipe as never);
 
       expect(confirmMock).not.toHaveBeenCalled();
-      expect(recipe.is_public).toBe(true);
       expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+      expect(persistenceSaveRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'copy-1', is_public: true })
+      );
+    });
+
+    // GH #3262 (KAN-149): the server owns slug minting — the client no longer
+    // predicts one, and adopts the server's answer once the sync resolves.
+    it('sends no client-derived slug and adopts the server-minted slug after sync', async () => {
+      vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+      const { component, persistenceSaveRecipe, authUser } = createComponent({ isGuest: false });
+
+      const recipe = { ...(savedCopy() as object), sourceSlug: undefined } as unknown as {
+        id: string;
+        is_public?: boolean;
+        slug?: string;
+      };
+      component.recipe.set(recipe as never);
+      // Emulate the persistence mirror-back: the server minted a -2 slug on
+      // name collision and auth state was updated before saveRecipe resolved.
+      persistenceSaveRecipe.mockImplementation(async (saved: { slug?: string }) => {
+        expect(saved.slug).toBeUndefined();
+        authUser.savedRecipes = [{ ...recipe, is_public: true, slug: 'vegan-cornbread-2' }];
+        return true;
+      });
+
+      await component.togglePublic(recipe as never);
+
+      const viewed = component.recipe() as { is_public?: boolean; slug?: string } | null;
+      expect(viewed?.is_public).toBe(true);
+      expect(viewed?.slug).toBe('vegan-cornbread-2');
     });
 
     // KAN-104 (#3146): empty-slug titles are pre-checked client-side with an
@@ -229,9 +311,13 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const recipe = savedCopy() as { is_public?: boolean };
+      component.recipe.set(recipe as never);
       await component.togglePublic(recipe as never);
 
-      expect(recipe.is_public).toBeFalsy();
+      // The viewed signal flips optimistically, then reverts to the original
+      // object on sync failure (KAN-149: signal-driven, not in-place).
+      const viewed = component.recipe() as { is_public?: boolean } | null;
+      expect(viewed?.is_public).toBeFalsy();
       expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/publishing failed to sync/i));
       expect(consoleError).toHaveBeenCalled();
     });
@@ -287,8 +373,11 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       await component.togglePublic(recipe as never);
 
       expect(confirmMock).not.toHaveBeenCalled();
-      expect(recipe.is_public).toBe(false);
       expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+      // Unpublish keeps the slug (KAN-139: unpublished rows retain slugs).
+      expect(persistenceSaveRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ is_public: false, slug: 'vegan-cornbread-2' })
+      );
     });
   });
 });

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -15,6 +15,7 @@ import {
   publishToggleKind,
 } from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
+import { recipeFromRow } from '../../utils/recipe-row';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
 @Component({
@@ -107,7 +108,11 @@ export class RecipeDetailComponent {
         this.router.navigate(['/kitchen'], { replaceUrl: true });
         return;
       }
-      const recipe: Recipe = await resp.json();
+      // GET /api/recipes/:id returns the row shape, not the Recipe blob —
+      // rendering it raw left ingredients/instructions undefined and blanked
+      // the page on refresh (#3263). Same column-over-blob merge as
+      // PersistenceService.loadFromApi.
+      const recipe = recipeFromRow(await resp.json());
       // Not in the user's cookbook (cold deep link) — keep Save enabled (#3210).
       this.recipeState.viewRecipe(recipe, false);
     } catch {
@@ -212,21 +217,34 @@ export class RecipeDetailComponent {
       return;
     }
 
-    recipe.is_public = nextState;
-
-    if (nextState && !recipe.slug) {
-      recipe.slug = this.slugFromTitle(recipe.name);
+    // KAN-149 (#3262): the flip is immutable and goes through the signal —
+    // zoneless change detection never re-renders on in-place mutation, which
+    // both hid the failure-revert below and froze the View link on a
+    // client-predicted slug. The slug itself is server-minted (collision →
+    // -N suffix), so no client-side guess: the View link appears once the
+    // sync merges the server's answer back.
+    const updated: Recipe = { ...recipe, is_public: nextState };
+    if (this.recipe()?.id === recipe.id) {
+      this.recipe.set(updated);
     }
 
     try {
-      const synced = await this.persistenceService.saveRecipe(recipe);
+      const synced = await this.persistenceService.saveRecipe(updated);
       if (!synced) {
         throw new Error('Publish state failed to sync to the server');
       }
+      // Adopt the server-authoritative row (slug included) into the viewed
+      // signal — auth state was just updated by the save's mirror-back.
+      const fresh = this.authService.currentUser()?.savedRecipes.find((r) => r.id === recipe.id);
+      if (fresh && this.recipe()?.id === recipe.id) {
+        this.recipe.set(fresh);
+      }
     } catch (err) {
       console.error('Failed to toggle public state:', err);
-      recipe.is_public = !nextState;
       this.authService.saveRecipe(recipe);
+      if (this.recipe()?.id === recipe.id) {
+        this.recipe.set(recipe);
+      }
       // KAN-104 (#3146): the revert already worked; without a message the
       // user just sees the switch snap back with no explanation.
       this.toastService.show(

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -2,6 +2,7 @@ import { Injectable, effect, signal, untracked, inject } from '@angular/core';
 import { AuthService } from './auth.service';
 import { Recipe } from '../recipe.types';
 import { Cookbook } from '../auth.types';
+import { recipeFromRow, RecipeRow } from '../utils/recipe-row';
 
 /**
  * PersistenceService — hybrid persistence layer for Phase IV.
@@ -254,32 +255,10 @@ export class PersistenceService {
         const recipesData = await recipesRes.json();
         const collectionsData = await collectionsRes.json();
 
-        // The blob (r.data) is the complete recipe, but its slug/is_public
-        // copies can lag the DB columns on rows written before the backend
-        // synced blob and column on every write — Adam's repeat-save trap
-        // miss (KAN-139) was exactly such a row. When the backend exposes
-        // the columns (is_canonical present = new contract), they win,
-        // including nulls; older backends fall back to the blob unchanged.
-        const recipes: Recipe[] = (recipesData.recipes ?? []).map(
-          (r: {
-            id: string;
-            data: Recipe;
-            slug?: string | null;
-            is_public?: boolean;
-            is_canonical?: boolean;
-            source_slug?: string | null;
-            origin?: Recipe['origin'] | null;
-          }) => {
-            if (r.is_canonical === undefined) return r.data;
-            return {
-              ...r.data,
-              slug: r.slug ?? undefined,
-              is_public: r.is_public,
-              is_canonical: r.is_canonical,
-              sourceSlug: r.data.sourceSlug ?? r.source_slug ?? undefined,
-              origin: r.origin ?? r.data.origin,
-            };
-          }
+        // Column-over-blob merge (KAN-139) — see recipeFromRow for the
+        // contract; shared with recipe-detail's cold deep-link fetch (KAN-149).
+        const recipes: Recipe[] = (recipesData.recipes ?? []).map((r: RecipeRow) =>
+          recipeFromRow(r)
         );
 
         const cookbooks: Cookbook[] = (collectionsData.collections ?? []).map(this._toCookbook);
@@ -326,12 +305,15 @@ export class PersistenceService {
       // sent (uniqueness collision suffix), so mirror its authoritative
       // value back into local state — otherwise the /r/<slug> link in the UI
       // silently points at another recipe or 404s until the next reload.
+      // Immutable on purpose (KAN-149 / #3262): zoneless change detection
+      // only re-renders on a signal change, so an in-place `recipe.slug =`
+      // write updated the store but never the screen. Callers that render
+      // this recipe must re-read it from auth state after the sync resolves.
       try {
         const body = await res.json();
         const serverSlug = body?.slug;
         if (typeof serverSlug === 'string' && serverSlug && serverSlug !== recipe.slug) {
-          recipe.slug = serverSlug;
-          this.auth.saveRecipe(recipe);
+          this.auth.saveRecipe({ ...recipe, slug: serverSlug });
         }
       } catch {
         // Body missing or not JSON — keep the optimistic local value.

--- a/src/utils/recipe-row.test.ts
+++ b/src/utils/recipe-row.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { recipeFromRow, type RecipeRow } from './recipe-row';
+import type { Recipe } from '../recipe.types';
+
+const blob = (over: Partial<Recipe> = {}): Recipe =>
+  ({
+    id: 'r1',
+    name: 'Vegan Zucchini Poppers',
+    description: '',
+    prepTime: 10,
+    cookTime: 20,
+    servings: 4,
+    ingredients: { wet: [], dry: [], other: [] },
+    instructions: ['fry'],
+    tags: ['snack'],
+    ...over,
+  }) as Recipe;
+
+const row = (over: Partial<RecipeRow> = {}): RecipeRow => ({
+  id: 'r1',
+  data: blob(),
+  slug: 'vegan-zucchini-poppers-2',
+  is_public: true,
+  is_canonical: false,
+  source_slug: null,
+  origin: 'generated',
+  ...over,
+});
+
+// GH #3263: GET /api/recipes/:id returns the row shape; rendering it raw
+// blanks the page (`@for` over undefined ingredients). Every API consumer
+// must go through this merge.
+describe('recipeFromRow', () => {
+  it('unwraps the blob and overlays the authoritative columns', () => {
+    const merged = recipeFromRow(
+      row({ data: blob({ slug: 'stale-blob-slug', is_public: false }) })
+    );
+
+    expect(merged.ingredients).toEqual({ wet: [], dry: [], other: [] });
+    expect(merged.instructions).toEqual(['fry']);
+    expect(merged.servings).toBe(4);
+    // Columns win over lagging blob copies (KAN-139).
+    expect(merged.slug).toBe('vegan-zucchini-poppers-2');
+    expect(merged.is_public).toBe(true);
+    expect(merged.is_canonical).toBe(false);
+    expect(merged.origin).toBe('generated');
+  });
+
+  it('clears a lagging blob slug when the column is null', () => {
+    const merged = recipeFromRow(
+      row({ slug: null, is_public: false, data: blob({ slug: 'ghost' }) })
+    );
+
+    expect(merged.slug).toBeUndefined();
+    expect(merged.is_public).toBe(false);
+  });
+
+  it('prefers the blob sourceSlug and falls back to the source_slug column', () => {
+    expect(
+      recipeFromRow(row({ source_slug: 'col-slug', data: blob({ sourceSlug: 'blob-slug' }) }))
+        .sourceSlug
+    ).toBe('blob-slug');
+    expect(recipeFromRow(row({ source_slug: 'col-slug' })).sourceSlug).toBe('col-slug');
+  });
+
+  it('falls back to the blob origin when the column is null', () => {
+    expect(recipeFromRow(row({ origin: null, data: blob({ origin: 'manual' }) })).origin).toBe(
+      'manual'
+    );
+  });
+
+  it('returns the blob unchanged on the pre-columns contract (no is_canonical)', () => {
+    const data = blob({ slug: 'blob-slug' });
+    const merged = recipeFromRow({ id: 'r1', data } as RecipeRow);
+
+    expect(merged).toBe(data);
+  });
+
+  it('passes a bare Recipe blob through untouched', () => {
+    const bare = blob();
+    expect(recipeFromRow(bare)).toBe(bare);
+  });
+});

--- a/src/utils/recipe-row.ts
+++ b/src/utils/recipe-row.ts
@@ -1,0 +1,56 @@
+import type { Recipe } from '../recipe.types';
+
+/**
+ * KAN-149 — shared column-over-blob merge for API recipe rows.
+ *
+ * The Flask recipe endpoints (`GET /api/recipes`, `GET /api/recipes/:id`,
+ * `POST /api/recipes`) all return the row shape (`recipe.to_dict()`):
+ * `{id, name, slug, is_public, is_canonical, origin, data: {…blob…}}`.
+ * The blob (`data`) is the complete recipe, but its slug/is_public copies
+ * can lag the DB columns on rows written before the backend synced blob and
+ * column on every write — Adam's repeat-save trap miss (KAN-139) was exactly
+ * such a row. When the backend exposes the columns (`is_canonical` present =
+ * new contract), they win, including nulls; older backends fall back to the
+ * blob unchanged.
+ *
+ * Every consumer of a recipe API response must go through this merge —
+ * recipe-detail's cold deep-link fetch treating the raw row as a Recipe blob
+ * was GH #3263 (blank page: `@for` over `undefined` ingredients).
+ */
+export interface RecipeRow {
+  id: string;
+  data: Recipe;
+  slug?: string | null;
+  is_public?: boolean;
+  is_canonical?: boolean;
+  source_slug?: string | null;
+  origin?: Recipe['origin'] | null;
+}
+
+/** True when the payload is a row envelope rather than a bare Recipe blob. */
+function isRecipeRow(payload: RecipeRow | Recipe): payload is RecipeRow {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    'data' in payload &&
+    !!(payload as RecipeRow).data
+  );
+}
+
+/**
+ * Normalizes an API recipe payload to the client Recipe shape. Accepts a
+ * bare blob too (defensive: a backend predating the row envelope) and
+ * returns it untouched.
+ */
+export function recipeFromRow(payload: RecipeRow | Recipe): Recipe {
+  if (!isRecipeRow(payload)) return payload;
+  if (payload.is_canonical === undefined) return payload.data;
+  return {
+    ...payload.data,
+    slug: payload.slug ?? undefined,
+    is_public: payload.is_public,
+    is_canonical: payload.is_canonical,
+    sourceSlug: payload.data.sourceSlug ?? payload.source_slug ?? undefined,
+    origin: payload.origin ?? payload.data.origin,
+  };
+}


### PR DESCRIPTION
Closes #3262, closes #3263, closes #3264. Jira: KAN-149 (child of Sprint 3 epic KAN-136).

One branch for the three bugs from Adam's post-v0.4.4 zucchini-poppers field test — they share the SPA publish/view path and two of them share a single root cause.

## #3262 — View link on a client-predicted slug (404 / wrong page)

**Root cause (two layers):**
1. `togglePublic` (generator + recipe-detail) predicted the slug client-side (`slugFromTitle`) — but the server owns minting (`_resolve_public_slug`, collision → `-N`, KAN-139 semantics), so the prediction is wrong exactly when it matters.
2. The persistence mirror-back that should have healed it (shipped since v0.4.2, `e0346f3`) **mutated the recipe object in place** — and the app is zoneless (`provideZonelessChangeDetection`). The `currentRecipe` signal's reference never changed, so the corrected slug (and the failure revert!) never re-rendered.

**Fix:** no client-side slug derivation at all; the optimistic flip goes through the signal immutably; after the sync resolves the component adopts the server-authoritative row from auth state (the mirror-back now writes an immutable copy). The View link simply appears once the real slug exists. The KAN-104 empty-slug preflight and KAN-137 confirm-guard are untouched.

## #3263 — blank page on refresh of `/recipe/:id`

`fetchRecipeFromApi` treated the `GET /api/recipes/:id` **row shape** (`{…columns, data: {…blob}}`) as the Recipe blob → `@for` over `undefined` ingredients → blank render. Every refresh hits this path because auth isn't hydrated when the constructor's `paramMap` handler fires.

**Fix:** the KAN-139 column-over-blob merge is extracted from `PersistenceService.loadFromApi` into a shared `src/utils/recipe-row.ts` (`recipeFromRow`) — the #3209 shared-extraction argument — and the deep-link fetch now normalizes through it. Tolerates the pre-columns contract and a bare blob defensively.

## #3264 — View link paints behind the image after toggling publish ON

The action rows are **non-wrapping** flex rows inside a `minmax(0, 1fr)` grid column; a flex row can't shrink below its content, so the freshly-mounted link overflowed the half-width column and painted behind the adjacent image block (`position: relative` = own stacking context, painted on top). The generator card only shows the link right after a toggle, which is why a refresh always "healed" it. Fix: `flex-wrap` (+ `min-w-0`) on the action row and publish cluster in both templates.

## Verification

- `npm run lint` / `format:check` / `type-check` / `build` — clean
- `npm test` — 189/190; the one failure is `server/redirects.test.ts` favicon 404, **pre-existing** (fails identically on a clean `origin/dev` tree in this environment; CI was green on v0.4.4) and untouched by this diff
- New Vitest coverage: `recipe-row` unit suite (7 cases: column-over-blob, null-column clears, sourceSlug/origin fallbacks, legacy contracts); recipe-detail regressions for row normalization on cold deep link (#3263), no-client-slug + server-slug adoption (#3262), signal-driven failure revert
- #3264 is a static-CSS fix verified by analysis; worth a quick eyeball in the walkthrough: publish-capable account → generate → toggle Public ON → link should wrap below the buttons instead of clipping under the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

