### PR TITLE
fix(spa): make an unavailable publish toggle explain itself, and free manual notes [KAN-143] [KAN-144]

### DIFF
--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -573,9 +573,14 @@
               </div>
             </div>
           } @else {
-            <p class="text-yellow-900 italic whitespace-pre-wrap">
-              {{ r.notes || 'No notes added yet.' }}
-            </p>
+            <!-- GH #3256 (KAN-144): "No notes added yet." directly above the
+                 user's own notes reads as a contradiction — a migrated manual
+                 recipe has no generated notes but plenty of personal ones. -->
+            @if (r.notes || !r.personalNotes) {
+              <p class="text-yellow-900 italic whitespace-pre-wrap">
+                {{ r.notes || 'No notes added yet.' }}
+              </p>
+            }
             @if (r.personalNotes) {
               <p
                 class="mt-3 pt-3 border-t border-yellow-100 text-yellow-900/80 italic whitespace-pre-wrap text-sm"

--- a/src/components/generator/generator.component.html
+++ b/src/components/generator/generator.component.html
@@ -172,15 +172,20 @@
                     >Public</span
                   >
                   <!-- KAN-139: greyed while the initial server sync is pending
-                       and for copies saved from a public recipe; disabled
-                       outright when the recipe is canonical (server-locked). -->
+                       and for copies saved from a public recipe; unavailable
+                       when the recipe is canonical (server-locked).
+                       GH #3255 (KAN-143): aria-disabled, not disabled — a
+                       disabled button takes no focus and shows no reliable
+                       tooltip, so the `title` explaining *why* could never
+                       reach the user. togglePublic() refuses the change and
+                       toasts the reason instead. -->
                   <button
                     type="button"
                     role="switch"
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
-                    [disabled]="
+                    [attr.aria-disabled]="
                       publishToggleKind(r) === 'locked' ||
                       publishToggleKind(r) === 'manual' ||
                       publishTogglePending()

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -74,15 +74,20 @@
                     >Public</span
                   >
                   <!-- KAN-139: greyed while the initial server sync is pending
-                       and for copies saved from a public recipe; disabled
-                       outright when the recipe is canonical (server-locked). -->
+                       and for copies saved from a public recipe; unavailable
+                       when the recipe is canonical (server-locked).
+                       GH #3255 (KAN-143): aria-disabled, not disabled — a
+                       disabled button takes no focus and shows no reliable
+                       tooltip, so the `title` explaining *why* could never
+                       reach the user. togglePublic() refuses the change and
+                       toasts the reason instead. -->
                   <button
                     type="button"
                     role="switch"
                     [attr.aria-checked]="r.is_public"
                     aria-labelledby="public-toggle-label"
                     (click)="togglePublic(r)"
-                    [disabled]="
+                    [attr.aria-disabled]="
                       publishToggleKind(r) === 'locked' ||
                       publishToggleKind(r) === 'manual' ||
                       publishTogglePending()

--- a/src/components/recipe-detail/recipe-detail.component.html
+++ b/src/components/recipe-detail/recipe-detail.component.html
@@ -476,9 +476,14 @@
               </div>
             </div>
           } @else {
-            <p class="text-yellow-900 italic whitespace-pre-wrap">
-              {{ r.notes || 'No notes added yet.' }}
-            </p>
+            <!-- GH #3256 (KAN-144): "No notes added yet." directly above the
+                 user's own notes reads as a contradiction — a migrated manual
+                 recipe has no generated notes but plenty of personal ones. -->
+            @if (r.notes || !r.personalNotes) {
+              <p class="text-yellow-900 italic whitespace-pre-wrap">
+                {{ r.notes || 'No notes added yet.' }}
+              </p>
+            }
             @if (r.personalNotes) {
               <p
                 class="mt-3 pt-3 border-t border-yellow-100 text-yellow-900/80 italic whitespace-pre-wrap text-sm"

--- a/src/components/shared/recipe-view.base.test.ts
+++ b/src/components/shared/recipe-view.base.test.ts
@@ -28,7 +28,7 @@ describe('RecipeViewBase', () => {
     vi.restoreAllMocks();
   });
 
-  const createHost = (opts: { isGuest?: boolean } = {}) => {
+  const createHost = (opts: { isGuest?: boolean; publishStateSync?: string } = {}) => {
     const recipeState = runInInjectionContext(
       Injector.create({ providers: [] }),
       () => new RecipeStateService()
@@ -48,7 +48,10 @@ describe('RecipeViewBase', () => {
         },
         {
           provide: PersistenceService,
-          useValue: { saveRecipe: persistenceSaveRecipe, publishStateSync: () => 'synced' },
+          useValue: {
+            saveRecipe: persistenceSaveRecipe,
+            publishStateSync: () => opts.publishStateSync ?? 'synced',
+          },
         },
         { provide: GeminiService, useValue: {} },
         { provide: RecipeStateService, useValue: recipeState },
@@ -95,6 +98,90 @@ describe('RecipeViewBase', () => {
     expect(persistenceSaveRecipe).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'r1', is_public: true })
     );
+  });
+
+  // GH #3255 (KAN-143): the reason a toggle is unavailable used to live only in
+  // a `title` on a `disabled` button, which neither surfaces a tooltip reliably
+  // nor is reachable by keyboard — so the explanation could never appear.
+  // Activating an unavailable toggle now says why out loud.
+  it('says why a canonical recipe cannot be unpublished', async () => {
+    const { host, persistenceSaveRecipe } = createHost();
+
+    await host.togglePublic({
+      id: 'r1',
+      name: 'Vegan Cornbread',
+      is_canonical: true,
+      is_public: true,
+    } as never);
+
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/locked/i));
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  it('says why the toggle is inert while the publish state is still syncing', async () => {
+    const { host, persistenceSaveRecipe } = createHost({ publishStateSync: 'pending' });
+
+    await host.togglePublic({ id: 'r1', name: 'Vegan Cornbread' } as never);
+
+    expect(toastShow).toHaveBeenCalledWith(expect.stringMatching(/checking publish state/i));
+    expect(persistenceSaveRecipe).not.toHaveBeenCalled();
+  });
+
+  // GH #3256 (KAN-144): manual entry wrote the user's own notes into `notes`,
+  // the generated-content field the editor treats as read-only — so those notes
+  // were frozen and the pencil opened an empty box. Manual recipes are never
+  // published, so nothing public depends on their `notes`: adopt the text.
+  it('seeds the editor from the legacy notes of a manually entered recipe', () => {
+    const { host } = createHost();
+    host.recipe.set({
+      id: 'r1',
+      name: 'Grandma Cornbread',
+      origin: 'manual',
+      notes: 'skillet must be screaming hot',
+    } as never);
+
+    host.startEditNotes();
+
+    expect(host.editedNotes()).toBe('skillet must be screaming hot');
+  });
+
+  it('migrates legacy manual notes into personalNotes and clears the legacy field', async () => {
+    const { host, persistenceSaveRecipe } = createHost();
+    host.recipe.set({
+      id: 'r1',
+      name: 'Grandma Cornbread',
+      origin: 'manual',
+      notes: 'skillet must be screaming hot',
+    } as never);
+
+    host.startEditNotes();
+    host.editedNotes.set('skillet must be screaming hot — and use bacon fat');
+    await host.saveNotes();
+
+    const saved = host.recipe() as { notes?: string; personalNotes?: string } | null;
+    expect(saved?.personalNotes).toBe('skillet must be screaming hot — and use bacon fat');
+    expect(saved?.notes).toBe('');
+    expect(persistenceSaveRecipe).toHaveBeenCalledWith(expect.objectContaining({ notes: '' }));
+  });
+
+  it('never adopts the generated notes of a generated recipe', async () => {
+    const { host } = createHost();
+    host.recipe.set({
+      id: 'r1',
+      name: 'Vegan Cornbread',
+      origin: 'generated',
+      notes: 'generated public notes',
+    } as never);
+
+    host.startEditNotes();
+    expect(host.editedNotes()).toBe('');
+
+    host.editedNotes.set('my private tweaks');
+    await host.saveNotes();
+
+    const saved = host.recipe() as { notes?: string; personalNotes?: string } | null;
+    expect(saved?.notes).toBe('generated public notes');
+    expect(saved?.personalNotes).toBe('my private tweaks');
   });
 
   it('formats fractional and ranged amounts', () => {

--- a/src/components/shared/recipe-view.base.ts
+++ b/src/components/shared/recipe-view.base.ts
@@ -113,12 +113,25 @@ export abstract class RecipeViewBase {
     }
   }
 
+  /**
+   * GH #3256 (KAN-144): manual entry used to write the user's own "Chef's
+   * Notes" into `notes` — the field KAN-140 froze as generated, publicly
+   * rendered, read-only content. Those recipes were left with notes they
+   * could no longer edit and a pencil that opened an empty box.
+   *
+   * A manual recipe can never be published, so nothing public depends on its
+   * `notes`: on first edit, adopt the text into personalNotes instead.
+   */
+  private migratesLegacyNotes(r: Recipe): boolean {
+    return r.origin === 'manual' && !r.personalNotes && !!r.notes;
+  }
+
   startEditNotes() {
     const r = this.recipe();
     if (!r) return;
     // KAN-140: the editor only ever touches personalNotes — the generated
     // notes render on the public page and must not be user-writable.
-    this.editedNotes.set(r.personalNotes || '');
+    this.editedNotes.set(this.migratesLegacyNotes(r) ? (r.notes ?? '') : r.personalNotes || '');
     this.isEditingNotes.set(true);
   }
 
@@ -130,7 +143,10 @@ export abstract class RecipeViewBase {
   async saveNotes() {
     const r = this.recipe();
     if (r) {
-      const updatedRecipe = { ...r, personalNotes: this.editedNotes() };
+      const updatedRecipe: Recipe = { ...r, personalNotes: this.editedNotes() };
+      // Clear the adopted legacy field so the same text doesn't render twice —
+      // once read-only above the editor, once as "My notes (private)".
+      if (this.migratesLegacyNotes(r)) updatedRecipe.notes = '';
       this.recipe.set(updatedRecipe);
       await this.persistenceService.saveRecipe(updatedRecipe);
       this.isEditingNotes.set(false);
@@ -148,9 +164,15 @@ export abstract class RecipeViewBase {
     }
     // KAN-139: the server rejects publish-state changes on canonical recipes
     // (400), and while the initial sync is pending we don't yet know the
-    // authoritative state — the template disables the toggle in both cases;
-    // this guard backstops it.
-    if (recipe.is_canonical || this.publishTogglePending()) return;
+    // authoritative state.
+    //
+    // GH #3255 (KAN-143): say why rather than no-op. The template used to hide
+    // the reason in a `title` on a `disabled` button — unreachable by keyboard
+    // and unreliable on hover — so an unavailable toggle just sat there.
+    if (recipe.is_canonical || this.publishTogglePending()) {
+      this.toastService.show(this.publishToggleTitle(recipe));
+      return;
+    }
     const nextState = !recipe.is_public;
 
     // KAN-140: manually entered recipes cannot be published — the server

--- a/src/modals/manual-entry/manual-entry-modal.component.html
+++ b/src/modals/manual-entry/manual-entry-modal.component.html
@@ -266,8 +266,10 @@
             </div>
 
             <div>
+              <!-- GH #3256 (KAN-144): these save as personalNotes — the private,
+                   editable field — not as the read-only generated `notes`. -->
               <label for="manual-notes" class="block text-sm font-medium text-stone-600 mb-1 mt-4"
-                >Chef's Notes</label
+                >Chef's Notes <span class="text-stone-400 font-normal">(private)</span></label
               >
               <textarea
                 id="manual-notes"

--- a/src/modals/manual-entry/manual-entry-modal.component.test.ts
+++ b/src/modals/manual-entry/manual-entry-modal.component.test.ts
@@ -1,0 +1,50 @@
+import '@angular/compiler';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ManualEntryModalComponent } from './manual-entry-modal.component';
+import { PersistenceService } from '../../services/persistence.service';
+
+// GH #3256 (KAN-144): "Chef's Notes" here are the user's own text, but they
+// were written into `notes` — the field KAN-140 froze as generated,
+// publicly-rendered, read-only content. They belong in personalNotes.
+describe('ManualEntryModalComponent', () => {
+  let saveRecipe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    saveRecipe = vi.fn().mockResolvedValue(true);
+  });
+
+  const createComponent = () => {
+    const injector = Injector.create({
+      providers: [{ provide: PersistenceService, useValue: { saveRecipe } }],
+    });
+    return runInInjectionContext(injector, () => new ManualEntryModalComponent());
+  };
+
+  it('files the chef notes as private personal notes, not as generated notes', async () => {
+    const component = createComponent();
+    component.open();
+    component.manualRecipe.update((r) => ({
+      ...r,
+      name: 'Grandma Cornbread',
+      notes: 'skillet must be screaming hot',
+    }));
+
+    await component.save();
+
+    expect(saveRecipe).toHaveBeenCalledOnce();
+    const saved = saveRecipe.mock.calls[0][0];
+    expect(saved.personalNotes).toBe('skillet must be screaming hot');
+    expect(saved.notes).toBeUndefined();
+  });
+
+  it('labels the recipe as manually entered so the server can gate publishing', async () => {
+    const component = createComponent();
+    component.open();
+    component.manualRecipe.update((r) => ({ ...r, name: 'Grandma Cornbread' }));
+
+    await component.save();
+
+    expect(saveRecipe.mock.calls[0][0].origin).toBe('manual');
+  });
+});

--- a/src/modals/manual-entry/manual-entry-modal.component.ts
+++ b/src/modals/manual-entry/manual-entry-modal.component.ts
@@ -124,7 +124,10 @@ export class ManualEntryModalComponent {
       servings: info.servings,
       ingredients,
       instructions: this.manualInstructions(),
-      notes: info.notes,
+      // GH #3256 (KAN-144): the chef's own notes are private notes, not
+      // generated content. Writing them to `notes` — read-only since KAN-140 —
+      // froze them the moment the recipe was saved.
+      personalNotes: info.notes,
       tags: info.tags
         .split(',')
         .map((t) => t.trim())


### PR DESCRIPTION
Sprint 3 wave-2 item **B2** — the two Codex P2 findings from the KAN-140 review (parent #3254).

Closes #3255
Closes #3256

## #3255 — the explanation was attached to a control that can't show it

The publish toggle carried its reason-why in a `title` on a button that was `[disabled]` for exactly the cases the title explains. A disabled button takes no focus and shows no reliable native tooltip, so *"Manually entered recipes can't be published."* could never actually reach the user.

- `[disabled]` → `[attr.aria-disabled]` in both templates: the state is still announced, but the control stays hoverable and focusable so the `title` works.
- `togglePublic()` refuses the change and **toasts the reason** instead of returning silently. The manual case already toasted; canonical (`locked`) and mid-sync (`pending`) did not, and now use the same copy as the tooltip.

The guards in `RecipeViewBase.togglePublic()` were already the real backstop (they predate this and are tested) — the template's `disabled` was belt-and-braces on top of them, so dropping it changes no publish behaviour.

## #3256 — manual entry wrote the chef's notes into the read-only field

`manual-entry-modal.component.ts` wrote free text into `notes`, the field KAN-140 froze as generated, publicly-rendered, read-only content. A manual recipe's own notes were unreachable forever and the pencil opened an empty box.

- Manual entry now writes **`personalNotes`** (label updated to "Chef's Notes (private)").
- An **existing** manual recipe adopts its legacy `notes` into `personalNotes` on first edit and clears the legacy field, so the same text doesn't render twice. Manual recipes can never be published, so nothing public depends on their `notes`.
- Generated recipes are untouched — pinned by a test.
- Follow-on found in the browser: after migration the read-only block fell through to *"No notes added yet."* printed directly above the user's own notes. The fallback now only shows when there are no personal notes either.

## Tests

TDD — 5 new cases in `recipe-view.base.test.ts`, all watched failing for the missing behaviour first, plus a **new test file for `ManualEntryModalComponent`**, which had none.

`npm test` → 19 files, **212 passed**. Lint, `type-check`, `format:check`, and `build` all clean.

## Browser verification

Templates can't be unit-tested here (no TestBed harness), so this was verified against `npm run dev` with a seeded manual recipe carrying legacy notes:

| Check | Result |
|---|---|
| Manual toggle attributes | `aria-disabled="true"`, `disabled: false`, `title="Manually entered recipes can't be published."` |
| Activating it | toast renders: *"Manually entered recipes can't be published."* |
| Toggle focusable | `document.activeElement` reaches it (a `disabled` button cannot) |
| Notes editor on a legacy manual recipe | seeds with `skillet must be screaming hot` (was empty) |
| After save | `{"notes":"","personalNotes":"skillet must be screaming hot — and use bacon fat"}`, renders under "My notes (private)" |
| Generated recipe (control) | toggle `aria-disabled="false"`, title "Publish this recipe", generated notes still render |

One thing worth knowing: Playwright's actionability check treats `aria-disabled="true"` as disabled and refuses to click, so the activation above was dispatched with `el.click()` (which no-ops on a natively `disabled` button — so it's still a fair A/B). Real users and AT are unaffected; future browser tests targeting these toggles will need `force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014psWRRrZLX2xKNyeTvXVPo



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

