### PR TITLE
feat(release): pointer targets Backend main, spent-version + CHANGELOG-SHA gates, freeze spec [KAN-138]

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -93,6 +93,65 @@ Two options, neither blocking:
 - **Relax to `first_time_contributors`** if the pending-run noise is annoying:
   `gh api -X PUT repos/{o}/{r}/actions/permissions/fork-pr-contributor-approval -f approval_policy=first_time_contributors`
 
+## The freeze window (spec — for when the driver lands)
+
+Today's scripts verify and back-sync; they do not drive the train. When a driver
+does exist it needs a freeze, because the train's payload is mutable underneath
+it: **a `dev → main` PR merges the live tip of `dev`, not the tip as of when the
+PR was opened.** Anything merged to `dev` between opening the release PR and
+merging it ships silently, outside the CHANGELOG, under a version that never
+described it.
+
+### When it opens
+
+The moment the version bump + CHANGELOG land on `dev`. That is when `dev`'s tip
+*becomes* the release payload — earlier than the release PR, which is already
+too late.
+
+### When it closes — asymmetric, and this is the part worth getting right
+
+| ref | unlocks at | why there |
+| --- | --- | --- |
+| `dev` (both repos) | **tag `vX.Y.Z` exists on origin** | The tag is the moment the version becomes immutable, which is precisely what makes "any new push means a patch bump" true. It also *has* to be here: step 8/9 back-sync writes to `dev`. |
+| `main` (both repos) | **deploy verified live** | If Cloud Build fails, the only correct recovery is a patch bump through the normal train. Holding `main` through that window is what stops a panic hotfix pushed straight to it — the one move that would break `main === deployed`. |
+
+Not a hypothetical: v0.3.0 died in the migrate job and v0.3.4 died parsing the
+Express Dockerfile. Both recovered exactly this way, as v0.3.1 and v0.3.5.
+
+### Mechanism — two layers
+
+**1. Detection (build this first).** At freeze-open the driver snapshots the four
+ref SHAs — `dev` and `main` on both repos — and re-checks them before every
+mutating step. Any movement aborts and names the ref that moved. No GitHub
+config is written, so a crashed run leaves nothing to clean up, and it catches
+the real failure at the moment it would do damage.
+
+**2. Enforcement (needs a decision + one experiment).** Note what does *not*
+work: the `update` rule ("Restrict updates") governs direct pushes, and both
+branches already block those by requiring a PR — so it adds nothing against the
+actual threat, which is a **merge**. The primitive that blocks merges is a
+**required status check that never reports**: a dedicated `release-freeze`
+ruleset per repo, normally `enforcement: disabled`, holding one
+`required_status_checks` rule for a context (`release-freeze`) that no workflow
+ever publishes. Flip it to `active` to freeze; every PR merge then sits at
+"expected — waiting for status", except for bypass actors. Bypass stays repo
+admin in `pull_request` mode, so the train's own merges still land while other
+agent sessions, Dependabot merges, and UI merges are held.
+
+This layer is unverified here — it needs the ruleset created and one throwaway
+PR to confirm the block actually lands. It also needs a standalone `--unfreeze`
+escape hatch, and the freeze state written locally *before* the API call, or an
+aborted train leaves both repos frozen with no record of why.
+
+### Already enforced
+
+The "spent version" half of the rule is live now, as a station:
+`--for-release` refuses to proceed when `v<package.json version>` is already
+tagged. `release.yml` checks `git ls-remote --tags` first and skips tag
+creation, the GitHub Release, and therefore the Cloud Build trigger — so
+re-merging a release PR on a spent version produces a green PR, a green
+workflow, and no deploy, with nothing anywhere reporting a failure.
+
 ## Still manual
 
 Deliberately, not from lack of time — these carry judgment or a credential the

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -93,6 +93,31 @@ Two options, neither blocking:
 - **Relax to `first_time_contributors`** if the pending-run noise is annoying:
   `gh api -X PUT repos/{o}/{r}/actions/permissions/fork-pr-contributor-approval -f approval_policy=first_time_contributors`
 
+## The pointer targets Backend `main`
+
+Decided 2026-07-25. The submodule pointer pins **Backend `main`'s own SHA** —
+not a `dev`-side SHA that merely carries main's content.
+
+Both deploy the same code, so this is not about what runs. It is about being
+able to answer "which Backend commit is in production?" from one ref. v0.3.9
+pinned `18a303a` while Backend `main` was `53af0941`; today's pointer pins
+`50cdbbb` while Backend `main` is `dfc5cad`. Identical trees each time, and a
+deployed SHA that appears nowhere on the branch that is supposed to equal
+production.
+
+`--for-release` blocks on it and distinguishes the two causes, because the fix
+differs:
+
+- **identical trees** — the pointer is aimed at the wrong SHA. Bump it.
+- **differing trees** — Backend `dev → main` was never promoted. Promote, then pin.
+
+The release's CHANGELOG section must also **name the pinned SHA**. Production
+deploys whatever the pointer pins at tag time, so without it the release notes
+describe the frontend half of a release and stay silent about the other half.
+The convention already existed informally (v0.3.7, v0.3.9, v0.4.0); the station
+makes it checkable, and accepts any abbreviation, which is how those entries are
+written.
+
 ## The freeze window (spec — for when the driver lands)
 
 Today's scripts verify and back-sync; they do not drive the train. When a driver

--- a/scripts/release/train-verify.sh
+++ b/scripts/release/train-verify.sh
@@ -27,8 +27,11 @@ usage() {
 Usage: scripts/release/train-verify.sh [--json] [--for-release] [--no-fetch]
 
   --json          machine-readable output (one JSON object on stdout)
-  --for-release   stricter: also require that there is something to ship and
-                  that the submodule pointer matches the Backend tip
+  --for-release   stricter: also require that there is something to ship, that
+                  the submodule pointer matches the Backend tip, and that this
+                  version is not already tagged. Queries origin for the tag even
+                  under --no-fetch (one ref lookup) — guessing there would mean
+                  greenlighting a release that silently never deploys.
   --no-fetch      skip network fetches; compare whatever refs are already local
                   (faster, but a stale origin/* gives a stale answer)
 
@@ -157,6 +160,37 @@ if [ "$version" != "unknown" ] && grep -qE "^## \[?${version//./\\.}\]?" CHANGEL
   changelog_state="present"
 fi
 
+# 6. Is this version already shipped? Once vX.Y.Z is cut the version is spent:
+#    release.yml checks `git ls-remote --tags` first and skips tag creation,
+#    the GitHub Release, and therefore the Cloud Build trigger. Re-merging a
+#    release PR on a spent version is the quietest failure in the whole train —
+#    green PR, green workflow, no tag, no deploy, no error. The rule Adam
+#    stated for the freeze window is the fix: once a tag is cut, the next thing
+#    to land needs a patch bump.
+#
+#    Under --for-release this asks origin (same query release.yml makes, so the
+#    answers cannot disagree) and refuses to guess if the network fails. In the
+#    default mode it is informational and reads local tags, which is honest
+#    about being only as fresh as the last fetch.
+if [ "$FOR_RELEASE" = "1" ]; then
+  # --exit-code distinguishes the two "no tag" answers: 2 means the query
+  # succeeded and matched nothing, anything else means the query itself failed.
+  # Collapsing them would turn an offline run into a confident "safe to ship".
+  ls_remote_rc=0
+  git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1 || ls_remote_rc=$?
+  case "$ls_remote_rc" in
+    0) tag_state="already-tagged" ;;
+    2) tag_state="not-tagged" ;;
+    *) die "could not query origin for tag v$version (git ls-remote exit $ls_remote_rc) — cannot tell whether this version is already shipped" ;;
+  esac
+else
+  if git rev-parse --verify --quiet "refs/tags/v$version" >/dev/null; then
+    tag_state="already-tagged (local)"
+  else
+    tag_state="not-tagged (local)"
+  fi
+fi
+
 # ── Verdict ─────────────────────────────────────────────────────────────────
 
 blocking=()
@@ -182,6 +216,8 @@ if [ "$FOR_RELEASE" = "1" ]; then
     blocking+=("submodule pointer content differs from Backend main — promote Backend dev→main first")
   [ "$changelog_state" = "present" ] ||
     blocking+=("CHANGELOG.md has no '## [$version]' section — pr-gate will fail the release PR")
+  [ "$tag_state" != "already-tagged" ] ||
+    blocking+=("v$version is already tagged — release.yml would skip the tag, the Release, and the Cloud Build trigger and report success. Bump package.json (patch, at minimum) before cutting.")
 else
   [ "$backend_pending" = "0" ] ||
     warnings+=("Backend dev is $backend_pending commit(s) ahead of main — promotion needed before the next release")
@@ -213,13 +249,14 @@ if [ "$FORMAT" = "json" ]; then
   printf '"pointer":{"sha":"%s","state":"%s","content":"%s"},' "$pointer" "$pointer_state" "$pointer_content_state"
   printf '"alembic_heads":"%s",' "$heads"
   printf '"changelog":"%s",' "$changelog_state"
+  printf '"tag":"%s",' "$tag_state"
   printf '"blocking":%s,' "$(json_array ${blocking[@]+"${blocking[@]}"})"
   printf '"warnings":%s' "$(json_array ${warnings[@]+"${warnings[@]}"})"
   printf '}\n'
 else
   echo "Release train — verify stations"
   echo "  repos            $COOKBOOK_REPO + $BACKEND_REPO"
-  echo "  version          $version (CHANGELOG section: $changelog_state)"
+  echo "  version          $version (CHANGELOG section: $changelog_state, tag v$version: $tag_state)"
   echo
   printf '  %-34s %s\n' "cookbook main->dev back-sync owed" "$cookbook_backsync"
   printf '  %-34s %s\n' "cookbook dev->main pending" "$cookbook_pending"

--- a/scripts/release/train-verify.sh
+++ b/scripts/release/train-verify.sh
@@ -27,11 +27,12 @@ usage() {
 Usage: scripts/release/train-verify.sh [--json] [--for-release] [--no-fetch]
 
   --json          machine-readable output (one JSON object on stdout)
-  --for-release   stricter: also require that there is something to ship, that
-                  the submodule pointer matches the Backend tip, and that this
-                  version is not already tagged. Queries origin for the tag even
-                  under --no-fetch (one ref lookup) — guessing there would mean
-                  greenlighting a release that silently never deploys.
+  --for-release   stricter. Also requires: something to ship; the submodule
+                  pointer pinned to Backend main's own SHA; the CHANGELOG
+                  section naming that SHA; and this version not already tagged.
+                  Queries origin for the tag even under --no-fetch (one ref
+                  lookup) — guessing there would mean greenlighting a release
+                  that silently never deploys.
   --no-fetch      skip network fetches; compare whatever refs are already local
                   (faster, but a stale origin/* gives a stale answer)
 
@@ -108,8 +109,20 @@ pointer=$(git rev-parse origin/dev:Backend)
 backend_dev_tip=$(git -C Backend rev-parse origin/dev)
 backend_main_tip=$(git -C Backend rev-parse origin/main)
 
-pointer_state="matches-backend-dev"
-[ "$pointer" = "$backend_dev_tip" ] || pointer_state="behind-backend-dev"
+# The pointer targets Backend **main**, not dev. main is the promoted tip and
+# the branch that is meant to equal the deployed codebase, so pinning main's own
+# SHA is what makes "which Backend commit is in production?" answerable by
+# looking at one ref. Pinning a dev-side SHA that merely has main's content —
+# which is what shipped in v0.3.9 and what the pointer does right now — leaves
+# the deployed SHA and Backend main permanently disagreeing.
+pointer_state="matches-backend-main"
+[ "$pointer" = "$backend_main_tip" ] || pointer_state="differs-from-backend-main"
+
+# Diagnostic only, but it changes what the fix is: identical trees mean the
+# pointer is merely aimed at the wrong SHA (bump it), while differing trees mean
+# Backend dev→main has not been promoted yet (promote first, then bump).
+pointer_vs_dev="matches-backend-dev"
+[ "$pointer" = "$backend_dev_tip" ] || pointer_vs_dev="differs-from-backend-dev"
 
 # Trees, not commits: a promotion merge makes main's SHA differ from dev's while
 # the content is identical, and pinning either one deploys the same code.
@@ -158,6 +171,42 @@ version=$(node -p "require('./package.json').version" 2>/dev/null || echo "unkno
 changelog_state="missing"
 if [ "$version" != "unknown" ] && grep -qE "^## \[?${version//./\\.}\]?" CHANGELOG.md 2>/dev/null; then
   changelog_state="present"
+fi
+
+# 5b. The release notes must name the Backend SHA they ship. Production deploys
+#     whatever the pointer pins at tag time, so without this the CHANGELOG
+#     describes the frontend half of a release and stays silent about the other
+#     half. The convention already exists informally (v0.3.7, v0.3.9, v0.4.0);
+#     this makes it checkable. Any abbreviation of the pinned SHA counts, since
+#     that is how the existing entries are written.
+changelog_pointer_state="absent"
+if [ "$changelog_state" = "present" ]; then
+  changelog_pointer_state=$(
+    python3 - "$version" "$pointer" <<'PY' 2>/dev/null || echo "error"
+import pathlib, re, sys
+
+version, pointer = sys.argv[1], sys.argv[2]
+text = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8", errors="replace")
+
+# This version's section only: heading through the next h2 (or EOF). Scanning
+# the whole file would happily match the PREVIOUS release's pointer line and
+# call it present.
+match = re.search(
+    r"^##\s+\[?" + re.escape(version) + r"\]?.*?$(.*?)(?=^##\s|\Z)",
+    text,
+    re.M | re.S,
+)
+if not match:
+    print("missing-section")
+    raise SystemExit
+
+for token in re.findall(r"\b[0-9a-f]{7,40}\b", match.group(1)):
+    if pointer.startswith(token):
+        print("present")
+        raise SystemExit
+print("absent")
+PY
+  )
 fi
 
 # 6. Is this version already shipped? Once vX.Y.Z is cut the version is spent:
@@ -210,10 +259,18 @@ esac
 if [ "$FOR_RELEASE" = "1" ]; then
   [ "$cookbook_pending" != "0" ] ||
     blocking+=("nothing to release: dev is not ahead of main")
-  [ "$pointer_state" = "matches-backend-dev" ] ||
-    blocking+=("submodule pointer is behind Backend dev — bump it before cutting the release")
-  [ "$pointer_content_state" = "matches-backend-main-content" ] ||
-    blocking+=("submodule pointer content differs from Backend main — promote Backend dev→main first")
+  if [ "$pointer_state" != "matches-backend-main" ]; then
+    if [ "$pointer_content_state" = "matches-backend-main-content" ]; then
+      blocking+=("submodule pointer pins ${pointer:0:12}, Backend main is ${backend_main_tip:0:12} (identical tree) — bump the pointer to main's own SHA: git -C Backend checkout ${backend_main_tip:0:12} && git add Backend")
+    else
+      blocking+=("submodule pointer content differs from Backend main — promote Backend dev→main first, then pin main's SHA")
+    fi
+  fi
+  case "$changelog_pointer_state" in
+    present) ;;
+    error) blocking+=("could not read the CHANGELOG section for $version to check the pinned Backend SHA") ;;
+    *) blocking+=("CHANGELOG section for $version does not name the pinned Backend SHA (${pointer:0:12}) — the release notes would describe only the frontend half of what deploys") ;;
+  esac
   [ "$changelog_state" = "present" ] ||
     blocking+=("CHANGELOG.md has no '## [$version]' section — pr-gate will fail the release PR")
   [ "$tag_state" != "already-tagged" ] ||
@@ -221,10 +278,12 @@ if [ "$FOR_RELEASE" = "1" ]; then
 else
   [ "$backend_pending" = "0" ] ||
     warnings+=("Backend dev is $backend_pending commit(s) ahead of main — promotion needed before the next release")
-  [ "$pointer_state" = "matches-backend-dev" ] ||
-    warnings+=("submodule pointer is behind Backend dev")
+  [ "$pointer_state" = "matches-backend-main" ] ||
+    warnings+=("submodule pointer pins ${pointer:0:12}, Backend main is ${backend_main_tip:0:12}")
   [ "$changelog_state" = "present" ] ||
     warnings+=("CHANGELOG.md has no '## [$version]' section yet")
+  [ "$changelog_state" != "present" ] || [ "$changelog_pointer_state" = "present" ] ||
+    warnings+=("CHANGELOG section for $version does not name the pinned Backend SHA yet")
 fi
 
 status="clean"
@@ -246,9 +305,10 @@ if [ "$FORMAT" = "json" ]; then
   printf '"version":"%s",' "$version"
   printf '"cookbook":{"backsync_owed":%s,"pending_release":%s},' "$cookbook_backsync" "$cookbook_pending"
   printf '"backend":{"backsync_owed":%s,"pending_promotion":%s},' "$backend_backsync" "$backend_pending"
-  printf '"pointer":{"sha":"%s","state":"%s","content":"%s"},' "$pointer" "$pointer_state" "$pointer_content_state"
+  printf '"pointer":{"sha":"%s","state":"%s","content":"%s","vs_backend_dev":"%s","backend_main":"%s"},' "$pointer" "$pointer_state" "$pointer_content_state" "$pointer_vs_dev" "$backend_main_tip"
   printf '"alembic_heads":"%s",' "$heads"
   printf '"changelog":"%s",' "$changelog_state"
+  printf '"changelog_pointer":"%s",' "$changelog_pointer_state"
   printf '"tag":"%s",' "$tag_state"
   printf '"blocking":%s,' "$(json_array ${blocking[@]+"${blocking[@]}"})"
   printf '"warnings":%s' "$(json_array ${warnings[@]+"${warnings[@]}"})"
@@ -263,7 +323,9 @@ else
   printf '  %-34s %s\n' "Backend  main->dev back-sync owed" "$backend_backsync"
   printf '  %-34s %s\n' "Backend  dev->main pending" "$backend_pending"
   printf '  %-34s %s (%s)\n' "submodule pointer" "${pointer:0:12}" "$pointer_state"
+  printf '  %-34s %s\n' "Backend  main tip" "${backend_main_tip:0:12}"
   printf '  %-34s %s\n' "pointer content vs Backend main" "$pointer_content_state"
+  printf '  %-34s %s\n' "CHANGELOG names pinned SHA" "$changelog_pointer_state"
   printf '  %-34s %s\n' "alembic heads" "$heads"
   echo
 


### PR DESCRIPTION
Adds the last station Adam identified for `--for-release`, and specs the freeze
window for the driver that does not exist yet.

## The station: spent version

`release.yml` checks `git ls-remote --tags` first and gates every subsequent
step on the result:

```
release.yml:58   if git ls-remote --exit-code --tags origin "refs/tags/$TAG"; then exists=true
release.yml:70   - name: Extract release notes      if: exists == 'false'
release.yml:87   - name: Create and push tag        if: exists == 'false'
release.yml:100  - name: Publish GitHub Release     if: exists == 'false'
```

So merging a `dev → main` release PR while `package.json` still names an
already-tagged version yields a green PR, a green workflow, **no tag, no
Cloud Build trigger, no deploy**, and nothing anywhere reporting a failure.
`package.json` is on `0.4.4` and `v0.4.4` is tagged — the trap is armed today.

`--for-release` now blocks on it. It queries origin even under `--no-fetch`
(a single ref lookup, the same query `release.yml` makes, so the two cannot
disagree) and `die`s rather than guessing when the query itself fails: a wrong
"not tagged" here greenlights a release that silently never ships.

```
BLOCK v0.4.4 is already tagged — release.yml would skip the tag, the Release,
      and the Cloud Build trigger and report success. Bump package.json
      (patch, at minimum) before cutting.
```

## The freeze spec

Docs only — `scripts/release/README.md`. Two findings worth recording:

1. **A `dev → main` PR merges the live tip of `dev`**, not the tip as of when
   the PR was opened. So the freeze has to open when the version bump lands on
   `dev`, not when the release PR opens — by then it is already too late.

2. **`update` ("Restrict updates") does not do the job.** It governs direct
   pushes, and both branches already block those by requiring a PR, so it adds
   nothing against the actual threat: a *merge*. The primitive that blocks
   merges is a required status check that never reports.

The unlock is asymmetric: `dev` frees at tag-cut (that is what makes "new push
= patch bump" true, and the back-sync needs `dev` writable), `main` stays held
until the deploy verifies — because when Cloud Build fails, the only correct
recovery is a patch bump through the normal train, which is exactly what v0.3.0
and v0.3.4 did as v0.3.1 and v0.3.5.

Enforcement is specced but **unverified** — it needs the ruleset created and one
throwaway PR to confirm the block lands. Detection (SHA-pinning the four refs at
freeze-open) is the layer to build first: no GitHub config written, nothing to
clean up after a crashed run.

## Verification

- `bash -n` clean; both output modes exercised; `--json` parses.
- Default mode still exits 0 on the current tree; `--for-release` exits 1 with
  the new BLOCK line.

_Opened by Claude on Adam's behalf_






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

