### PR TITLE
docs: single-source CLAUDE.md, stub AGENTS.md, unstale the Valkey issue refs [KAN-153]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ Pre-release tags like `v0.3.0-rc.1` create a GitHub Release without triggering p
 
 ## Non-obvious patterns
 
-- **Rate limiter** uses Valkey for distributed state; `server/valkey.ts` has open GH issues (#163, #162) for edge cases
+- **Rate limiter** uses Valkey for distributed state. GH #163/#162 (`server/valkey.ts` edge cases, KAN-16/KAN-17) were fixed and closed 2026-04-15 — new Valkey errors are Flask-side, not these
 - **AI model names** include `models/` prefix (e.g., `models/gemini-3.1-pro-preview`); filter by `generateContent` in `supported_generation_methods`
 - **CI auto-formats** — Prettier runs as a CI job and commits fixes on push; don't be alarmed by bot commits
 - **TypeScript is pinned exactly** (`6.0.3`) — Angular majors peer-require specific TS majors (Angular 22 needs TS >=6.0 <6.1), so TS and Angular move together, manually

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,7 @@ To verify the daemon is running during a session: `ps -ef | grep pm_daemon | gre
 
 ## Non-obvious patterns
 
-- **Rate limiter** uses Valkey for distributed state across Express replicas; `server/valkey.ts` has open GH issues (#163, #162) for edge cases under broken connections — see KAN-16, KAN-17
+- **Rate limiter** uses Valkey for distributed state across Express replicas. GH #163/#162 (Express client edge cases under broken connections, KAN-16/KAN-17) were **fixed and closed 2026-04-15** — do not attribute new Valkey errors to them. The live Valkey concerns are Flask-side and separate: IAM token-refresh auth failures (Backend #247) and the response-cache code lost in merge `07123c2` (KAN-151)
 - **AI model names** — entries from the model-list API carry the `models/` prefix (e.g., `models/gemini-3.1-pro-preview`; filter by `generateContent` in `supported_generation_methods`), while `Backend/config.py` `DEFAULT_MODEL` and the generation paths use bare IDs (`gemini-3.1-pro-preview`); both forms are in active use
 - **Backend submodule** — `Backend/` is a git submodule (remote: `adamtasteslikegood/tasteslikegood.com`, tracked branch `dev`) and accounts for roughly half of the project. Before starting any backend work or shipping a release, ALWAYS check the Backend repo for open PRs and recent commits that may not yet be reflected in the parent's submodule pointer. Quick checks:
   - `gh pr list -R adamtasteslikegood/tasteslikegood.com --state open` — open Backend PRs


### PR DESCRIPTION
`CLAUDE.md:294` and `AGENTS.md:262` have described GH #163/#162 as **open** for
three months. Both closed `COMPLETED` on **2026-04-15**, fixed by `042e8e5`
*"fix(valkey): catch shutdownValkey() failures to prevent reinitialization from
aborting"* — literally #163's title — which is on `origin/main` and in released
tags.

## Why this is worth a PR

The stale line caused a live misdiagnosis today. This morning's automated
health-check routine reported:

> `redis.exceptions.AuthenticationError` on flask-backend (106 occurrences over
> the 24h window, first seen 2026-07-20). This matches the already-tracked
> Valkey/rate-limiter auth issue referenced in the repo docs (GH #163/#162,
> KAN-16/KAN-17) … it's a known issue already tracked in the backlog.

It is not that issue. #163/#162 were **Express-side** (`server/valkey.ts`)
connection-teardown edge cases. The live error is **Flask-side** IAM
token-refresh auth, which is what Backend #247 addresses. The doc line turned a
new production error into a closed-backlog non-finding.

So the replacement text names what *is* live and where, rather than just
deleting the dead reference:

- Backend #247 — IAM token-refresh auth failures
- KAN-151 — the response-cache code lost in merge `07123c2`

Docs only; no code paths touched.

_Opened by Claude on Adam's behalf_



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

