### PR TITLE
fix(spa): anchor the app shell at the site root so deep-link reloads boot [KAN-159]

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Anchors every relative URL in this document at the site root. The Angular
+      builder injects its bundles as bare filenames (main-<hash>.js), which the
+      browser resolves against the *current directory* of the document URL. On
+      "/" and "/kitchen" that directory is "/" and the bundles load. On a
+      two-segment route it is not: reloading /recipe/<id> made the browser ask
+      for /recipe/main-<hash>.js, which no build artifact matches, so the
+      request fell through to the SPA catch-all and came back as 13KB of this
+      very file labelled text/html. Helmet's X-Content-Type-Options: nosniff
+      then (correctly) refuses to execute HTML as a script, Angular never
+      bootstraps, and the page is blank with no router — so in-page links and
+      the back button are dead too.
+
+      Keep this above any relative URL in the head: the element only governs
+      what follows it. Guarded by src/app-shell.test.ts.
+    -->
+    <base href="/" />
     <title>Tasteslikegood.org — VeganGenius Chef: AI-Powered Vegan Recipe Generator & Cookbook</title>
 
     <!-- SEO Meta Tags -->

--- a/src/app-shell.test.ts
+++ b/src/app-shell.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Guards on the app shell (repo-root index.html) that no other test covers.
+ *
+ * KAN-159 (production, 2026-07-25): the shell shipped without a <base> element.
+ * The Angular builder injects its bundles as bare filenames (main-<hash>.js),
+ * which a browser resolves against the current *directory* of the document URL
+ * — so a reload of /recipe/<id> requested /recipe/main-<hash>.js, missed every
+ * build artifact, fell through to the Express SPA catch-all, and came back as
+ * the shell itself labelled text/html. Helmet's nosniff then refused to execute
+ * it, Angular never bootstrapped, and the page was blank with a dead router.
+ *
+ * Asserted against the source file rather than dist/: the Vitest CI job does
+ * not run an Angular build, so a dist-based check would silently skip.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const shell = readFileSync(fileURLToPath(new URL('../index.html', import.meta.url)), 'utf8');
+
+// Prose in comments mentions the element by name; only real markup counts.
+const markup = shell.replace(/<!--[\s\S]*?-->/g, '');
+
+describe('app shell <base href>', () => {
+  it('declares exactly one base element, anchored at the site root', () => {
+    const baseTags = markup.match(/<base\b[^>]*>/g) ?? [];
+    expect(baseTags).toHaveLength(1);
+    expect(baseTags[0]).toMatch(/href="\/"/);
+  });
+
+  it('places it before anything that resolves a relative URL', () => {
+    const baseIndex = markup.search(/<base\b/);
+    expect(baseIndex).toBeGreaterThan(-1);
+
+    // Any src=/href= that is not absolute (https://, //host) and not already
+    // root-anchored would resolve against the document directory, so it has to
+    // sit after <base> to be anchored correctly.
+    const relativeRefRe = /(?:src|href)="(?!https?:\/\/|\/\/|\/|#|data:|mailto:)[^"]+"/g;
+    for (const match of markup.matchAll(relativeRefRe)) {
+      expect(match.index).toBeGreaterThan(baseIndex);
+    }
+  });
+
+  it('keeps the base element inside the head', () => {
+    const headEnd = markup.indexOf('</head>');
+    expect(headEnd).toBeGreaterThan(-1);
+
+    const baseIndex = markup.search(/<base\b/);
+    // Guard the vacuous pass: search() returns -1 when absent, which would
+    // otherwise satisfy "before </head>" without a base element existing.
+    expect(baseIndex).toBeGreaterThan(-1);
+    expect(baseIndex).toBeLessThan(headEnd);
+  });
+});

--- a/src/app-shell.test.ts
+++ b/src/app-shell.test.ts
@@ -18,37 +18,66 @@ import { fileURLToPath } from 'node:url';
 
 const shell = readFileSync(fileURLToPath(new URL('../index.html', import.meta.url)), 'utf8');
 
-// Prose in comments mentions the element by name; only real markup counts.
-const markup = shell.replace(/<!--[\s\S]*?-->/g, '');
+/**
+ * Single left-to-right scan of the shell. The comment alternative comes first
+ * and consumes whole comments, so markup *mentioned* inside one is never
+ * mistaken for the real thing — this file's own <base> prose would otherwise
+ * be counted. Likewise the <base …> alternative swallows its own href, so it
+ * cannot also register as a URL reference.
+ *
+ * Deliberately a tokenizer rather than "strip comments, then match": a
+ * `.replace()` that removes <!-- … --> has the shape of an HTML sanitizer
+ * without being one (CodeQL js/incomplete-multi-character-sanitization flags
+ * it, correctly — a single pass can leave <!-- behind on malformed input).
+ */
+const TOKEN_RE = /<!--[\s\S]*?-->|<base\b[^>]*>|<\/head>|(?:src|href)="([^"]*)"/g;
+
+type Token = { kind: 'base' | 'headEnd' | 'ref'; text: string; index: number; url: string };
+
+function scanShell(html: string): Token[] {
+  const tokens: Token[] = [];
+  for (const match of html.matchAll(TOKEN_RE)) {
+    const text = match[0];
+    const index = match.index ?? 0;
+    if (text.startsWith('<!--')) continue;
+    if (text.startsWith('<base')) tokens.push({ kind: 'base', text, index, url: '' });
+    else if (text.startsWith('</head')) tokens.push({ kind: 'headEnd', text, index, url: '' });
+    else tokens.push({ kind: 'ref', text, index, url: match[1] ?? '' });
+  }
+  return tokens;
+}
+
+const tokens = scanShell(shell);
+const baseTags = tokens.filter((t) => t.kind === 'base');
+
+// A URL that is neither absolute nor already root-anchored resolves against the
+// document's directory — the exact bug this file guards.
+const isDirectoryRelative = (url: string): boolean =>
+  !/^(?:https?:)?\/\//.test(url) && !url.startsWith('/') && !/^(?:#|data:|mailto:)/.test(url);
 
 describe('app shell <base href>', () => {
   it('declares exactly one base element, anchored at the site root', () => {
-    const baseTags = markup.match(/<base\b[^>]*>/g) ?? [];
     expect(baseTags).toHaveLength(1);
-    expect(baseTags[0]).toMatch(/href="\/"/);
+    expect(baseTags[0].text).toMatch(/href="\/"/);
   });
 
   it('places it before anything that resolves a relative URL', () => {
-    const baseIndex = markup.search(/<base\b/);
-    expect(baseIndex).toBeGreaterThan(-1);
+    expect(baseTags).toHaveLength(1);
+    const baseIndex = baseTags[0].index;
 
-    // Any src=/href= that is not absolute (https://, //host) and not already
-    // root-anchored would resolve against the document directory, so it has to
-    // sit after <base> to be anchored correctly.
-    const relativeRefRe = /(?:src|href)="(?!https?:\/\/|\/\/|\/|#|data:|mailto:)[^"]+"/g;
-    for (const match of markup.matchAll(relativeRefRe)) {
-      expect(match.index).toBeGreaterThan(baseIndex);
+    // Vacuous today — every URL in the source shell is absolute or
+    // root-anchored. It is a forward guard: adding a bare-filename asset above
+    // <base> would reintroduce the directory-relative resolution bug.
+    const relative = tokens.filter((t) => t.kind === 'ref' && isDirectoryRelative(t.url));
+    for (const ref of relative) {
+      expect(ref.index).toBeGreaterThan(baseIndex);
     }
   });
 
   it('keeps the base element inside the head', () => {
-    const headEnd = markup.indexOf('</head>');
-    expect(headEnd).toBeGreaterThan(-1);
-
-    const baseIndex = markup.search(/<base\b/);
-    // Guard the vacuous pass: search() returns -1 when absent, which would
-    // otherwise satisfy "before </head>" without a base element existing.
-    expect(baseIndex).toBeGreaterThan(-1);
-    expect(baseIndex).toBeLessThan(headEnd);
+    expect(baseTags).toHaveLength(1);
+    const headEnd = tokens.find((t) => t.kind === 'headEnd');
+    expect(headEnd).toBeDefined();
+    expect(baseTags[0].index).toBeLessThan(headEnd!.index);
   });
 });


### PR DESCRIPTION
## Problem

Reloading (or cold-loading) `/recipe/<id>` in production renders a **blank page with a dead router** — in-page links and the browser back button go nowhere. Reported during walkthrough round 2.

## Root cause

`index.html` ships no `<base>` element, and the Angular builder injects its bundles as bare filenames (`main-<hash>.js`). Browsers resolve those against the current *directory* of the document URL, so route depth decides whether the app boots:

| Document URL | Resolves to | Result |
|---|---|---|
| `/` | `/main-<hash>.js` | works |
| `/kitchen` | `/main-<hash>.js` | works |
| `/recipe/<id>` | `/recipe/main-<hash>.js` | **broken** |

The broken path matches no build artifact, so it falls through to the Express SPA catch-all and returns the shell. Verified against production:

```
/recipe/main-GTOZZOJH.js   200  text/html         13307 bytes
/main-GTOZZOJH.js          200  text/javascript  560638 bytes
```

Helmet's `X-Content-Type-Options: nosniff` then correctly refuses to execute HTML as a script — Angular never bootstraps.

This is the same class of defect as #3164 (`/favicon.ico`) and KAN-154 (`/apple-touch-icon*.png`): a request the app never anticipated, served the shell with the wrong content type.

Client-side navigation never re-requests the bundles, which is why the app only breaks on reload or a cold deep link — everything looks fine until you refresh.

Public SSR pages (`/r/<slug>`, `/browse`) are Flask-rendered and unaffected.

## Fix

One line: `<base href="/" />`, above any relative URL in `<head>`.

## Verification

- `src/app-shell.test.ts` — presence, ordering vs. relative URLs, and head placement. **All three assertions fail without the fix** (checked by stashing it), all three pass with it.
- Built `dist/index.html` contains exactly one `<base href="/">` once comments are stripped.
- Full suite green: 215 tests / 20 files. Lint, type-check, and Prettier clean.

## Note for review

The test asserts against the **source** `index.html`, not `dist/` — the Vitest CI job does not run an Angular build, so a dist-based check would silently skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014psWRRrZLX2xKNyeTvXVPo






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

