### PR TITLE
ci(release): make the single-Alembic-head check a required gate [KAN-138]

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -107,6 +107,22 @@ jobs:
           PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest
 
+  # Branched Alembic heads make `flask db upgrade` refuse to run, which fails
+  # the flask-backend-migrate Cloud Run Job and aborts the deploy mid-release.
+  # This ran only on release-train.yml's manual dispatch and daily cron, so a
+  # pointer bump onto a two-head Backend could merge clean and surface hours
+  # later. It is a required check now: same script train-verify.sh station 4
+  # calls, so the gate and the release train cannot disagree.
+  alembic-heads:
+    name: Backend — single Alembic head
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Verify exactly one Alembic head
+        run: ./scripts/release/alembic-heads.sh --check
+
   # ── Docker ────────────────────────────────────────────────────────────────
   # Builds the production Express image (no push, no credentials). Catches
   # Dockerfile/lockfile breakage before a release tag hands it to Cloud Build
@@ -160,6 +176,7 @@ jobs:
       - frontend-build
       - frontend-test
       - backend-test
+      - alembic-heads
       - docker-build
       - changelog-check
       - canonical-recipes

--- a/scripts/release/alembic-heads.sh
+++ b/scripts/release/alembic-heads.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Alembic head count for the pinned Backend submodule.
+#
+# Why this is its own script rather than an inline block: two callers need the
+# same answer at different moments, and a second implementation would drift.
+#
+#   1. scripts/release/train-verify.sh — station 4, at release time.
+#   2. .github/workflows/pr-gate.yml   — the required status check, on every PR.
+#
+# (2) is the one that actually blocks a merge. Before it existed, the check ran
+# only on release-train.yml's manual dispatch and its daily 15:00 cron, so a PR
+# that moved the submodule pointer onto a branched-head Backend merged clean and
+# the drift surfaced hours later — or at deploy time, which is worse: two heads
+# make `flask db upgrade` refuse, the flask-backend-migrate Cloud Run Job fails,
+# and cloudbuild.yaml aborts the release mid-flight with the old revision left
+# serving.
+#
+# Heads are parsed out of the migration files rather than shelled out to
+# `flask db heads` on purpose: that keeps this runnable with nothing but
+# python3 — no Backend virtualenv, no uv sync, no DATABASE_URL, no app import.
+# A gate that needs a database to tell you the database migration is malformed
+# is a gate that gets skipped.
+#
+# Usage:
+#   alembic-heads.sh            prints the head count, or "error"; always exits 0
+#                               (train-verify.sh captures this and renders its
+#                               own BLOCK line, so it must not die on failure)
+#   alembic-heads.sh --check    prints a human verdict; exits 1 unless exactly
+#                               one head was found
+#
+set -uo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+versions_dir="${ALEMBIC_VERSIONS_DIR:-$repo_root/Backend/migrations/versions}"
+
+count_heads() {
+  VERSIONS_DIR="$versions_dir" python3 - <<'PY' 2>/dev/null || echo "error"
+import os, pathlib, re, sys
+
+# Heads = revisions nobody names as a parent, which is how alembic computes
+# them. The down_revision pattern deliberately allows a tuple to span lines: a
+# merge migration's `down_revision = ('a', 'b')` is one line as alembic writes
+# it, but a formatter will wrap a long one, and missing those parents would
+# over-count heads and block a release that is fine.
+versions = pathlib.Path(os.environ["VERSIONS_DIR"])
+if not versions.is_dir():
+    print("error")
+    sys.exit(0)
+
+revisions, parents = set(), set()
+for path in versions.glob("*.py"):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = re.search(r"^revision(?::\s*str)?\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
+    if match:
+        revisions.add(match.group(1))
+    for down in re.findall(
+        r"down_revision(?:\s*:[^=]*)?\s*=\s*(\([^)]*\)|\[[^\]]*\]|['\"][^'\"]*['\"])",
+        text,
+        re.S,
+    ):
+        parents.update(re.findall(r"['\"]([^'\"]+)['\"]", down))
+print(len(revisions - parents) if revisions else "error")
+PY
+}
+
+list_heads() {
+  VERSIONS_DIR="$versions_dir" python3 - <<'PY' 2>/dev/null || true
+import os, pathlib, re
+
+versions = pathlib.Path(os.environ["VERSIONS_DIR"])
+revisions, parents, where = set(), set(), {}
+for path in versions.glob("*.py"):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = re.search(r"^revision(?::\s*str)?\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
+    if match:
+        revisions.add(match.group(1))
+        where[match.group(1)] = path.name
+    for down in re.findall(
+        r"down_revision(?:\s*:[^=]*)?\s*=\s*(\([^)]*\)|\[[^\]]*\]|['\"][^'\"]*['\"])",
+        text,
+        re.S,
+    ):
+        parents.update(re.findall(r"['\"]([^'\"]+)['\"]", down))
+for head in sorted(revisions - parents):
+    print(f"  {head}  {where.get(head, '?')}")
+PY
+}
+
+heads=$(count_heads)
+
+if [ "${1:-}" != "--check" ]; then
+  echo "$heads"
+  exit 0
+fi
+
+case "$heads" in
+  1)
+    echo "OK: Alembic has exactly one head."
+    list_heads
+    exit 0
+    ;;
+  error)
+    echo "FAIL: could not determine Alembic heads."
+    echo "  Looked in: $versions_dir"
+    echo "  Is the Backend submodule checked out? (actions/checkout needs submodules: true)"
+    exit 1
+    ;;
+  *)
+    echo "FAIL: Alembic has $heads heads — 'flask db upgrade' will refuse to run."
+    echo
+    echo "Heads found:"
+    list_heads
+    echo
+    echo "This would fail the flask-backend-migrate Cloud Run Job and abort the"
+    echo "deploy, leaving the previous Flask revision serving. Unify them with:"
+    echo
+    echo "  cd Backend && uv run flask db merge -m 'merge <topic-a> and <topic-b> heads' <revA> <revB>"
+    echo
+    echo "Commit the resulting *_merge_*.py alongside this change."
+    exit 1
+    ;;
+esac

--- a/scripts/release/train-verify.sh
+++ b/scripts/release/train-verify.sh
@@ -15,6 +15,13 @@
 
 set -euo pipefail
 
+# Resolve to an absolute path before any `cd`, so the alembic-heads.sh sibling
+# call below still points at the right file when the script is invoked as
+# `./train-verify.sh` from within scripts/release/ (BASH_SOURCE stays literal,
+# and the `cd "$ROOT"` a few lines down would otherwise leave a bare `.` pointing
+# at the repo root and turn the check into a spurious "could not determine").
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
 BACKEND_REPO="adamtasteslikegood/tasteslikegood.com"
 COOKBOOK_REPO="adamtasteslikegood/tasteslikegoodtheangularsvegancookbook"
 
@@ -140,7 +147,7 @@ pointer_content_state="matches-backend-main-content"
 #    fails the migrate Job and aborts the deploy mid-release.
 #    Shared with pr-gate.yml's required "Backend — single Alembic head" job so
 #    the release train and the merge gate can never disagree about the answer.
-heads=$("$(dirname "${BASH_SOURCE[0]}")/alembic-heads.sh" 2>/dev/null || echo "error")
+heads=$("$SCRIPT_DIR/alembic-heads.sh" 2>/dev/null || echo "error")
 
 # 5. Version / CHANGELOG coherence. pr-gate enforces this on the release PR;
 #    checking it here means a bad bump is caught before the PR exists.

--- a/scripts/release/train-verify.sh
+++ b/scripts/release/train-verify.sh
@@ -138,32 +138,9 @@ pointer_content_state="matches-backend-main-content"
 
 # 4. Alembic heads. Two heads means `flask db upgrade` refuses to run, which
 #    fails the migrate Job and aborts the deploy mid-release.
-heads=$(
-  python3 - <<'PY' 2>/dev/null || echo "error"
-import pathlib, re
-
-# Heads = revisions nobody names as a parent, which is how alembic computes
-# them. Parsed rather than shelled out to `flask db heads` so this station
-# needs no Backend virtualenv. The down_revision pattern deliberately allows a
-# tuple to span lines: a merge migration's `down_revision = ('a', 'b')` is one
-# line as alembic writes it, but a formatter will wrap a long one, and missing
-# those parents would over-count heads and block a release that is fine.
-versions = pathlib.Path("Backend/migrations/versions")
-revisions, parents = set(), set()
-for path in versions.glob("*.py"):
-    text = path.read_text(encoding="utf-8", errors="replace")
-    match = re.search(r"^revision(?::\s*str)?\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
-    if match:
-        revisions.add(match.group(1))
-    for down in re.findall(
-        r"down_revision(?:\s*:[^=]*)?\s*=\s*(\([^)]*\)|\[[^\]]*\]|['\"][^'\"]*['\"])",
-        text,
-        re.S,
-    ):
-        parents.update(re.findall(r"['\"]([^'\"]+)['\"]", down))
-print(len(revisions - parents) if revisions else "error")
-PY
-)
+#    Shared with pr-gate.yml's required "Backend — single Alembic head" job so
+#    the release train and the merge gate can never disagree about the answer.
+heads=$("$(dirname "${BASH_SOURCE[0]}")/alembic-heads.sh" 2>/dev/null || echo "error")
 
 # 5. Version / CHANGELOG coherence. pr-gate enforces this on the release PR;
 #    checking it here means a bad bump is caught before the PR exists.


### PR DESCRIPTION
## The gap

The single-Alembic-head check **already existed** and was already correct — it is station 4 of `scripts/release/train-verify.sh`. Nothing was wrong with the logic.

What was missing: **nothing ran it before a merge.**

| runs it | trigger | blocks a merge? |
|---|---|---|
| `release-train.yml` → `train-verify.sh` | `workflow_dispatch` + daily 15:00 cron | no |
| `pr-gate.yml` (the required check) | every PR | **had no Alembic check at all** |

So a PR bumping the `Backend` submodule pointer onto a branched-head Backend passed `Gate — all checks passed`, merged clean, and the drift surfaced on the next cron run — or at deploy time, which is worse: two heads make `flask db upgrade` refuse, which fails the `flask-backend-migrate` Cloud Run Job and aborts `cloudbuild.yaml` mid-release with the previous Flask revision left serving.

## Changes

- **`scripts/release/alembic-heads.sh`** (new) — the head-counting logic lifted verbatim out of `train-verify.sh`, so there is one implementation instead of two that drift.
  - bare mode → prints the count (or `error`), always exits 0. That is the contract `train-verify.sh`'s `$(...)` capture already relied on, so its BLOCK line still renders.
  - `--check` → prints a verdict, names every head with its file, exits 1 unless there is exactly one.
  - Still pure `python3` parsing. No Backend virtualenv, no `uv sync`, no `DATABASE_URL`, no app import. A gate that needs a database to tell you the database migration is malformed is a gate that gets skipped.
- **`train-verify.sh`** — calls the shared script instead of carrying its own copy.
- **`pr-gate.yml`** — new `Backend — single Alembic head` job, listed in `gate.needs` so it is part of the required `Gate — all checks passed` status check.

## Verification — including that it can fail

A gate that only ever passes is decoration, so the negative cases were run explicitly:

| case | result |
|---|---|
| real tree | `OK: Alembic has exactly one head.` → `e4a7b2d9c5f1`, exit 0 |
| synthetic 2nd head | `FAIL: Alembic has 2 heads` — names both heads + files, prints the `flask db merge` command, **exit 1** |
| missing submodule | `FAIL: could not determine Alembic heads` — points at `submodules: true`, **exit 1** |
| `train-verify.sh --no-fetch` | still reports `alembic heads 1`, exit 0, no blocking drift |

Also: `pr-gate.yml` parses as YAML, `alembic-heads` appears in both `jobs` and `gate.needs`, Prettier clean, `bash -n` clean on both scripts.

## Note on branch protection

This adds a job to the `gate` aggregate, which is already the required check — so it takes effect without touching branch-protection settings. No ruleset change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqwHC5WeVAtgosDb469Foy






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

