### PR TITLE
fix(server): stop metering static subresources against the page rate limit [KAN-154]

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import type { Server } from 'node:http';
 import {
   applySecurityMiddleware,
   createApiLimiter,
+  createPageLimiter,
   createErrorHandler,
   createExpensiveOperationLimiter,
   createRequestLogger,
@@ -78,8 +79,11 @@ export const ready = (async () => {
   // Expensive AI operations: 20 req / hour per IP
   app.use('/api/generate', createExpensiveOperationLimiter(valkeyClient));
   app.use('/api/generate_image', createExpensiveOperationLimiter(valkeyClient));
-  // Static HTML shell (index.html) catch-all: reuse general API limiter
-  const staticPageLimiter = createApiLimiter(valkeyClient);
+  // Public HTML surface (SPA shell, SSR pages, standalone static pages).
+  // KAN-154: its own limiter, not a second createApiLimiter — that shared the
+  // `rl:api:` Valkey keyspace with the /api limiter above, and it metered
+  // static subresources as if they were navigations.
+  const staticPageLimiter = createPageLimiter(valkeyClient);
 
   // Apply security middleware (Helmet headers) and request logging before
   // the Flask proxy so that security headers and telemetry cover all
@@ -131,6 +135,23 @@ export const ready = (async () => {
     // page navigation re-fetches the favicon and counts toward
     // staticPageLimiter's 300 req / 15 min per-IP budget. Cache it for a day.
     res.sendFile(path.join(publicPath, 'favicon.svg'), { maxAge: '1d' });
+  });
+
+  // /apple-touch-icon.png + /apple-touch-icon-precomposed.png — iOS Safari
+  // requests both by convention on every page view, with no <link> needed.
+  // The repo ships no PNG icon, so they fell through to the SPA catch-all and
+  // came back as 13KB of index.html labelled image/png with max-age=0 — which
+  // iOS neither caches nor accepts, so it asked again on the next page. That
+  // was 60 requests and 44 of the 429s in the KAN-154 incident: the same
+  // defect #3164 fixed for /favicon.ico, on the paths it missed.
+  //
+  // 204 rather than 404: both stop the index.html leak, but a cacheable 204
+  // tells iOS not to re-probe, and 404s are re-requested. iOS falls back to a
+  // page screenshot for the home-screen icon, which is the pre-existing
+  // behaviour anyway.
+  app.get(/^\/apple-touch-icon(-precomposed)?\.png$/, staticPageLimiter, (_req, res) => {
+    res.set('Cache-Control', 'public, max-age=86400');
+    res.status(204).end();
   });
 
   // Flask SSR routes — individual public recipes, the browse index, and the

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -112,3 +112,34 @@ describe('SSR page proxying (guard against regressions)', () => {
     expect(await res.text()).toBe(STUB_HTML);
   });
 });
+
+/**
+ * KAN-154 (production incident 2026-07-25): iOS Safari requests both
+ * apple-touch-icon paths on every page view without any <link> tag. The repo
+ * ships no PNG icon, so they fell through to the SPA catch-all and returned
+ * 13KB of index.html with max-age=0 — uncacheable, so iOS re-asked on the next
+ * page. Those two paths accounted for 44 of the 84 HTTP 429s that locked two
+ * users out of the public site during ordinary browsing.
+ */
+describe('apple-touch-icon requests do not leak the SPA shell', () => {
+  for (const iconPath of ['/apple-touch-icon.png', '/apple-touch-icon-precomposed.png']) {
+    it(`answers ${iconPath} with a cacheable 204, not index.html`, async () => {
+      const res = await fetch(`${baseUrl}${iconPath}`);
+      expect(res.status).toBe(204);
+      // A 204 carries no body, so no content-type at all — which is precisely
+      // the fix: the old behaviour advertised text/html and shipped 13KB.
+      expect(res.headers.get('content-type')).toBeNull();
+      expect(res.headers.get('cache-control')).toContain('max-age=86400');
+      expect(await res.text()).toBe('');
+    });
+  }
+
+  // Guards the icon regex against over-matching: a normal SPA route must still
+  // reach the catch-all rather than being answered with an empty 204. (It 404s
+  // here only because this harness has no Angular build to serve index.html
+  // from; the point is that it is not 204.)
+  it('does not swallow ordinary SPA routes', async () => {
+    const res = await fetch(`${baseUrl}/kitchen`);
+    expect(res.status).not.toBe(204);
+  });
+});

--- a/server/security.ts
+++ b/server/security.ts
@@ -49,6 +49,34 @@ export function shouldSkipRateLimiting(req: Request): boolean {
   return req.path === '/health' || IMAGE_SERVING_RE.test(req.path);
 }
 
+// Subresources a browser requests on its own for every page view: Flask's SSR
+// stylesheets/scripts and the icon set that iOS probes by convention.
+const SUBRESOURCE_PREFIX_RE = /^\/(?:static\/|favicon\.|apple-touch-icon)/;
+
+// Angular's content-hashed build output (main-GTOZZOJH.js, styles-VFQLW5EH.css,
+// chunk-UORTPREJ.js). Anchored on the hash so an arbitrary /evil.js is not
+// exempt. Bundles also arrive under a route prefix (/recipe/main-….js) because
+// the SPA requests them relative to the current URL, so this matches on the
+// basename rather than the whole path.
+const HASHED_BUNDLE_RE = /(?:^|\/)[\w.-]+-[A-Z0-9]{8}\.(?:js|css)$/;
+
+/**
+ * Returns true for static subresources that must not count against the page
+ * rate limit.
+ *
+ * KAN-154: these were metered like real navigations, so a single SSR page view
+ * cost ~8 requests out of a 300 req / 15 min per-IP budget — roughly 37 page
+ * views per quarter hour, shared by every device behind one NAT'd address.
+ * Two people browsing recipes exhausted it and both got 429s. Rate limiting
+ * here exists to protect Flask and the AI endpoints; metering CSS bought
+ * nothing and cost the public surface.
+ *
+ * Exported for unit testing.
+ */
+export function isPageSubresource(req: Request): boolean {
+  return SUBRESOURCE_PREFIX_RE.test(req.path) || HASHED_BUNDLE_RE.test(req.path);
+}
+
 // Rate limiter for general API requests
 export const createApiLimiter = (
   valkeyClient: Redis | null = null,
@@ -65,6 +93,33 @@ export const createApiLimiter = (
     skip: shouldSkipRateLimiting,
     keyGenerator: (req) => getClientIp(req),
     store: buildRedisStore(valkeyClient, 'rl:api:'),
+  });
+};
+
+/**
+ * Rate limiter for the public HTML surface: the SPA shell, the Flask-rendered
+ * SSR pages, and the standalone static pages.
+ *
+ * KAN-154: kept separate from createApiLimiter for two reasons. It skips
+ * static subresources (see isPageSubresource), and it writes to its own Valkey
+ * keyspace — previously both limiters were built from createApiLimiter and so
+ * shared the `rl:api:` prefix, letting ordinary browsing exhaust the budget
+ * for /api/* on the same IP.
+ */
+export const createPageLimiter = (
+  valkeyClient: Redis | null = null,
+  windowMs: number = 15 * 60 * 1000,
+  max: number = 300
+) => {
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests, please try again later.' },
+    skip: isPageSubresource,
+    keyGenerator: (req) => getClientIp(req),
+    store: buildRedisStore(valkeyClient, 'rl:page:'),
   });
 };
 

--- a/server/server.test.ts
+++ b/server/server.test.ts
@@ -162,10 +162,21 @@ describe('isPageSubresource', () => {
 describe('createPageLimiter', () => {
   it('uses a Valkey keyspace separate from the API limiter', async () => {
     const { createPageLimiter, createApiLimiter } = await import('./security.js');
-    // Both must build without throwing and be distinct middleware; the
-    // prefixes they pass to RedisStore are asserted via the store mock below.
-    expect(typeof createPageLimiter(null)).toBe('function');
-    expect(createPageLimiter(null)).not.toBe(createApiLimiter(null));
+    const RedisStore = (await import('rate-limit-redis')).default as unknown as {
+      mockClear: () => void;
+      mock: { calls: Array<[{ prefix: string }]> };
+    };
+    RedisStore.mockClear();
+
+    const valkeyClient = { call: vi.fn() } as unknown as Parameters<typeof createPageLimiter>[0];
+    expect(typeof createPageLimiter(valkeyClient)).toBe('function');
+    expect(createPageLimiter(valkeyClient)).not.toBe(createApiLimiter(valkeyClient));
+
+    // KAN-154 regression guard: the page and API limiters must write to
+    // separate Valkey keyspaces, or ordinary browsing exhausts the /api budget.
+    const prefixes = RedisStore.mock.calls.map((call) => call[0].prefix);
+    expect(prefixes).toContain('rl:page:');
+    expect(prefixes).toContain('rl:api:');
   });
 });
 

--- a/server/server.test.ts
+++ b/server/server.test.ts
@@ -104,6 +104,71 @@ describe('shouldSkipRateLimiting', () => {
   });
 });
 
+// KAN-154: a browser fires these on its own for every page view — the SSR
+// stylesheets, the icon set, Angular's hashed bundles. Metering them made one
+// page view cost ~8 requests against a 300/15min per-IP budget, so two people
+// behind one NAT'd IP hit 429 during ordinary browsing. They are static bytes;
+// the limiter exists to protect Flask and the AI endpoints.
+describe('isPageSubresource', () => {
+  const subresources = [
+    '/static/css/tokens.css',
+    '/static/css/recipe-site.css',
+    '/static/js/public.js',
+    '/favicon.ico',
+    '/favicon.svg',
+    '/apple-touch-icon.png',
+    '/apple-touch-icon-precomposed.png',
+    '/styles-VFQLW5EH.css',
+    '/main-GTOZZOJH.js',
+    '/chunk-UORTPREJ.js',
+    // Angular emits bundle requests relative to the current route, so the
+    // same asset also arrives under a route prefix.
+    '/recipe/styles-VFQLW5EH.css',
+    '/recipe/chunk-CSQ5XSFZ.js',
+  ];
+
+  for (const path of subresources) {
+    it(`treats ${path} as a subresource`, async () => {
+      const { isPageSubresource } = await import('./security.js');
+      expect(isPageSubresource({ path } as Request)).toBe(true);
+    });
+  }
+
+  // Real navigations must keep counting — exempting these would remove the
+  // rate limit from the public surface entirely.
+  const pages = [
+    '/',
+    '/browse',
+    '/kitchen',
+    '/privacy-policy',
+    '/sitemap.xml',
+    '/r/vegan-baked-blooming-onion-with-zesty-dip',
+    '/recipe/db958616-04b4-495f-a67b-34b0760dc97a',
+  ];
+
+  for (const path of pages) {
+    it(`does not treat ${path} as a subresource`, async () => {
+      const { isPageSubresource } = await import('./security.js');
+      expect(isPageSubresource({ path } as Request)).toBe(false);
+    });
+  }
+
+  it('does not exempt an unhashed .js path (only content-hashed bundles)', async () => {
+    const { isPageSubresource } = await import('./security.js');
+    expect(isPageSubresource({ path: '/evil.js' } as Request)).toBe(false);
+  });
+});
+
+describe('createPageLimiter', () => {
+  it('uses a Valkey keyspace separate from the API limiter', async () => {
+    const { createPageLimiter, createApiLimiter } = await import('./security.js');
+    // Both must build without throwing and be distinct middleware; the
+    // prefixes they pass to RedisStore are asserted via the store mock below.
+    expect(typeof createPageLimiter(null)).toBe('function');
+    expect(createPageLimiter(null)).not.toBe(createApiLimiter(null));
+  });
+});
+
 describe('createExpensiveOperationLimiter', () => {
   it('should return a middleware function', async () => {
     const { createExpensiveOperationLimiter } = await import('./security.js');


### PR DESCRIPTION
Fixes the production incident where two users on one home connection both got
`{"error": "Too many requests, please try again later."}` on `/browse` and on
individual `/r/<slug>` pages during ordinary mobile browsing.

**84 × HTTP 429** on `express-frontend` since the v0.4.5 deploy, vs **0** in the
preceding 24 hours.

## Root cause

Every subresource a browser fetches on its own was metered as a navigation
against the same 300 req / 15 min per-IP bucket:

| Cause | Evidence |
|---|---|
| Flask SSR assets served `cache-control: no-cache` | 41 fetches of `tokens.css` in 45 min |
| `/apple-touch-icon(-precomposed)?.png` don't exist → SPA catch-all returns 13KB of `index.html` as `image/png`, `max-age=0` | 60 requests, **44 of the 429s** |
| Both limiters built from `createApiLimiter` → shared `rl:api:` Valkey keyspace | browsing drained the `/api` budget |

That put one page view at **~8 counted requests**. 300 ÷ 8 ≈ **37 page views per
quarter hour**, shared across every device behind one NAT'd public IP.

Confirmed live: `ratelimit-remaining` fell 222 → 221 → 220 across three
consecutive subresource fetches.

The icon half is the same defect [#3164](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3164) already fixed for `/favicon.ico` — see the comment at `server/index.ts:121`, which names this exact budget. It just missed the two apple-touch-icon paths.

## Changes

- **`isPageSubresource()`** exempts `/static/*`, `/favicon.*`, `/apple-touch-icon*`
  and Angular's content-hashed bundles. Anchored on the 8-char hash so an
  arbitrary `/evil.js` is *not* exempt, and matched on the basename because the
  SPA requests bundles relative to the current route (`/recipe/main-….js`).
- **`createPageLimiter()`** replaces the second `createApiLimiter`, with its own
  `rl:page:` prefix so public browsing can't exhaust `/api`.
- **`/apple-touch-icon*.png`** answers a cacheable 204 instead of the SPA shell.
  204 over 404 because 404s get re-probed; iOS falls back to a page screenshot,
  which was the effective behaviour anyway.

**A page view now costs 1 counted request instead of ~8.**

## Not a v0.4.5 regression

Valkey was already the rate-limit store before the deploy — `Rate limit store: Valkey`
at the previous revision's 10:43Z boot. The 0 → 84 jump is traffic-shaped: this was
the first two-person mobile pass over the public SSR surface. The release exposed
the defect; it did not introduce it.

## Tests

TDD — 21 assertions written and watched fail before the implementation existed.

- `server/server.test.ts` — `isPageSubresource` over 12 real subresource paths
  from the incident logs and 7 real navigations, plus the `/evil.js` over-match guard.
- `server/routes.test.ts` — boots the real Express app and asserts both
  apple-touch-icon paths return a cacheable 204 with no `content-type` (the old
  behaviour advertised `text/html` and shipped 13KB), and that ordinary SPA
  routes are not swallowed by the icon regex.

236/236 tests pass; `type-check` and `lint` clean.

## Follow-up (not in this PR)

Flask serves `/static/*` with `cache-control: no-cache`, so those three assets are
still re-fetched on every page view — they just no longer count against the limit.
Real cache headers belong in a Backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014psWRRrZLX2xKNyeTvXVPo









<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Something went wrong while reviewing this pull request.
[Troubleshoot code review errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

