### PR TITLE
refactor(spa): extract shared recipe methods into RecipeViewBase (#3209) [KAN-126]

### DIFF
--- a/src/components/generator/generator.component.test.ts
+++ b/src/components/generator/generator.component.test.ts
@@ -1,0 +1,208 @@
+import '@angular/compiler';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GeneratorComponent } from './generator.component';
+import { AuthService } from '../../services/auth.service';
+import { PersistenceService } from '../../services/persistence.service';
+import { GeminiService } from '../../services/gemini.service';
+import { RecipeStateService } from '../../services/recipe-state.service';
+import { ToastService } from '../../services/toast.service';
+import { ModalService } from '../../services/modal.service';
+
+// KAN-126 (#3209): GeneratorComponent carried ~13 methods byte-identical to
+// RecipeDetailComponent but had no test file of its own, so the extraction
+// into the shared base had no regression net on this side. These pin the
+// shared behaviour *through the generator's surface* — above all the one
+// branch where the two components legitimately differ (see the first test).
+describe('GeneratorComponent shared recipe behaviour', () => {
+  let toastShow: ReturnType<typeof vi.fn>;
+  let openAuth: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    toastShow = vi.fn();
+    openAuth = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const createComponent = (opts: { isGuest?: boolean } = {}) => {
+    const recipeState = runInInjectionContext(
+      Injector.create({ providers: [] }),
+      () => new RecipeStateService()
+    );
+    const persistenceSaveRecipe = vi.fn().mockResolvedValue(true);
+    const authUser = { isGuest: opts.isGuest ?? true, savedRecipes: [] as unknown[] };
+
+    const injector = Injector.create({
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser: () => authUser,
+            saveRecipe: vi.fn(),
+            updateRecipeField: vi.fn(),
+            ensureGuestSession: vi.fn(),
+          },
+        },
+        {
+          provide: PersistenceService,
+          useValue: { saveRecipe: persistenceSaveRecipe, publishStateSync: () => 'synced' },
+        },
+        { provide: GeminiService, useValue: {} },
+        { provide: RecipeStateService, useValue: recipeState },
+        { provide: ToastService, useValue: { show: toastShow } },
+        { provide: ModalService, useValue: { openAuth, openAddToCookbook: vi.fn() } },
+      ],
+    });
+    const component = runInInjectionContext(injector, () => new GeneratorComponent());
+    return { component, persistenceSaveRecipe, authUser };
+  };
+
+  const draftRecipe = () =>
+    ({
+      id: 'gen-1',
+      name: 'Vegan Cornbread',
+      ingredients: { wet: [], dry: [], other: [] },
+      instructions: [],
+    }) as never;
+
+  // THE divergence from RecipeDetailComponent: the generator prompts a guest to
+  // sign in, where recipe-detail returns silently (it renders a separate
+  // "Sign in to publish" button instead). An extraction that collapses both
+  // onto one implementation would silently drop this.
+  it('opens the auth modal when a guest tries to publish, and saves nothing', async () => {
+    const { component, persistenceSaveRecipe } = createComponent({ isGuest: true });
+
+    await component.togglePublic(draftRecipe());
+
+    expect(openAuth).toHaveBeenCalledOnce();
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('publishes immutably for a signed-in user and adopts the server-minted slug', async () => {
+    const { component, persistenceSaveRecipe, authUser } = createComponent({ isGuest: false });
+    const recipe = draftRecipe() as unknown as { id: string; is_public?: boolean; slug?: string };
+    component.recipe.set(recipe as never);
+
+    persistenceSaveRecipe.mockImplementation(async (saved: { slug?: string }) => {
+      // The client must not predict a slug — the server mints it (#3262).
+      expect(saved.slug).toBeUndefined();
+      authUser.savedRecipes = [{ ...recipe, is_public: true, slug: 'vegan-cornbread-2' }];
+      return true;
+    });
+
+    await component.togglePublic(recipe as never);
+
+    expect(recipe.is_public).toBeFalsy(); // passed object never mutated
+    const viewed = component.recipe() as { is_public?: boolean; slug?: string } | null;
+    expect(viewed?.is_public).toBe(true);
+    expect(viewed?.slug).toBe('vegan-cornbread-2');
+  });
+
+  it('blocks publishing a manually entered recipe with a toast', async () => {
+    const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+    await component.togglePublic({ ...(draftRecipe() as object), origin: 'manual' } as never);
+
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/manually entered/i));
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('ignores toggle attempts on a canonical recipe', async () => {
+    const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+    await component.togglePublic({
+      ...(draftRecipe() as object),
+      is_canonical: true,
+      is_public: true,
+      slug: 'vegan-cornbread',
+    } as never);
+
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('blocks a title that derives an empty slug and says why', async () => {
+    const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+    await component.togglePublic({ ...(draftRecipe() as object), name: '🌮🌮🌮' } as never);
+
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/can't be published/i));
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('prompts before first publish of a sourceSlug copy and aborts on "no"', async () => {
+    const confirmMock = vi.fn().mockReturnValue(false);
+    vi.stubGlobal('confirm', confirmMock);
+    const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+
+    await component.togglePublic({
+      ...(draftRecipe() as object),
+      sourceSlug: 'vegan-cornbread',
+    } as never);
+
+    expect(confirmMock).toHaveBeenCalledOnce();
+    expect(confirmMock.mock.calls[0][0]).toContain('/r/vegan-cornbread');
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('reverts the viewed signal and toasts when the publish fails to sync', async () => {
+    const { component, persistenceSaveRecipe } = createComponent({ isGuest: false });
+    persistenceSaveRecipe.mockResolvedValue(false);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const recipe = draftRecipe() as unknown as { is_public?: boolean };
+    component.recipe.set(recipe as never);
+    await component.togglePublic(recipe as never);
+
+    const viewed = component.recipe() as { is_public?: boolean } | null;
+    expect(viewed?.is_public).toBeFalsy();
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/publishing failed to sync/i));
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  // KAN-140: generated notes render live on /r/<slug>, so the editor only ever
+  // touches the private personalNotes field.
+  it('notes editor opens with personalNotes and never rewrites the generated notes', async () => {
+    const { component } = createComponent({ isGuest: false });
+    component.recipe.set({
+      ...(draftRecipe() as object),
+      notes: 'generated public notes',
+      personalNotes: 'my private tweaks',
+    } as never);
+
+    component.startEditNotes();
+    expect(component.editedNotes()).toBe('my private tweaks');
+
+    component.editedNotes.set('do not tell the internet');
+    await component.saveNotes();
+
+    const saved = component.recipe() as { notes?: string; personalNotes?: string } | null;
+    expect(saved?.notes).toBe('generated public notes');
+    expect(saved?.personalNotes).toBe('do not tell the internet');
+  });
+
+  it('scales ingredient amounts and servings by the portion multiplier', () => {
+    const { component } = createComponent({ isGuest: false });
+    component.recipe.set({
+      ...(draftRecipe() as object),
+      servings: 4,
+      ingredients: { dry: [{ name: 'flour', amount: 2, unit: 'cup' }] },
+    } as never);
+
+    component.updatePortions(2);
+
+    expect(component.scaledServings()).toBe(8);
+    expect(component.scaledIngredients()?.dry?.[0].amount).toBe(4);
+  });
+
+  it('formats common fractional amounts', () => {
+    const { component } = createComponent();
+    expect(component.formatAmount(0.25)).toBe('1/4');
+    expect(component.formatAmount(0.5)).toBe('1/2');
+    expect(component.formatAmount(2)).toBe('2');
+    expect(component.formatAmount([1, 2])).toBe('1 - 2');
+  });
+});

--- a/src/components/generator/generator.component.ts
+++ b/src/components/generator/generator.component.ts
@@ -1,20 +1,8 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { GeminiService } from '../../services/gemini.service';
-import { AuthService } from '../../services/auth.service';
-import { PersistenceService } from '../../services/persistence.service';
-import { RecipeStateService } from '../../services/recipe-state.service';
-import { ModalService } from '../../services/modal.service';
-import { ToastService } from '../../services/toast.service';
-import {
-  isPublicViewable,
-  publicLinkKind,
-  publicSlugOf,
-  publishToggleKind,
-} from '../../utils/public-link';
-import { slugFromTitle } from '../../utils/slug';
-import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
+import { RecipeViewBase } from '../shared/recipe-view.base';
+import type { Recipe } from '../../recipe.types';
 
 @Component({
   selector: 'app-generator',
@@ -22,58 +10,19 @@ import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../..
   imports: [CommonModule, FormsModule],
   templateUrl: './generator.component.html',
 })
-export class GeneratorComponent {
-  private readonly geminiService = inject(GeminiService);
-  private readonly persistenceService = inject(PersistenceService);
-  readonly authService = inject(AuthService);
-  private readonly recipeState = inject(RecipeStateService);
-  private readonly modalService = inject(ModalService);
-  private readonly toastService = inject(ToastService);
-
-  readonly recipe = this.recipeState.currentRecipe;
-  readonly generatedImageUrl = this.recipeState.generatedImageUrl;
-  readonly isSaved = this.recipeState.isSaved;
-
+export class GeneratorComponent extends RecipeViewBase {
   prompt = signal('');
   isRecipeLoading = signal(false);
-  isImageLoading = signal(false);
   error = signal<string | null>(null);
-  servingsMultiplier = signal(1);
-  isEditingNotes = signal(false);
-  editedNotes = signal('');
 
-  canPublish = computed(() => {
-    const user = this.authService.currentUser();
-    return !!user && user.isGuest === false;
-  });
-
-  scaledIngredients = computed(() => {
-    const r = this.recipe();
-    const mult = this.servingsMultiplier();
-    if (!r) return null;
-
-    const scaleIngredient = (ing: Ingredient): Ingredient => {
-      let newAmount: number | number[];
-      if (Array.isArray(ing.amount)) {
-        newAmount = ing.amount.map((val) => Number((val * mult).toFixed(2)));
-      } else {
-        newAmount = Number((ing.amount * mult).toFixed(2));
-      }
-      return { ...ing, amount: newAmount };
-    };
-
-    const scaledGroup: IngredientGroup = {};
-    if (r.ingredients.wet) scaledGroup.wet = r.ingredients.wet.map(scaleIngredient);
-    if (r.ingredients.dry) scaledGroup.dry = r.ingredients.dry.map(scaleIngredient);
-    if (r.ingredients.other) scaledGroup.other = r.ingredients.other.map(scaleIngredient);
-    return scaledGroup;
-  });
-
-  scaledServings = computed(() => {
-    const r = this.recipe();
-    if (!r) return 0;
-    return Math.round(r.servings * this.servingsMultiplier());
-  });
+  /**
+   * A guest activating the publish toggle gets the sign-in modal here, where
+   * recipe-detail stays silent (its template renders a dedicated "Sign in to
+   * publish" button instead — #3211).
+   */
+  protected override onPublishDenied(): void {
+    this.modalService.openAuth();
+  }
 
   async onGenerate() {
     if (!this.prompt().trim()) return;
@@ -125,27 +74,6 @@ export class GeneratorComponent {
     }
   }
 
-  async regenerateImage() {
-    const currentRecipe = this.recipe();
-    if (!currentRecipe) return;
-    const targetId = currentRecipe.id;
-    this.isImageLoading.set(true);
-    try {
-      const imageUrl = await this.geminiService.generateImage(targetId, true);
-      if (this.recipe()?.id === targetId) {
-        this.generatedImageUrl.set(imageUrl);
-        this.recipe.update((r) => (r ? { ...r, ai_image_url: imageUrl } : null));
-      }
-      this.authService.updateRecipeField(targetId, 'ai_image_url', imageUrl);
-    } catch (err) {
-      console.error('Image regeneration failed', err);
-    } finally {
-      if (this.recipe()?.id === targetId) {
-        this.isImageLoading.set(false);
-      }
-    }
-  }
-
   async onSaveRecipe() {
     const currentRecipe = this.recipe();
     if (!currentRecipe) return;
@@ -153,187 +81,12 @@ export class GeneratorComponent {
     this.isSaved.set(true);
   }
 
-  startEditNotes() {
-    const r = this.recipe();
-    if (!r) return;
-    // KAN-140: the editor only ever touches personalNotes — the generated
-    // notes render on the public page and must not be user-writable.
-    this.editedNotes.set(r.personalNotes || '');
-    this.isEditingNotes.set(true);
-  }
-
-  cancelEditNotes() {
-    this.isEditingNotes.set(false);
-    this.editedNotes.set('');
-  }
-
-  async saveNotes() {
-    const r = this.recipe();
-    if (r) {
-      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
-      this.recipe.set(updatedRecipe);
-      await this.persistenceService.saveRecipe(updatedRecipe);
-      this.isEditingNotes.set(false);
-    }
-  }
-
-  updatePortions(multiplier: number) {
-    this.servingsMultiplier.set(multiplier);
-  }
-
   openAddToCookbookModal() {
     const r = this.recipe();
     if (r) this.modalService.openAddToCookbook(r);
   }
 
-  exportRecipe(recipe: Recipe) {
-    const fileName = `${recipe.name.replace(/\s+/g, '_')}.json`;
-    const blob = new Blob([JSON.stringify(recipe, null, 2)], { type: 'application/json' });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = fileName;
-    a.click();
-    window.URL.revokeObjectURL(url);
-  }
-
-  async togglePublic(recipe: Recipe) {
-    if (!this.canPublish()) {
-      this.modalService.openAuth();
-      return;
-    }
-    // KAN-139: the server rejects publish-state changes on canonical recipes
-    // (400), and while the initial sync is pending we don't yet know the
-    // authoritative state — the template disables the toggle in both cases;
-    // this guard backstops it.
-    if (recipe.is_canonical || this.publishTogglePending()) return;
-    const nextState = !recipe.is_public;
-
-    // KAN-140: manually entered recipes cannot be published — the server
-    // rejects with 400; the template disables the toggle, this backstops it.
-    if (nextState && recipe.origin === 'manual') {
-      this.toastService.show("Manually entered recipes can't be published.");
-      return;
-    }
-
-    // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
-    // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
-    // with 400. Same derivation as the server (parity is spec-pinned), so
-    // catch it before the round trip and say why instead of failing silently.
-    if (nextState && !recipe.slug && !this.slugFromTitle(recipe.name)) {
-      this.toastService.show(
-        "This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."
-      );
-      return;
-    }
-
-    // KAN-137: first publish of a copy saved from a public recipe would mint
-    // a near-identical second public page (name collision → -N slug). Make
-    // that an informed choice instead of a silent side effect.
-    if (
-      nextState &&
-      !recipe.slug &&
-      recipe.sourceSlug &&
-      !confirm(
-        `This recipe was saved from a public recipe that may still be live at /r/${recipe.sourceSlug}. Publish your copy as a separate public page?`
-      )
-    ) {
-      return;
-    }
-
-    // KAN-149 (#3262): the flip is immutable and goes through the signal —
-    // zoneless change detection never re-renders on in-place mutation, which
-    // both hid the failure-revert below and froze the View link on a
-    // client-predicted slug. The slug itself is server-minted (collision →
-    // -N suffix), so no client-side guess: the View link appears once the
-    // sync merges the server's answer back.
-    const updated: Recipe = { ...recipe, is_public: nextState };
-    if (this.recipe()?.id === recipe.id) {
-      this.recipe.set(updated);
-    }
-
-    try {
-      const synced = await this.persistenceService.saveRecipe(updated);
-      if (!synced) {
-        throw new Error('Publish state failed to sync to the server');
-      }
-      // Adopt the server-authoritative row (slug included) into the viewed
-      // signal — auth state was just updated by the save's mirror-back.
-      const fresh = this.authService.currentUser()?.savedRecipes.find((r) => r.id === recipe.id);
-      if (fresh && this.recipe()?.id === recipe.id) {
-        this.recipe.set(fresh);
-      }
-    } catch (err) {
-      console.error('Failed to toggle public state:', err);
-      this.authService.saveRecipe(recipe);
-      if (this.recipe()?.id === recipe.id) {
-        this.recipe.set(recipe);
-      }
-      // KAN-104 (#3146): the revert already worked; without a message the
-      // user just sees the switch snap back with no explanation.
-      this.toastService.show(
-        nextState
-          ? 'Publishing failed to sync to the server. Check your connection and try again.'
-          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
-      );
-    }
-  }
-
-  isPublicViewable(recipe: Recipe): boolean {
-    return isPublicViewable(recipe);
-  }
-
-  publicLinkKind(recipe: Recipe): 'own' | 'source' | null {
-    return publicLinkKind(recipe);
-  }
-
-  publicSlugOf(recipe: Recipe): string | null {
-    return publicSlugOf(recipe);
-  }
-
-  publishToggleKind(recipe: Recipe): 'locked' | 'manual' | 'source' | 'normal' {
-    return publishToggleKind(recipe);
-  }
-
-  publishTogglePending(): boolean {
-    return this.persistenceService.publishStateSync() === 'pending';
-  }
-
-  publishToggleTitle(recipe: Recipe): string {
-    if (this.publishTogglePending()) return 'Checking publish state…';
-    const kind = publishToggleKind(recipe);
-    if (kind === 'locked') return 'Canonical recipe — publish state is locked';
-    if (kind === 'manual') return "Manually entered recipes can't be published.";
-    if (kind === 'source') {
-      return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
-    }
-    return recipe.is_public ? 'Unpublish this recipe' : 'Publish this recipe';
-  }
-
-  private slugFromTitle = slugFromTitle;
-
-  formatAmount(amount: number | number[]): string {
-    if (Array.isArray(amount)) {
-      return amount.join(' - ');
-    }
-    const decimal = amount;
-    if (Math.abs(decimal - 0.25) < 0.01) return '1/4';
-    if (Math.abs(decimal - 0.5) < 0.01) return '1/2';
-    if (Math.abs(decimal - 0.75) < 0.01) return '3/4';
-    if (Math.abs(decimal - 0.33) < 0.01) return '1/3';
-    if (Math.abs(decimal - 0.66) < 0.01) return '2/3';
-    return decimal.toString();
-  }
-
   isString(val: unknown): boolean {
     return typeof val === 'string';
-  }
-
-  instructionText(step: string | InstructionStep): string {
-    return typeof step === 'string' ? step : step.description;
-  }
-
-  openAuthModal() {
-    this.modalService.openAuth();
   }
 }

--- a/src/components/recipe-detail/recipe-detail.component.ts
+++ b/src/components/recipe-detail/recipe-detail.component.ts
@@ -1,22 +1,9 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AuthService } from '../../services/auth.service';
-import { PersistenceService } from '../../services/persistence.service';
-import { GeminiService } from '../../services/gemini.service';
-import { RecipeStateService } from '../../services/recipe-state.service';
-import { ToastService } from '../../services/toast.service';
-import { ModalService } from '../../services/modal.service';
-import {
-  isPublicViewable,
-  publicLinkKind,
-  publicSlugOf,
-  publishToggleKind,
-} from '../../utils/public-link';
-import { slugFromTitle } from '../../utils/slug';
+import { RecipeViewBase } from '../shared/recipe-view.base';
 import { recipeFromRow } from '../../utils/recipe-row';
-import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
 
 @Component({
   selector: 'app-recipe-detail',
@@ -24,60 +11,14 @@ import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../..
   imports: [CommonModule, FormsModule],
   templateUrl: './recipe-detail.component.html',
 })
-export class RecipeDetailComponent {
+export class RecipeDetailComponent extends RecipeViewBase {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
-  readonly authService = inject(AuthService);
-  private readonly persistenceService = inject(PersistenceService);
-  private readonly geminiService = inject(GeminiService);
-  private readonly recipeState = inject(RecipeStateService);
-  private readonly toastService = inject(ToastService);
-  private readonly modalService = inject(ModalService);
-
-  readonly recipe = this.recipeState.currentRecipe;
-  readonly generatedImageUrl = this.recipeState.generatedImageUrl;
-  readonly isSaved = this.recipeState.isSaved;
 
   isLoading = signal(false);
-  isImageLoading = signal(false);
-  servingsMultiplier = signal(1);
-  isEditingNotes = signal(false);
-  editedNotes = signal('');
-
-  canPublish = computed(() => {
-    const user = this.authService.currentUser();
-    return !!user && user.isGuest === false;
-  });
-
-  scaledIngredients = computed(() => {
-    const r = this.recipe();
-    const mult = this.servingsMultiplier();
-    if (!r) return null;
-
-    const scaleIngredient = (ing: Ingredient): Ingredient => {
-      let newAmount: number | number[];
-      if (Array.isArray(ing.amount)) {
-        newAmount = ing.amount.map((val) => Number((val * mult).toFixed(2)));
-      } else {
-        newAmount = Number((ing.amount * mult).toFixed(2));
-      }
-      return { ...ing, amount: newAmount };
-    };
-
-    const scaledGroup: IngredientGroup = {};
-    if (r.ingredients.wet) scaledGroup.wet = r.ingredients.wet.map(scaleIngredient);
-    if (r.ingredients.dry) scaledGroup.dry = r.ingredients.dry.map(scaleIngredient);
-    if (r.ingredients.other) scaledGroup.other = r.ingredients.other.map(scaleIngredient);
-    return scaledGroup;
-  });
-
-  scaledServings = computed(() => {
-    const r = this.recipe();
-    if (!r) return 0;
-    return Math.round(r.servings * this.servingsMultiplier());
-  });
 
   constructor() {
+    super();
     this.route.paramMap.subscribe((params) => {
       const id = params.get('id');
       if (!id) return;
@@ -125,198 +66,5 @@ export class RecipeDetailComponent {
 
   goBack() {
     this.router.navigate(['/kitchen']);
-  }
-
-  async regenerateImage() {
-    const currentRecipe = this.recipe();
-    if (!currentRecipe) return;
-    const targetId = currentRecipe.id;
-    this.isImageLoading.set(true);
-    try {
-      const imageUrl = await this.geminiService.generateImage(targetId, true);
-      if (this.recipe()?.id === targetId) {
-        this.generatedImageUrl.set(imageUrl);
-        this.recipe.update((r) => (r ? { ...r, ai_image_url: imageUrl } : null));
-      }
-      this.authService.updateRecipeField(targetId, 'ai_image_url', imageUrl);
-    } catch (err) {
-      console.error('Image regeneration failed', err);
-    } finally {
-      if (this.recipe()?.id === targetId) {
-        this.isImageLoading.set(false);
-      }
-    }
-  }
-
-  startEditNotes() {
-    const r = this.recipe();
-    if (!r) return;
-    // KAN-140: the editor only ever touches personalNotes — the generated
-    // notes render on the public page and must not be user-writable.
-    this.editedNotes.set(r.personalNotes || '');
-    this.isEditingNotes.set(true);
-  }
-
-  cancelEditNotes() {
-    this.isEditingNotes.set(false);
-    this.editedNotes.set('');
-  }
-
-  async saveNotes() {
-    const r = this.recipe();
-    if (r) {
-      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
-      this.recipe.set(updatedRecipe);
-      await this.persistenceService.saveRecipe(updatedRecipe);
-      this.isEditingNotes.set(false);
-    }
-  }
-
-  updatePortions(multiplier: number) {
-    this.servingsMultiplier.set(multiplier);
-  }
-
-  async togglePublic(recipe: Recipe) {
-    if (!this.canPublish()) return;
-    // KAN-139: the server rejects publish-state changes on canonical recipes
-    // (400), and while the initial sync is pending we don't yet know the
-    // authoritative state — the template disables the toggle in both cases;
-    // this guard backstops it.
-    if (recipe.is_canonical || this.publishTogglePending()) return;
-    const nextState = !recipe.is_public;
-
-    // KAN-140: manually entered recipes cannot be published — the server
-    // rejects with 400; the template disables the toggle, this backstops it.
-    if (nextState && recipe.origin === 'manual') {
-      this.toastService.show("Manually entered recipes can't be published.");
-      return;
-    }
-
-    // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
-    // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
-    // with 400. Same derivation as the server (parity is spec-pinned), so
-    // catch it before the round trip and say why instead of failing silently.
-    if (nextState && !recipe.slug && !this.slugFromTitle(recipe.name)) {
-      this.toastService.show(
-        "This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."
-      );
-      return;
-    }
-
-    // KAN-137: first publish of a copy saved from a public recipe would mint
-    // a near-identical second public page (name collision → -N slug). Make
-    // that an informed choice instead of a silent side effect.
-    if (
-      nextState &&
-      !recipe.slug &&
-      recipe.sourceSlug &&
-      !confirm(
-        `This recipe was saved from a public recipe that may still be live at /r/${recipe.sourceSlug}. Publish your copy as a separate public page?`
-      )
-    ) {
-      return;
-    }
-
-    // KAN-149 (#3262): the flip is immutable and goes through the signal —
-    // zoneless change detection never re-renders on in-place mutation, which
-    // both hid the failure-revert below and froze the View link on a
-    // client-predicted slug. The slug itself is server-minted (collision →
-    // -N suffix), so no client-side guess: the View link appears once the
-    // sync merges the server's answer back.
-    const updated: Recipe = { ...recipe, is_public: nextState };
-    if (this.recipe()?.id === recipe.id) {
-      this.recipe.set(updated);
-    }
-
-    try {
-      const synced = await this.persistenceService.saveRecipe(updated);
-      if (!synced) {
-        throw new Error('Publish state failed to sync to the server');
-      }
-      // Adopt the server-authoritative row (slug included) into the viewed
-      // signal — auth state was just updated by the save's mirror-back.
-      const fresh = this.authService.currentUser()?.savedRecipes.find((r) => r.id === recipe.id);
-      if (fresh && this.recipe()?.id === recipe.id) {
-        this.recipe.set(fresh);
-      }
-    } catch (err) {
-      console.error('Failed to toggle public state:', err);
-      this.authService.saveRecipe(recipe);
-      if (this.recipe()?.id === recipe.id) {
-        this.recipe.set(recipe);
-      }
-      // KAN-104 (#3146): the revert already worked; without a message the
-      // user just sees the switch snap back with no explanation.
-      this.toastService.show(
-        nextState
-          ? 'Publishing failed to sync to the server. Check your connection and try again.'
-          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
-      );
-    }
-  }
-
-  isPublicViewable(recipe: Recipe): boolean {
-    return isPublicViewable(recipe);
-  }
-
-  publicSlugOf(recipe: Recipe): string | null {
-    return publicSlugOf(recipe);
-  }
-
-  publicLinkKind(recipe: Recipe): 'own' | 'source' | null {
-    return publicLinkKind(recipe);
-  }
-
-  publishToggleKind(recipe: Recipe): 'locked' | 'manual' | 'source' | 'normal' {
-    return publishToggleKind(recipe);
-  }
-
-  publishTogglePending(): boolean {
-    return this.persistenceService.publishStateSync() === 'pending';
-  }
-
-  publishToggleTitle(recipe: Recipe): string {
-    if (this.publishTogglePending()) return 'Checking publish state…';
-    const kind = publishToggleKind(recipe);
-    if (kind === 'locked') return 'Canonical recipe — publish state is locked';
-    if (kind === 'manual') return "Manually entered recipes can't be published.";
-    if (kind === 'source') {
-      return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
-    }
-    return recipe.is_public ? 'Unpublish this recipe' : 'Publish this recipe';
-  }
-
-  openAuthModal() {
-    this.modalService.openAuth();
-  }
-
-  private slugFromTitle = slugFromTitle;
-
-  exportRecipe(recipe: Recipe) {
-    const fileName = `${recipe.name.replace(/\s+/g, '_')}.json`;
-    const blob = new Blob([JSON.stringify(recipe, null, 2)], { type: 'application/json' });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = fileName;
-    a.click();
-    window.URL.revokeObjectURL(url);
-  }
-
-  formatAmount(amount: number | number[]): string {
-    if (Array.isArray(amount)) {
-      return amount.join(' - ');
-    }
-    const decimal = amount;
-    if (Math.abs(decimal - 0.25) < 0.01) return '1/4';
-    if (Math.abs(decimal - 0.5) < 0.01) return '1/2';
-    if (Math.abs(decimal - 0.75) < 0.01) return '3/4';
-    if (Math.abs(decimal - 0.33) < 0.01) return '1/3';
-    if (Math.abs(decimal - 0.66) < 0.01) return '2/3';
-    return decimal.toString();
-  }
-
-  instructionText(step: string | InstructionStep): string {
-    return typeof step === 'string' ? step : step.description;
   }
 }

--- a/src/components/shared/recipe-view.base.test.ts
+++ b/src/components/shared/recipe-view.base.test.ts
@@ -1,0 +1,115 @@
+import '@angular/compiler';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { RecipeViewBase } from './recipe-view.base';
+import { AuthService } from '../../services/auth.service';
+import { PersistenceService } from '../../services/persistence.service';
+import { GeminiService } from '../../services/gemini.service';
+import { RecipeStateService } from '../../services/recipe-state.service';
+import { ToastService } from '../../services/toast.service';
+import { ModalService } from '../../services/modal.service';
+
+// KAN-126 (#3209): the shared seam between GeneratorComponent and
+// RecipeDetailComponent. The component test files cover the behaviour through
+// each surface; this file pins the *contract of the abstraction itself* — above
+// all onPublishDenied, the single hook where the two components legitimately
+// diverge (generator opens the auth modal, recipe-detail stays silent).
+describe('RecipeViewBase', () => {
+  let toastShow: ReturnType<typeof vi.fn>;
+  let denied: Mock<() => void>;
+
+  beforeEach(() => {
+    toastShow = vi.fn();
+    denied = vi.fn<() => void>();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const createHost = (opts: { isGuest?: boolean } = {}) => {
+    const recipeState = runInInjectionContext(
+      Injector.create({ providers: [] }),
+      () => new RecipeStateService()
+    );
+    const persistenceSaveRecipe = vi.fn().mockResolvedValue(true);
+    const authUser = { isGuest: opts.isGuest ?? false, savedRecipes: [] as unknown[] };
+
+    const injector = Injector.create({
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser: () => authUser,
+            saveRecipe: vi.fn(),
+            updateRecipeField: vi.fn(),
+          },
+        },
+        {
+          provide: PersistenceService,
+          useValue: { saveRecipe: persistenceSaveRecipe, publishStateSync: () => 'synced' },
+        },
+        { provide: GeminiService, useValue: {} },
+        { provide: RecipeStateService, useValue: recipeState },
+        { provide: ToastService, useValue: { show: toastShow } },
+        { provide: ModalService, useValue: { openAuth: vi.fn() } },
+      ],
+    });
+
+    class Host extends RecipeViewBase {
+      protected override onPublishDenied(): void {
+        denied();
+      }
+    }
+
+    const host = runInInjectionContext(injector, () => new Host());
+    return { host, persistenceSaveRecipe };
+  };
+
+  it('calls the onPublishDenied hook instead of saving when the user cannot publish', async () => {
+    const { host, persistenceSaveRecipe } = createHost({ isGuest: true });
+
+    await host.togglePublic({ id: 'r1', name: 'Vegan Cornbread' } as never);
+
+    expect(denied).toHaveBeenCalledOnce();
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('does not call the hook when the user can publish', async () => {
+    const { host, persistenceSaveRecipe } = createHost({ isGuest: false });
+
+    await host.togglePublic({ id: 'r1', name: 'Vegan Cornbread' } as never);
+
+    expect(denied).not.toHaveBeenCalled();
+    expect(persistenceSaveRecipe).toHaveBeenCalledOnce();
+  });
+
+  it('flips publish state on a copy, never mutating the passed recipe', async () => {
+    const { host, persistenceSaveRecipe } = createHost({ isGuest: false });
+    const recipe = { id: 'r1', name: 'Vegan Cornbread' } as unknown as { is_public?: boolean };
+
+    await host.togglePublic(recipe as never);
+
+    expect(recipe.is_public).toBeFalsy();
+    expect(persistenceSaveRecipe).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r1', is_public: true })
+    );
+  });
+
+  it('formats fractional and ranged amounts', () => {
+    const { host } = createHost();
+    expect(host.formatAmount(0.33)).toBe('1/3');
+    expect(host.formatAmount(0.75)).toBe('3/4');
+    expect(host.formatAmount(3)).toBe('3');
+    expect(host.formatAmount([1, 2])).toBe('1 - 2');
+  });
+
+  it('reads instruction text from both the string and step-object shapes', () => {
+    const { host } = createHost();
+    expect(host.instructionText('Preheat the oven')).toBe('Preheat the oven');
+    expect(host.instructionText({ description: 'Fold the batter' } as never)).toBe(
+      'Fold the batter'
+    );
+  });
+});

--- a/src/components/shared/recipe-view.base.ts
+++ b/src/components/shared/recipe-view.base.ts
@@ -1,0 +1,288 @@
+import { computed, inject, signal } from '@angular/core';
+import { AuthService } from '../../services/auth.service';
+import { PersistenceService } from '../../services/persistence.service';
+import { GeminiService } from '../../services/gemini.service';
+import { RecipeStateService } from '../../services/recipe-state.service';
+import { ToastService } from '../../services/toast.service';
+import { ModalService } from '../../services/modal.service';
+import {
+  isPublicViewable,
+  publicLinkKind,
+  publicSlugOf,
+  publishToggleKind,
+} from '../../utils/public-link';
+import { slugFromTitle } from '../../utils/slug';
+import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
+
+/**
+ * State and behaviour shared by the two components that render a single recipe
+ * (KAN-126 / #3209).
+ *
+ * `GeneratorComponent` and `RecipeDetailComponent` carried ~13 byte-identical
+ * methods, so every fix had to be applied twice — the `togglePublic`
+ * redundant-save bug (da445b3) and the KAN-149 immutability fix both had to
+ * land in two places, and PR #3265 grew the duplication further.
+ *
+ * The components keep whatever is genuinely theirs: prompt/generation state on
+ * the generator, routing and the cold deep-link fetch on recipe-detail.
+ *
+ * Uses `inject()` in field initialisers rather than constructor parameters, so
+ * subclasses need no constructor boilerplate and no Angular decorator is
+ * required here.
+ */
+export abstract class RecipeViewBase {
+  readonly authService = inject(AuthService);
+  protected readonly persistenceService = inject(PersistenceService);
+  protected readonly geminiService = inject(GeminiService);
+  protected readonly recipeState = inject(RecipeStateService);
+  protected readonly toastService = inject(ToastService);
+  protected readonly modalService = inject(ModalService);
+
+  readonly recipe = this.recipeState.currentRecipe;
+  readonly generatedImageUrl = this.recipeState.generatedImageUrl;
+  readonly isSaved = this.recipeState.isSaved;
+
+  isImageLoading = signal(false);
+  servingsMultiplier = signal(1);
+  isEditingNotes = signal(false);
+  editedNotes = signal('');
+
+  canPublish = computed(() => {
+    const user = this.authService.currentUser();
+    return !!user && user.isGuest === false;
+  });
+
+  scaledIngredients = computed(() => {
+    const r = this.recipe();
+    const mult = this.servingsMultiplier();
+    if (!r) return null;
+
+    const scaleIngredient = (ing: Ingredient): Ingredient => {
+      let newAmount: number | number[];
+      if (Array.isArray(ing.amount)) {
+        newAmount = ing.amount.map((val) => Number((val * mult).toFixed(2)));
+      } else {
+        newAmount = Number((ing.amount * mult).toFixed(2));
+      }
+      return { ...ing, amount: newAmount };
+    };
+
+    const scaledGroup: IngredientGroup = {};
+    if (r.ingredients.wet) scaledGroup.wet = r.ingredients.wet.map(scaleIngredient);
+    if (r.ingredients.dry) scaledGroup.dry = r.ingredients.dry.map(scaleIngredient);
+    if (r.ingredients.other) scaledGroup.other = r.ingredients.other.map(scaleIngredient);
+    return scaledGroup;
+  });
+
+  scaledServings = computed(() => {
+    const r = this.recipe();
+    if (!r) return 0;
+    return Math.round(r.servings * this.servingsMultiplier());
+  });
+
+  protected slugFromTitle = slugFromTitle;
+
+  /**
+   * What to do when a user who cannot publish activates the toggle.
+   *
+   * The one place the two components legitimately diverge: the generator
+   * prompts the guest to sign in, while recipe-detail stays silent because its
+   * template already renders a dedicated "Sign in to publish" button (#3211).
+   * Default is the silent branch.
+   */
+  protected onPublishDenied(): void {}
+
+  async regenerateImage() {
+    const currentRecipe = this.recipe();
+    if (!currentRecipe) return;
+    const targetId = currentRecipe.id;
+    this.isImageLoading.set(true);
+    try {
+      const imageUrl = await this.geminiService.generateImage(targetId, true);
+      if (this.recipe()?.id === targetId) {
+        this.generatedImageUrl.set(imageUrl);
+        this.recipe.update((r) => (r ? { ...r, ai_image_url: imageUrl } : null));
+      }
+      this.authService.updateRecipeField(targetId, 'ai_image_url', imageUrl);
+    } catch (err) {
+      console.error('Image regeneration failed', err);
+    } finally {
+      if (this.recipe()?.id === targetId) {
+        this.isImageLoading.set(false);
+      }
+    }
+  }
+
+  startEditNotes() {
+    const r = this.recipe();
+    if (!r) return;
+    // KAN-140: the editor only ever touches personalNotes — the generated
+    // notes render on the public page and must not be user-writable.
+    this.editedNotes.set(r.personalNotes || '');
+    this.isEditingNotes.set(true);
+  }
+
+  cancelEditNotes() {
+    this.isEditingNotes.set(false);
+    this.editedNotes.set('');
+  }
+
+  async saveNotes() {
+    const r = this.recipe();
+    if (r) {
+      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
+      this.recipe.set(updatedRecipe);
+      await this.persistenceService.saveRecipe(updatedRecipe);
+      this.isEditingNotes.set(false);
+    }
+  }
+
+  updatePortions(multiplier: number) {
+    this.servingsMultiplier.set(multiplier);
+  }
+
+  async togglePublic(recipe: Recipe) {
+    if (!this.canPublish()) {
+      this.onPublishDenied();
+      return;
+    }
+    // KAN-139: the server rejects publish-state changes on canonical recipes
+    // (400), and while the initial sync is pending we don't yet know the
+    // authoritative state — the template disables the toggle in both cases;
+    // this guard backstops it.
+    if (recipe.is_canonical || this.publishTogglePending()) return;
+    const nextState = !recipe.is_public;
+
+    // KAN-140: manually entered recipes cannot be published — the server
+    // rejects with 400; the template disables the toggle, this backstops it.
+    if (nextState && recipe.origin === 'manual') {
+      this.toastService.show("Manually entered recipes can't be published.");
+      return;
+    }
+
+    // KAN-104 (#3146): a title with no ASCII alphanumerics (all-emoji,
+    // pure-CJK/Cyrillic) derives an empty slug, which the server rejects
+    // with 400. Same derivation as the server (parity is spec-pinned), so
+    // catch it before the round trip and say why instead of failing silently.
+    if (nextState && !recipe.slug && !this.slugFromTitle(recipe.name)) {
+      this.toastService.show(
+        "This recipe can't be published: its title has no letters or numbers (a-z, 0-9) to build a public link from."
+      );
+      return;
+    }
+
+    // KAN-137: first publish of a copy saved from a public recipe would mint
+    // a near-identical second public page (name collision → -N slug). Make
+    // that an informed choice instead of a silent side effect.
+    if (
+      nextState &&
+      !recipe.slug &&
+      recipe.sourceSlug &&
+      !confirm(
+        `This recipe was saved from a public recipe that may still be live at /r/${recipe.sourceSlug}. Publish your copy as a separate public page?`
+      )
+    ) {
+      return;
+    }
+
+    // KAN-149 (#3262): the flip is immutable and goes through the signal —
+    // zoneless change detection never re-renders on in-place mutation, which
+    // both hid the failure-revert below and froze the View link on a
+    // client-predicted slug. The slug itself is server-minted (collision →
+    // -N suffix), so no client-side guess: the View link appears once the
+    // sync merges the server's answer back.
+    const updated: Recipe = { ...recipe, is_public: nextState };
+    if (this.recipe()?.id === recipe.id) {
+      this.recipe.set(updated);
+    }
+
+    try {
+      const synced = await this.persistenceService.saveRecipe(updated);
+      if (!synced) {
+        throw new Error('Publish state failed to sync to the server');
+      }
+      // Adopt the server-authoritative row (slug included) into the viewed
+      // signal — auth state was just updated by the save's mirror-back.
+      const fresh = this.authService.currentUser()?.savedRecipes.find((r) => r.id === recipe.id);
+      if (fresh && this.recipe()?.id === recipe.id) {
+        this.recipe.set(fresh);
+      }
+    } catch (err) {
+      console.error('Failed to toggle public state:', err);
+      this.authService.saveRecipe(recipe);
+      if (this.recipe()?.id === recipe.id) {
+        this.recipe.set(recipe);
+      }
+      // KAN-104 (#3146): the revert already worked; without a message the
+      // user just sees the switch snap back with no explanation.
+      this.toastService.show(
+        nextState
+          ? 'Publishing failed to sync to the server. Check your connection and try again.'
+          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
+      );
+    }
+  }
+
+  isPublicViewable(recipe: Recipe): boolean {
+    return isPublicViewable(recipe);
+  }
+
+  publicSlugOf(recipe: Recipe): string | null {
+    return publicSlugOf(recipe);
+  }
+
+  publicLinkKind(recipe: Recipe): 'own' | 'source' | null {
+    return publicLinkKind(recipe);
+  }
+
+  publishToggleKind(recipe: Recipe): 'locked' | 'manual' | 'source' | 'normal' {
+    return publishToggleKind(recipe);
+  }
+
+  publishTogglePending(): boolean {
+    return this.persistenceService.publishStateSync() === 'pending';
+  }
+
+  publishToggleTitle(recipe: Recipe): string {
+    if (this.publishTogglePending()) return 'Checking publish state…';
+    const kind = publishToggleKind(recipe);
+    if (kind === 'locked') return 'Canonical recipe — publish state is locked';
+    if (kind === 'manual') return "Manually entered recipes can't be published.";
+    if (kind === 'source') {
+      return `This recipe was saved from a public recipe (/r/${recipe.sourceSlug}). Publishing creates your own separate public page.`;
+    }
+    return recipe.is_public ? 'Unpublish this recipe' : 'Publish this recipe';
+  }
+
+  exportRecipe(recipe: Recipe) {
+    const fileName = `${recipe.name.replace(/\s+/g, '_')}.json`;
+    const blob = new Blob([JSON.stringify(recipe, null, 2)], { type: 'application/json' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
+  formatAmount(amount: number | number[]): string {
+    if (Array.isArray(amount)) {
+      return amount.join(' - ');
+    }
+    const decimal = amount;
+    if (Math.abs(decimal - 0.25) < 0.01) return '1/4';
+    if (Math.abs(decimal - 0.5) < 0.01) return '1/2';
+    if (Math.abs(decimal - 0.75) < 0.01) return '3/4';
+    if (Math.abs(decimal - 0.33) < 0.01) return '1/3';
+    if (Math.abs(decimal - 0.66) < 0.01) return '2/3';
+    return decimal.toString();
+  }
+
+  instructionText(step: string | InstructionStep): string {
+    return typeof step === 'string' ? step : step.description;
+  }
+
+  openAuthModal() {
+    this.modalService.openAuth();
+  }
+}


### PR DESCRIPTION
Closes #3209. Sprint 3 item **B3** (KAN-126).

`GeneratorComponent` and `RecipeDetailComponent` carried ~13 byte-identical methods, so every fix had to land twice — the `togglePublic` redundant-save bug (`da445b3`) and the KAN-149 immutability fix both did, and **#3265 grew the duplication further**. Both reviewers on that PR flagged it.

## What moved

New `src/components/shared/recipe-view.base.ts`, extended by both components: the injected services, the recipe/notes/portion signals, `canPublish` + `scaled*` computeds, and `togglePublic`, `regenerateImage`, the notes editor, `exportRecipe`, `formatAmount`, `instructionText`, and the publish-link helpers.

Each component keeps what's genuinely its own — prompt/generation state on the generator, routing and the cold deep-link fetch on recipe-detail.

**Net: −515 lines across the two components, +16.**

## The one real difference, now an explicit seam

The two `togglePublic` copies were identical *except* one branch: a guest activating the toggle gets the auth modal in the generator, while recipe-detail returns silently because its template renders a dedicated "Sign in to publish" button (#3211).

Collapsing them onto one implementation would have silently dropped that. It's now a `protected onPublishDenied()` hook — default silent, overridden in the generator.

## Testing

**`GeneratorComponent` had no test file at all**, so its half of this logic was completely unprotected before the move. That was the main risk here, so I closed it first:

- **`generator.component.test.ts` (10 tests)** — pins the behaviour through the generator's surface: the guest/auth-modal branch, immutable publish + server-slug adoption, manual-origin and canonical blocks, empty-slug pre-check, sourceSlug confirm-guard, failure revert, notes editor, portion scaling.
- **`recipe-view.base.test.ts` (5 tests)** — pins the abstraction's own contract, above all the `onPublishDenied` seam.

The generator tests were **mutation-checked**: collapsing the guest branch onto recipe-detail's silent version — precisely the mistake this extraction could make — fails the first test. A characterization test that has never failed proves nothing, so I verified it can.

Suite **190 → 205 passing**, 18 files. Lint, `format:check`, `type-check` and build all clean.

## Bundle impact (measured, not assumed)

| | before | after |
| --- | --- | --- |
| Initial bundle | 885.64 kB | 885.78 kB (+0.14 kB) |
| `recipe-detail` lazy chunk | 21.19 kB | **16.81 kB (−21%)** |

The shared code is no longer duplicated into the lazy chunk. The pre-existing 500 kB initial-budget warning is unchanged — it was already exceeded on `dev`.

## Deliberately out of scope

`kitchen.component.ts` also has an `exportRecipe()`, but it's a *different* function (exports the whole cookbook, not one recipe) that merely shares a name. Left alone; renaming it isn't this PR's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014psWRRrZLX2xKNyeTvXVPo



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

