### PR TITLE
chore(seo): promote orange-chicken seitan recipe to canonical [KAN-158]

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
         <a href="/r/classic-vegan-chocolate-chip-cookies">Classic Vegan Chocolate Chip Cookies</a>
         <a href="/r/maple-smoked-tempeh-blt">Maple Smoked Tempeh BLT</a>
         <a href="/r/vegan-street-style-tofu-tacos">Vegan Street Style Tofu Tacos</a>
+        <a href="/r/vegan-orange-chicken-style-seitan-with-white-rice">Vegan Orange Chicken Style Seitan with White Rice</a>
       </nav>
     </noscript>
   </body>

--- a/scripts/seo/check_canonical_recipes.sh
+++ b/scripts/seo/check_canonical_recipes.sh
@@ -2,7 +2,7 @@
 # CI gate: validate canonical recipe list against index.html anchors.
 # Reads specs/canonical-recipes.json and checks:
 #   1. JSON is valid
-#   2. 3–7 recipes listed (Phase 0/1 bound)
+#   2. 3–8 recipes listed (Phase 0/1 bound)
 #   3. Every slug has a matching <a href="/r/{slug}"> in index.html <noscript>
 #   4. No anchors in index.html that aren't in the canonical list
 #
@@ -37,10 +37,13 @@ if ! jq empty "$CANONICAL_FILE" 2>/dev/null; then
   exit 1
 fi
 
-# 2. Count check (3–7)
+# 2. Count check (3–8). Raised from 7 for KAN-158: the upper bound exists to keep
+# the noscript nav a curated set rather than a dump of the whole catalog, so it
+# moves deliberately, one slug at a time, with Adam's approval on the PR. Keep
+# this in sync with maxItems in specs/canonical-recipes.schema.json.
 count=$(jq '.recipes | length' "$CANONICAL_FILE")
-if (( count < 3 || count > 7 )); then
-  echo "FAIL: canonical list has $count recipes (must be 3–7)"
+if (( count < 3 || count > 8 )); then
+  echo "FAIL: canonical list has $count recipes (must be 3–8)"
   errors=$((errors + 1))
 fi
 

--- a/specs/canonical-recipes.json
+++ b/specs/canonical-recipes.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./canonical-recipes.schema.json",
   "version": 1,
-  "updated": "2026-07-23",
+  "updated": "2026-07-25",
   "recipes": [
     {
       "slug": "classic-vegan-margherita-pizza",
@@ -85,6 +85,18 @@
         "breadth": 5,
         "search_intent": 4,
         "content_quality": 4
+      }
+    },
+    {
+      "slug": "vegan-orange-chicken-style-seitan-with-white-rice",
+      "title": "Vegan Orange Chicken Style Seitan with White Rice",
+      "rationale": "Asian/takeout-style breadth (new category for the set); proven search performance — ranks first for a partial-slug query with image and working link; complete content (17 ingredients, 10 steps, hero image)",
+      "added": "2026-07-25",
+      "score": {
+        "representativeness": 5,
+        "breadth": 5,
+        "search_intent": 5,
+        "content_quality": 5
       }
     }
   ]

--- a/specs/canonical-recipes.schema.json
+++ b/specs/canonical-recipes.schema.json
@@ -15,7 +15,7 @@
     "recipes": {
       "type": "array",
       "minItems": 3,
-      "maxItems": 7,
+      "maxItems": 8,
       "items": {
         "type": "object",
         "required": ["slug", "title", "rationale", "added", "score"],


### PR DESCRIPTION
## What

Adds `vegan-orange-chicken-style-seitan-with-white-rice` as the **eighth** canonical recipe:

- `specs/canonical-recipes.json` — new entry, `updated` bumped to 2026-07-25
- `index.html` — matching `<noscript>` anchor
- `specs/canonical-recipes.schema.json` — `maxItems` 7 → 8
- `scripts/seo/check_canonical_recipes.sh` — count bound 3–7 → 3–8

Adam's pick. It is the set's first Asian/takeout-style entry, and it already earns its keep: a partial-slug Google query returns it as the top result with its hero image intact.

## On raising the cap

The schema and the gate both capped the list at 7, so both move together — leaving either behind makes the two disagree about what is valid. The cap exists to keep the `<noscript>` nav a *curated* set rather than a dump of the catalog, so it moves deliberately, one slug at a time, with approval on the PR. A comment in the script records that and points at the schema as the thing to keep in sync.

## Verification

Checked against the gate's own criteria **before** adding the slug: HTTP 200, self-canonical, Recipe JSON-LD with 17 ingredients / 10 steps / image / yield 4.

```
$ scripts/seo/check_canonical_recipes.sh --live https://www.tasteslikegood.org
OK: .../r/classic-vegan-margherita-pizza → 200
... (8 slugs, all 200)
OK: 8 canonical recipes validated (JSON ↔ index.html consistent)
```

Scored 5/5/5/5 — the search-intent and content-quality scores are observed rather than estimated (live ranking; ingredient/step counts from the page's JSON-LD).

## Ships with

Backend PR #251 (`is_canonical = true` for this slug), which is the half that actually makes the page durable: the repository guards then reject unpublish, re-slug, and delete, so the public page survives the SPA copy being deleted later. **Merge #251 first**; a submodule pointer bump follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014psWRRrZLX2xKNyeTvXVPo



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

