### PR TITLE
chore(release): v0.4.5 — Backend pointer → ff92120, CHANGELOG [KAN-138]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-07-25
+
+Backend submodule pointer: `50cdbbb` → **`ff92120`** (Backend `main`, promoted in
+Backend [#249](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/249)).
+**No new Alembic migrations** — single head unchanged, so the
+`flask-backend-migrate` Cloud Run Job runs as a no-op.
+
 ### Fixed
+
+- **Valkey IAM token refresh no longer leaves a 30-minute dead window**
+  (KAN-16, Backend [#247](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/247)).
+  `_refresh_loop()` caught refresh failures and then slept the full 45-minute
+  interval, so a failure at t=45min let the token expire at t=60 with no further
+  attempt until t=90 — every Valkey cache write failing in between (258
+  `AuthenticationError`s over five days). It now retries with exponential
+  backoff (30s → 60s → 120s, capped at the normal interval, reset on success).
+  The client also forces RESP2, since redis-py 8.x defaults to RESP3 and rewrites
+  password-only credentials to `AUTH default <token>`; that is hardening rather
+  than the root cause, which remains unidentified — the underlying reason
+  refreshes fail is still open.
 
 - **SPA publish-state fix cluster** (KAN-149,
   [#3262](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3262),
@@ -32,6 +51,47 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     behind the recipe image: the action rows were non-wrapping flex rows
     inside a `minmax(0, 1fr)` grid column, so the extra link overflowed
     under the adjacent `position: relative` image block; the rows now wrap.
+
+- **An unavailable publish toggle now says why** (KAN-143,
+  [#3255](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3255)).
+  The reason was hidden in a `title` on a `disabled` button — unreachable by
+  keyboard and unreliable on hover — so the toggle just sat there doing nothing.
+  It now uses `aria-disabled` and raises a toast explaining the reason.
+
+- **Manual-entry notes stopped being overwritten** (KAN-144,
+  [#3256](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3256)).
+  Manual recipes wrote user notes into the shared `notes` field, which the
+  generated-recipe path also owns; they now use `personalNotes`, with existing
+  entries migrated on first edit.
+
+### Changed
+
+- **Shared recipe logic extracted into `RecipeViewBase`** (KAN-126,
+  [#3209](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3209)) —
+  Generator and RecipeDetail had drifted copies of the same publish, save, and
+  notes handlers.
+
+- **Release-train verification is now a script, not a memory exercise**
+  (KAN-138). `scripts/release/train-verify.sh` checks back-sync debt, promotion
+  debt, the submodule pointer against Backend `main`, Alembic head count, the
+  CHANGELOG section, and whether the version is already tagged — the last of
+  which catches a silent failure where `release.yml` skips the tag, the Release,
+  and the Cloud Build trigger while reporting success. `train-backsync.sh` opens
+  the `main → dev` back-sync PRs, and a scheduled workflow runs the verifier
+  daily.
+
+### Documentation
+
+- **Agent-instruction files single-sourced on `CLAUDE.md`** (KAN-153). The five
+  tracked files had drifted into contradicting each other and, in two cases,
+  into instructions that fail if followed: `GEMINI.md` told readers to
+  `pip install -r requirements.txt` (deleted 2026-07-18), and
+  `.github/copilot-instructions.md` directed agents to add `VITE_`-prefixed
+  variables for the client bundle, which an Angular CLI build never reads.
+  `AGENTS.md` is now a stub carrying only the non-Claude delta.
+
+- Architecture docs corrected to describe Valkey's real role and the actual
+  frontend/backend request flows (KAN-150).
 
 ## [0.4.4] - 2026-07-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@angular/build": "22.0.8",
         "@angular/cli": "22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
Step 4 of the release train. Pointer + version + CHANGELOG into `dev`, ahead of
the `dev → main` release PR.

## Pointer

```
50cdbbb891ae  →  ff921204d2fe   (Backend main, promotion merge from Backend #249)
```

Backend `main`'s **own SHA**, not a dev-side commit carrying main's content —
the rule adopted this sprint, so the deployed Backend commit is readable from
one ref. `train-verify.sh --for-release` enforces it.

## What reaches production

| | |
| --- | --- |
| Backend [#247](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/247) | Valkey IAM token-refresh retry — closes a 30-minute dead-cache window |
| Backend [#248](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/248) | delete legacy `agents.md` |
| Backend [#243](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/243) | GitHub Actions bump (CI only) |

Frontend side: the KAN-149 publish-state cluster, KAN-143/144 publish-toggle and
manual-notes fixes, the KAN-126 `RecipeViewBase` extraction, the KAN-138
release-train scripts, and the KAN-153 agent-doc hygiene.

## Migration safety

**No new Alembic migrations.** `git log origin/main..origin/dev -- migrations/versions/`
was empty at promotion time and the head count is unchanged at 1, so
`flask-backend-migrate` runs as a no-op and cannot abort the deploy mid-release.

## Verification

After this lands on `dev`, `train-verify.sh --for-release` should read clean —
it currently blocks only because it inspects `origin/dev:Backend`, which does
not yet carry this bump. Every other station is already green: back-sync debt 0
on both repos, one Alembic head, CHANGELOG section present and naming the pinned
SHA, and `v0.4.5` not yet tagged.

_Opened by Claude on Adam's behalf_



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

