### PR TITLE
release: v0.4.6 — deep-link reload fix, rate-limit incident fix, canonical #8, Alembic gate [KAN-138]

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -107,6 +107,22 @@ jobs:
           PUBSUB_EMULATOR_HOST: localhost:8085
         run: uv run pytest
 
+  # Branched Alembic heads make `flask db upgrade` refuse to run, which fails
+  # the flask-backend-migrate Cloud Run Job and aborts the deploy mid-release.
+  # This ran only on release-train.yml's manual dispatch and daily cron, so a
+  # pointer bump onto a two-head Backend could merge clean and surface hours
+  # later. It is a required check now: same script train-verify.sh station 4
+  # calls, so the gate and the release train cannot disagree.
+  alembic-heads:
+    name: Backend — single Alembic head
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Verify exactly one Alembic head
+        run: ./scripts/release/alembic-heads.sh --check
+
   # ── Docker ────────────────────────────────────────────────────────────────
   # Builds the production Express image (no push, no credentials). Catches
   # Dockerfile/lockfile breakage before a release tag hands it to Cloud Build
@@ -160,6 +176,7 @@ jobs:
       - frontend-build
       - frontend-test
       - backend-test
+      - alembic-heads
       - docker-build
       - changelog-check
       - canonical-recipes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,74 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-07-25
+
+Backend submodule pointer: `ff92120` → **`38736da`** (Backend `main`, promoted in
+Backend [#252](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/252)).
+**One new Alembic migration** (`e4a7b2d9c5f1`, chaining onto `d1e5a9c3f7b2`) —
+unlike v0.4.5, the `flask-backend-migrate` Cloud Run Job does real work this
+release. Head count after it applies: exactly 1.
+
+Two production defects reported during walkthrough round 2, both of which made
+ordinary browsing fail rather than any exotic path.
+
+### Fixed
+
+- **Reloading a recipe deep link no longer renders a blank page with a dead
+  router** (KAN-159,
+  [#3282](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3282)).
+  `index.html` shipped no `<base>` element, and the Angular builder injects its
+  bundles as bare filenames (`main-<hash>.js`). Browsers resolve those against
+  the document's current _directory_, so route depth decided whether the app
+  booted at all: `/` and `/kitchen` resolved `/main-<hash>.js` and worked, while
+  `/recipe/<id>` asked for `/recipe/main-<hash>.js`, matched no build artifact,
+  fell through to the Express SPA catch-all, and got 13KB of `index.html` back
+  labelled `text/html`. Adding `<base href="/">` anchors bundle resolution at the
+  site root regardless of route depth. A new `src/app-shell.test.ts` guards the
+  shell by tokenizing it left-to-right, so markup merely _mentioned_ inside a
+  comment can't satisfy the check.
+
+- **Ordinary mobile browsing no longer exhausts the per-IP rate limit**
+  (KAN-154,
+  [#3281](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3281)).
+  Two users sharing one home connection both hit
+  `{"error": "Too many requests, please try again later."}` on `/browse` and on
+  individual `/r/<slug>` pages — 84 × HTTP 429 on `express-frontend` after the
+  v0.4.5 deploy, against 0 in the preceding 24 hours. Every subresource the
+  browser fetched on its own was metered as a navigation against the same
+  300 req / 15 min bucket, putting one page view at roughly 8 counted requests
+  (≈37 page views per 15 minutes before lockout). Three causes, all fixed:
+  static subresources are now exempt from the page limiter; `/apple-touch-icon`
+  and `/apple-touch-icon-precomposed.png` are served explicitly instead of
+  falling through to the catch-all as 13KB of HTML labelled `image/png` (that
+  path alone was 44 of the 429s); and the page limiter now owns an `rl:page:`
+  Valkey keyspace instead of sharing `rl:api:`, so browsing can no longer drain
+  the `/api` budget.
+
+### Added
+
+- **Eighth canonical recipe: orange-chicken-style seitan** (KAN-158,
+  [#3283](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3283)
+  - Backend [#251](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/251)).
+    The set's first Asian/takeout-style entry, already ranking top for a
+    partial-slug query with its hero image intact. `is_canonical = true` makes the
+    public page durable: `_guard_canonical` refuses unpublish, re-slug, and delete,
+    so an indexed `/r/` page can't later turn into a 404. Schema `maxItems` and the
+    SEO gate's count bound both move 7 → 8 together, so they can't disagree about
+    what is valid.
+
+- **The single-Alembic-head check is now a required merge gate** (KAN-138,
+  [#3285](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3285)).
+  The check already existed and was already correct — station 4 of
+  `scripts/release/train-verify.sh` — but nothing ran it before a merge:
+  `release-train.yml` fires only on manual dispatch and a daily cron, and
+  `pr-gate.yml` had no Alembic check at all. A pointer bump onto a branched-head
+  Backend therefore merged clean and surfaced on the next cron, or at deploy,
+  where two heads make `flask db upgrade` refuse, fail the migrate Job, and abort
+  the release with the previous Flask revision left serving. The logic moved to
+  `scripts/release/alembic-heads.sh` (one implementation, shared by both callers)
+  and `pr-gate.yml` gained `Backend — single Alembic head` in `gate.needs`.
+
 ## [0.4.5] - 2026-07-25
 
 Backend submodule pointer: `50cdbbb` → **`ff92120`** (Backend `main`, promoted in

--- a/index.html
+++ b/index.html
@@ -3,6 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Anchors every relative URL in this document at the site root. The Angular
+      builder injects its bundles as bare filenames (main-<hash>.js), which the
+      browser resolves against the *current directory* of the document URL. On
+      "/" and "/kitchen" that directory is "/" and the bundles load. On a
+      two-segment route it is not: reloading /recipe/<id> made the browser ask
+      for /recipe/main-<hash>.js, which no build artifact matches, so the
+      request fell through to the SPA catch-all and came back as 13KB of this
+      very file labelled text/html. Helmet's X-Content-Type-Options: nosniff
+      then (correctly) refuses to execute HTML as a script, Angular never
+      bootstraps, and the page is blank with no router — so in-page links and
+      the back button are dead too.
+
+      Keep this above any relative URL in the head: the element only governs
+      what follows it. Guarded by src/app-shell.test.ts.
+    -->
+    <base href="/" />
     <title>Tasteslikegood.org — VeganGenius Chef: AI-Powered Vegan Recipe Generator & Cookbook</title>
 
     <!-- SEO Meta Tags -->

--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
         <a href="/r/classic-vegan-chocolate-chip-cookies">Classic Vegan Chocolate Chip Cookies</a>
         <a href="/r/maple-smoked-tempeh-blt">Maple Smoked Tempeh BLT</a>
         <a href="/r/vegan-street-style-tofu-tacos">Vegan Street Style Tofu Tacos</a>
+        <a href="/r/vegan-orange-chicken-style-seitan-with-white-rice">Vegan Orange Chicken Style Seitan with White Rice</a>
       </nav>
     </noscript>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "scripts": {
     "dev": "ng serve",

--- a/scripts/release/alembic-heads.sh
+++ b/scripts/release/alembic-heads.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Alembic head count for the pinned Backend submodule.
+#
+# Why this is its own script rather than an inline block: two callers need the
+# same answer at different moments, and a second implementation would drift.
+#
+#   1. scripts/release/train-verify.sh — station 4, at release time.
+#   2. .github/workflows/pr-gate.yml   — the required status check, on every PR.
+#
+# (2) is the one that actually blocks a merge. Before it existed, the check ran
+# only on release-train.yml's manual dispatch and its daily 15:00 cron, so a PR
+# that moved the submodule pointer onto a branched-head Backend merged clean and
+# the drift surfaced hours later — or at deploy time, which is worse: two heads
+# make `flask db upgrade` refuse, the flask-backend-migrate Cloud Run Job fails,
+# and cloudbuild.yaml aborts the release mid-flight with the old revision left
+# serving.
+#
+# Heads are parsed out of the migration files rather than shelled out to
+# `flask db heads` on purpose: that keeps this runnable with nothing but
+# python3 — no Backend virtualenv, no uv sync, no DATABASE_URL, no app import.
+# A gate that needs a database to tell you the database migration is malformed
+# is a gate that gets skipped.
+#
+# Usage:
+#   alembic-heads.sh            prints the head count, or "error"; always exits 0
+#                               (train-verify.sh captures this and renders its
+#                               own BLOCK line, so it must not die on failure)
+#   alembic-heads.sh --check    prints a human verdict; exits 1 unless exactly
+#                               one head was found
+#
+set -uo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+versions_dir="${ALEMBIC_VERSIONS_DIR:-$repo_root/Backend/migrations/versions}"
+
+count_heads() {
+  VERSIONS_DIR="$versions_dir" python3 - <<'PY' 2>/dev/null || echo "error"
+import os, pathlib, re, sys
+
+# Heads = revisions nobody names as a parent, which is how alembic computes
+# them. The down_revision pattern deliberately allows a tuple to span lines: a
+# merge migration's `down_revision = ('a', 'b')` is one line as alembic writes
+# it, but a formatter will wrap a long one, and missing those parents would
+# over-count heads and block a release that is fine.
+versions = pathlib.Path(os.environ["VERSIONS_DIR"])
+if not versions.is_dir():
+    print("error")
+    sys.exit(0)
+
+revisions, parents = set(), set()
+for path in versions.glob("*.py"):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = re.search(r"^revision(?::\s*str)?\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
+    if match:
+        revisions.add(match.group(1))
+    for down in re.findall(
+        r"down_revision(?:\s*:[^=]*)?\s*=\s*(\([^)]*\)|\[[^\]]*\]|['\"][^'\"]*['\"])",
+        text,
+        re.S,
+    ):
+        parents.update(re.findall(r"['\"]([^'\"]+)['\"]", down))
+print(len(revisions - parents) if revisions else "error")
+PY
+}
+
+list_heads() {
+  VERSIONS_DIR="$versions_dir" python3 - <<'PY' 2>/dev/null || true
+import os, pathlib, re
+
+versions = pathlib.Path(os.environ["VERSIONS_DIR"])
+revisions, parents, where = set(), set(), {}
+for path in versions.glob("*.py"):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = re.search(r"^revision(?::\s*str)?\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
+    if match:
+        revisions.add(match.group(1))
+        where[match.group(1)] = path.name
+    for down in re.findall(
+        r"down_revision(?:\s*:[^=]*)?\s*=\s*(\([^)]*\)|\[[^\]]*\]|['\"][^'\"]*['\"])",
+        text,
+        re.S,
+    ):
+        parents.update(re.findall(r"['\"]([^'\"]+)['\"]", down))
+for head in sorted(revisions - parents):
+    print(f"  {head}  {where.get(head, '?')}")
+PY
+}
+
+heads=$(count_heads)
+
+if [ "${1:-}" != "--check" ]; then
+  echo "$heads"
+  exit 0
+fi
+
+case "$heads" in
+  1)
+    echo "OK: Alembic has exactly one head."
+    list_heads
+    exit 0
+    ;;
+  error)
+    echo "FAIL: could not determine Alembic heads."
+    echo "  Looked in: $versions_dir"
+    echo "  Is the Backend submodule checked out? (actions/checkout needs submodules: true)"
+    exit 1
+    ;;
+  *)
+    echo "FAIL: Alembic has $heads heads — 'flask db upgrade' will refuse to run."
+    echo
+    echo "Heads found:"
+    list_heads
+    echo
+    echo "This would fail the flask-backend-migrate Cloud Run Job and abort the"
+    echo "deploy, leaving the previous Flask revision serving. Unify them with:"
+    echo
+    echo "  cd Backend && uv run flask db merge -m 'merge <topic-a> and <topic-b> heads' <revA> <revB>"
+    echo
+    echo "Commit the resulting *_merge_*.py alongside this change."
+    exit 1
+    ;;
+esac

--- a/scripts/release/train-verify.sh
+++ b/scripts/release/train-verify.sh
@@ -15,6 +15,13 @@
 
 set -euo pipefail
 
+# Resolve to an absolute path before any `cd`, so the alembic-heads.sh sibling
+# call below still points at the right file when the script is invoked as
+# `./train-verify.sh` from within scripts/release/ (BASH_SOURCE stays literal,
+# and the `cd "$ROOT"` a few lines down would otherwise leave a bare `.` pointing
+# at the repo root and turn the check into a spurious "could not determine").
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
 BACKEND_REPO="adamtasteslikegood/tasteslikegood.com"
 COOKBOOK_REPO="adamtasteslikegood/tasteslikegoodtheangularsvegancookbook"
 
@@ -138,32 +145,9 @@ pointer_content_state="matches-backend-main-content"
 
 # 4. Alembic heads. Two heads means `flask db upgrade` refuses to run, which
 #    fails the migrate Job and aborts the deploy mid-release.
-heads=$(
-  python3 - <<'PY' 2>/dev/null || echo "error"
-import pathlib, re
-
-# Heads = revisions nobody names as a parent, which is how alembic computes
-# them. Parsed rather than shelled out to `flask db heads` so this station
-# needs no Backend virtualenv. The down_revision pattern deliberately allows a
-# tuple to span lines: a merge migration's `down_revision = ('a', 'b')` is one
-# line as alembic writes it, but a formatter will wrap a long one, and missing
-# those parents would over-count heads and block a release that is fine.
-versions = pathlib.Path("Backend/migrations/versions")
-revisions, parents = set(), set()
-for path in versions.glob("*.py"):
-    text = path.read_text(encoding="utf-8", errors="replace")
-    match = re.search(r"^revision(?::\s*str)?\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
-    if match:
-        revisions.add(match.group(1))
-    for down in re.findall(
-        r"down_revision(?:\s*:[^=]*)?\s*=\s*(\([^)]*\)|\[[^\]]*\]|['\"][^'\"]*['\"])",
-        text,
-        re.S,
-    ):
-        parents.update(re.findall(r"['\"]([^'\"]+)['\"]", down))
-print(len(revisions - parents) if revisions else "error")
-PY
-)
+#    Shared with pr-gate.yml's required "Backend — single Alembic head" job so
+#    the release train and the merge gate can never disagree about the answer.
+heads=$("$SCRIPT_DIR/alembic-heads.sh" 2>/dev/null || echo "error")
 
 # 5. Version / CHANGELOG coherence. pr-gate enforces this on the release PR;
 #    checking it here means a bad bump is caught before the PR exists.

--- a/scripts/seo/check_canonical_recipes.sh
+++ b/scripts/seo/check_canonical_recipes.sh
@@ -2,7 +2,7 @@
 # CI gate: validate canonical recipe list against index.html anchors.
 # Reads specs/canonical-recipes.json and checks:
 #   1. JSON is valid
-#   2. 3–7 recipes listed (Phase 0/1 bound)
+#   2. 3–8 recipes listed (Phase 0/1 bound)
 #   3. Every slug has a matching <a href="/r/{slug}"> in index.html <noscript>
 #   4. No anchors in index.html that aren't in the canonical list
 #
@@ -37,10 +37,13 @@ if ! jq empty "$CANONICAL_FILE" 2>/dev/null; then
   exit 1
 fi
 
-# 2. Count check (3–7)
+# 2. Count check (3–8). Raised from 7 for KAN-158: the upper bound exists to keep
+# the noscript nav a curated set rather than a dump of the whole catalog, so it
+# moves deliberately, one slug at a time, with Adam's approval on the PR. Keep
+# this in sync with maxItems in specs/canonical-recipes.schema.json.
 count=$(jq '.recipes | length' "$CANONICAL_FILE")
-if (( count < 3 || count > 7 )); then
-  echo "FAIL: canonical list has $count recipes (must be 3–7)"
+if (( count < 3 || count > 8 )); then
+  echo "FAIL: canonical list has $count recipes (must be 3–8)"
   errors=$((errors + 1))
 fi
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import type { Server } from 'node:http';
 import {
   applySecurityMiddleware,
   createApiLimiter,
+  createPageLimiter,
   createErrorHandler,
   createExpensiveOperationLimiter,
   createRequestLogger,
@@ -78,8 +79,11 @@ export const ready = (async () => {
   // Expensive AI operations: 20 req / hour per IP
   app.use('/api/generate', createExpensiveOperationLimiter(valkeyClient));
   app.use('/api/generate_image', createExpensiveOperationLimiter(valkeyClient));
-  // Static HTML shell (index.html) catch-all: reuse general API limiter
-  const staticPageLimiter = createApiLimiter(valkeyClient);
+  // Public HTML surface (SPA shell, SSR pages, standalone static pages).
+  // KAN-154: its own limiter, not a second createApiLimiter — that shared the
+  // `rl:api:` Valkey keyspace with the /api limiter above, and it metered
+  // static subresources as if they were navigations.
+  const staticPageLimiter = createPageLimiter(valkeyClient);
 
   // Apply security middleware (Helmet headers) and request logging before
   // the Flask proxy so that security headers and telemetry cover all
@@ -131,6 +135,23 @@ export const ready = (async () => {
     // page navigation re-fetches the favicon and counts toward
     // staticPageLimiter's 300 req / 15 min per-IP budget. Cache it for a day.
     res.sendFile(path.join(publicPath, 'favicon.svg'), { maxAge: '1d' });
+  });
+
+  // /apple-touch-icon.png + /apple-touch-icon-precomposed.png — iOS Safari
+  // requests both by convention on every page view, with no <link> needed.
+  // The repo ships no PNG icon, so they fell through to the SPA catch-all and
+  // came back as 13KB of index.html labelled image/png with max-age=0 — which
+  // iOS neither caches nor accepts, so it asked again on the next page. That
+  // was 60 requests and 44 of the 429s in the KAN-154 incident: the same
+  // defect #3164 fixed for /favicon.ico, on the paths it missed.
+  //
+  // 204 rather than 404: both stop the index.html leak, but a cacheable 204
+  // tells iOS not to re-probe, and 404s are re-requested. iOS falls back to a
+  // page screenshot for the home-screen icon, which is the pre-existing
+  // behaviour anyway.
+  app.get(/^\/apple-touch-icon(-precomposed)?\.png$/, staticPageLimiter, (_req, res) => {
+    res.set('Cache-Control', 'public, max-age=86400');
+    res.status(204).end();
   });
 
   // Flask SSR routes — individual public recipes, the browse index, and the

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -112,3 +112,34 @@ describe('SSR page proxying (guard against regressions)', () => {
     expect(await res.text()).toBe(STUB_HTML);
   });
 });
+
+/**
+ * KAN-154 (production incident 2026-07-25): iOS Safari requests both
+ * apple-touch-icon paths on every page view without any <link> tag. The repo
+ * ships no PNG icon, so they fell through to the SPA catch-all and returned
+ * 13KB of index.html with max-age=0 — uncacheable, so iOS re-asked on the next
+ * page. Those two paths accounted for 44 of the 84 HTTP 429s that locked two
+ * users out of the public site during ordinary browsing.
+ */
+describe('apple-touch-icon requests do not leak the SPA shell', () => {
+  for (const iconPath of ['/apple-touch-icon.png', '/apple-touch-icon-precomposed.png']) {
+    it(`answers ${iconPath} with a cacheable 204, not index.html`, async () => {
+      const res = await fetch(`${baseUrl}${iconPath}`);
+      expect(res.status).toBe(204);
+      // A 204 carries no body, so no content-type at all — which is precisely
+      // the fix: the old behaviour advertised text/html and shipped 13KB.
+      expect(res.headers.get('content-type')).toBeNull();
+      expect(res.headers.get('cache-control')).toContain('max-age=86400');
+      expect(await res.text()).toBe('');
+    });
+  }
+
+  // Guards the icon regex against over-matching: a normal SPA route must still
+  // reach the catch-all rather than being answered with an empty 204. (It 404s
+  // here only because this harness has no Angular build to serve index.html
+  // from; the point is that it is not 204.)
+  it('does not swallow ordinary SPA routes', async () => {
+    const res = await fetch(`${baseUrl}/kitchen`);
+    expect(res.status).not.toBe(204);
+  });
+});

--- a/server/security.ts
+++ b/server/security.ts
@@ -49,6 +49,34 @@ export function shouldSkipRateLimiting(req: Request): boolean {
   return req.path === '/health' || IMAGE_SERVING_RE.test(req.path);
 }
 
+// Subresources a browser requests on its own for every page view: Flask's SSR
+// stylesheets/scripts and the icon set that iOS probes by convention.
+const SUBRESOURCE_PREFIX_RE = /^\/(?:static\/|favicon\.|apple-touch-icon)/;
+
+// Angular's content-hashed build output (main-GTOZZOJH.js, styles-VFQLW5EH.css,
+// chunk-UORTPREJ.js). Anchored on the hash so an arbitrary /evil.js is not
+// exempt. Bundles also arrive under a route prefix (/recipe/main-….js) because
+// the SPA requests them relative to the current URL, so this matches on the
+// basename rather than the whole path.
+const HASHED_BUNDLE_RE = /(?:^|\/)[\w.-]+-[A-Z0-9]{8}\.(?:js|css)$/;
+
+/**
+ * Returns true for static subresources that must not count against the page
+ * rate limit.
+ *
+ * KAN-154: these were metered like real navigations, so a single SSR page view
+ * cost ~8 requests out of a 300 req / 15 min per-IP budget — roughly 37 page
+ * views per quarter hour, shared by every device behind one NAT'd address.
+ * Two people browsing recipes exhausted it and both got 429s. Rate limiting
+ * here exists to protect Flask and the AI endpoints; metering CSS bought
+ * nothing and cost the public surface.
+ *
+ * Exported for unit testing.
+ */
+export function isPageSubresource(req: Request): boolean {
+  return SUBRESOURCE_PREFIX_RE.test(req.path) || HASHED_BUNDLE_RE.test(req.path);
+}
+
 // Rate limiter for general API requests
 export const createApiLimiter = (
   valkeyClient: Redis | null = null,
@@ -65,6 +93,33 @@ export const createApiLimiter = (
     skip: shouldSkipRateLimiting,
     keyGenerator: (req) => getClientIp(req),
     store: buildRedisStore(valkeyClient, 'rl:api:'),
+  });
+};
+
+/**
+ * Rate limiter for the public HTML surface: the SPA shell, the Flask-rendered
+ * SSR pages, and the standalone static pages.
+ *
+ * KAN-154: kept separate from createApiLimiter for two reasons. It skips
+ * static subresources (see isPageSubresource), and it writes to its own Valkey
+ * keyspace — previously both limiters were built from createApiLimiter and so
+ * shared the `rl:api:` prefix, letting ordinary browsing exhaust the budget
+ * for /api/* on the same IP.
+ */
+export const createPageLimiter = (
+  valkeyClient: Redis | null = null,
+  windowMs: number = 15 * 60 * 1000,
+  max: number = 300
+) => {
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests, please try again later.' },
+    skip: isPageSubresource,
+    keyGenerator: (req) => getClientIp(req),
+    store: buildRedisStore(valkeyClient, 'rl:page:'),
   });
 };
 

--- a/server/server.test.ts
+++ b/server/server.test.ts
@@ -104,6 +104,82 @@ describe('shouldSkipRateLimiting', () => {
   });
 });
 
+// KAN-154: a browser fires these on its own for every page view — the SSR
+// stylesheets, the icon set, Angular's hashed bundles. Metering them made one
+// page view cost ~8 requests against a 300/15min per-IP budget, so two people
+// behind one NAT'd IP hit 429 during ordinary browsing. They are static bytes;
+// the limiter exists to protect Flask and the AI endpoints.
+describe('isPageSubresource', () => {
+  const subresources = [
+    '/static/css/tokens.css',
+    '/static/css/recipe-site.css',
+    '/static/js/public.js',
+    '/favicon.ico',
+    '/favicon.svg',
+    '/apple-touch-icon.png',
+    '/apple-touch-icon-precomposed.png',
+    '/styles-VFQLW5EH.css',
+    '/main-GTOZZOJH.js',
+    '/chunk-UORTPREJ.js',
+    // Angular emits bundle requests relative to the current route, so the
+    // same asset also arrives under a route prefix.
+    '/recipe/styles-VFQLW5EH.css',
+    '/recipe/chunk-CSQ5XSFZ.js',
+  ];
+
+  for (const path of subresources) {
+    it(`treats ${path} as a subresource`, async () => {
+      const { isPageSubresource } = await import('./security.js');
+      expect(isPageSubresource({ path } as Request)).toBe(true);
+    });
+  }
+
+  // Real navigations must keep counting — exempting these would remove the
+  // rate limit from the public surface entirely.
+  const pages = [
+    '/',
+    '/browse',
+    '/kitchen',
+    '/privacy-policy',
+    '/sitemap.xml',
+    '/r/vegan-baked-blooming-onion-with-zesty-dip',
+    '/recipe/db958616-04b4-495f-a67b-34b0760dc97a',
+  ];
+
+  for (const path of pages) {
+    it(`does not treat ${path} as a subresource`, async () => {
+      const { isPageSubresource } = await import('./security.js');
+      expect(isPageSubresource({ path } as Request)).toBe(false);
+    });
+  }
+
+  it('does not exempt an unhashed .js path (only content-hashed bundles)', async () => {
+    const { isPageSubresource } = await import('./security.js');
+    expect(isPageSubresource({ path: '/evil.js' } as Request)).toBe(false);
+  });
+});
+
+describe('createPageLimiter', () => {
+  it('uses a Valkey keyspace separate from the API limiter', async () => {
+    const { createPageLimiter, createApiLimiter } = await import('./security.js');
+    const RedisStore = (await import('rate-limit-redis')).default as unknown as {
+      mockClear: () => void;
+      mock: { calls: Array<[{ prefix: string }]> };
+    };
+    RedisStore.mockClear();
+
+    const valkeyClient = { call: vi.fn() } as unknown as Parameters<typeof createPageLimiter>[0];
+    expect(typeof createPageLimiter(valkeyClient)).toBe('function');
+    expect(createPageLimiter(valkeyClient)).not.toBe(createApiLimiter(valkeyClient));
+
+    // KAN-154 regression guard: the page and API limiters must write to
+    // separate Valkey keyspaces, or ordinary browsing exhausts the /api budget.
+    const prefixes = RedisStore.mock.calls.map((call) => call[0].prefix);
+    expect(prefixes).toContain('rl:page:');
+    expect(prefixes).toContain('rl:api:');
+  });
+});
+
 describe('createExpensiveOperationLimiter', () => {
   it('should return a middleware function', async () => {
     const { createExpensiveOperationLimiter } = await import('./security.js');

--- a/specs/canonical-recipes.json
+++ b/specs/canonical-recipes.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./canonical-recipes.schema.json",
   "version": 1,
-  "updated": "2026-07-23",
+  "updated": "2026-07-25",
   "recipes": [
     {
       "slug": "classic-vegan-margherita-pizza",
@@ -85,6 +85,18 @@
         "breadth": 5,
         "search_intent": 4,
         "content_quality": 4
+      }
+    },
+    {
+      "slug": "vegan-orange-chicken-style-seitan-with-white-rice",
+      "title": "Vegan Orange Chicken Style Seitan with White Rice",
+      "rationale": "Asian/takeout-style breadth (new category for the set); proven search performance — ranks first for a partial-slug query with image and working link; complete content (17 ingredients, 10 steps, hero image)",
+      "added": "2026-07-25",
+      "score": {
+        "representativeness": 5,
+        "breadth": 5,
+        "search_intent": 5,
+        "content_quality": 5
       }
     }
   ]

--- a/specs/canonical-recipes.schema.json
+++ b/specs/canonical-recipes.schema.json
@@ -15,7 +15,7 @@
     "recipes": {
       "type": "array",
       "minItems": 3,
-      "maxItems": 7,
+      "maxItems": 8,
       "items": {
         "type": "object",
         "required": ["slug", "title", "rationale", "added", "score"],

--- a/src/app-shell.test.ts
+++ b/src/app-shell.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Guards on the app shell (repo-root index.html) that no other test covers.
+ *
+ * KAN-159 (production, 2026-07-25): the shell shipped without a <base> element.
+ * The Angular builder injects its bundles as bare filenames (main-<hash>.js),
+ * which a browser resolves against the current *directory* of the document URL
+ * — so a reload of /recipe/<id> requested /recipe/main-<hash>.js, missed every
+ * build artifact, fell through to the Express SPA catch-all, and came back as
+ * the shell itself labelled text/html. Helmet's nosniff then refused to execute
+ * it, Angular never bootstrapped, and the page was blank with a dead router.
+ *
+ * Asserted against the source file rather than dist/: the Vitest CI job does
+ * not run an Angular build, so a dist-based check would silently skip.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const shell = readFileSync(fileURLToPath(new URL('../index.html', import.meta.url)), 'utf8');
+
+/**
+ * Single left-to-right scan of the shell. The comment alternative comes first
+ * and consumes whole comments, so markup *mentioned* inside one is never
+ * mistaken for the real thing — this file's own <base> prose would otherwise
+ * be counted. Likewise the <base …> alternative swallows its own href, so it
+ * cannot also register as a URL reference.
+ *
+ * Deliberately a tokenizer rather than "strip comments, then match": a
+ * `.replace()` that removes <!-- … --> has the shape of an HTML sanitizer
+ * without being one (CodeQL js/incomplete-multi-character-sanitization flags
+ * it, correctly — a single pass can leave <!-- behind on malformed input).
+ */
+const TOKEN_RE = /<!--[\s\S]*?-->|<base\b[^>]*>|<\/head>|(?:src|href)="([^"]*)"/g;
+
+type Token = { kind: 'base' | 'headEnd' | 'ref'; text: string; index: number; url: string };
+
+function scanShell(html: string): Token[] {
+  const tokens: Token[] = [];
+  for (const match of html.matchAll(TOKEN_RE)) {
+    const text = match[0];
+    const index = match.index ?? 0;
+    if (text.startsWith('<!--')) continue;
+    if (text.startsWith('<base')) tokens.push({ kind: 'base', text, index, url: '' });
+    else if (text.startsWith('</head')) tokens.push({ kind: 'headEnd', text, index, url: '' });
+    else tokens.push({ kind: 'ref', text, index, url: match[1] ?? '' });
+  }
+  return tokens;
+}
+
+const tokens = scanShell(shell);
+const baseTags = tokens.filter((t) => t.kind === 'base');
+
+// A URL that is neither absolute nor already root-anchored resolves against the
+// document's directory — the exact bug this file guards.
+const isDirectoryRelative = (url: string): boolean =>
+  !/^(?:https?:)?\/\//.test(url) && !url.startsWith('/') && !/^(?:#|data:|mailto:)/.test(url);
+
+describe('app shell <base href>', () => {
+  it('declares exactly one base element, anchored at the site root', () => {
+    expect(baseTags).toHaveLength(1);
+    expect(baseTags[0].text).toMatch(/href="\/"/);
+  });
+
+  it('places it before anything that resolves a relative URL', () => {
+    expect(baseTags).toHaveLength(1);
+    const baseIndex = baseTags[0].index;
+
+    // Vacuous today — every URL in the source shell is absolute or
+    // root-anchored. It is a forward guard: adding a bare-filename asset above
+    // <base> would reintroduce the directory-relative resolution bug.
+    const relative = tokens.filter((t) => t.kind === 'ref' && isDirectoryRelative(t.url));
+    for (const ref of relative) {
+      expect(ref.index).toBeGreaterThan(baseIndex);
+    }
+  });
+
+  it('keeps the base element inside the head', () => {
+    expect(baseTags).toHaveLength(1);
+    const headEnd = tokens.find((t) => t.kind === 'headEnd');
+    expect(headEnd).toBeDefined();
+    expect(baseTags[0].index).toBeLessThan(headEnd!.index);
+  });
+});


### PR DESCRIPTION
## Ready to ship

`scripts/release/train-verify.sh --for-release` reports **`OK — no blocking drift`**. Every station:

| station | value |
|---|---|
| version | `0.4.6` — CHANGELOG section present, `v0.4.6` **not yet tagged** |
| cookbook `main`→`dev` back-sync owed | 0 |
| Backend `main`→`dev` back-sync owed | 0 |
| submodule pointer | `38736da55119` — **matches Backend `main`** (SHA and content) |
| CHANGELOG names pinned SHA | present |
| Alembic heads | **1** (`e4a7b2d9c5f1`) |

## Merging this deploys to production

`release.yml` reads `0.4.6` from `package.json`, creates and pushes tag **`v0.4.6`**, and publishes the GitHub Release from the matching CHANGELOG section. That tag push matches the Cloud Build trigger regex `^v[0-9]+\.[0-9]+\.[0-9]+$` and fires `cloudbuild.yaml`, which builds both images, runs the `flask-backend-migrate` Job, then deploys Flask and Express in that order.

**This release runs a real migration.** Unlike v0.4.5, `flask-backend-migrate` does work: `e4a7b2d9c5f1`, chaining onto the prior sole head `d1e5a9c3f7b2`. Head count is exactly 1, so `flask db upgrade` applies it rather than refusing on branched heads. That is now machine-checked on every PR, not asserted — see KAN-138 below.

**Merge with a merge commit, not squash.** The `main` ruleset disables squash on both repos (since the v0.3.0 incident), and squashing would rewrite ancestry so the back-sync count never converges.

## Payload — 7 commits

### Fixed

- **KAN-159** ([#3282](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3282)) — reloading `/recipe/<id>` rendered a blank page with a dead router. `index.html` shipped no `<base>`, so Angular's bare bundle filenames (`main-<hash>.js`) resolved against the document's *directory*: `/` and `/kitchen` worked, `/recipe/<id>` requested `/recipe/main-<hash>.js`, matched nothing, and got the SPA shell back as `text/html`. Reported in walkthrough round 2.

- **KAN-154** ([#3281](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3281)) — 84 × HTTP 429 on `express-frontend` after the v0.4.5 deploy (0 in the preceding 24h). Two users on one home connection were both locked out of ordinary browsing. Every browser-initiated subresource was metered as a navigation against the same 300 req / 15 min bucket — ~8 counted requests per page view, so ~37 page views before lockout. Fixed on all three causes: subresources exempt from the page limiter, `apple-touch-icon(-precomposed).png` served explicitly instead of returning 13KB of HTML labelled `image/png` (44 of the 429s), and the page limiter moved to its own `rl:page:` Valkey keyspace so browsing can't drain the `/api` budget.

### Added

- **KAN-158** ([#3283](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3283) + Backend [#251](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/251)) — eighth canonical recipe, orange-chicken-style seitan. `is_canonical = true` makes the public page durable: `_guard_canonical` refuses unpublish, re-slug, and delete, so an indexed `/r/` page can't later 404. Schema `maxItems` and the SEO gate's bound both move 7 → 8 together.

- **KAN-138** ([#3285](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3285)) — the single-Alembic-head check is now a **required merge gate**. It already existed and was correct (station 4 of `train-verify.sh`), but only ran on manual dispatch and a daily cron, so a pointer bump onto a branched-head Backend merged clean and surfaced later — or at deploy, where two heads fail the migrate Job and abort the release with the old Flask revision serving. Logic extracted to `scripts/release/alembic-heads.sh` (one implementation, both callers) and wired into `pr-gate.yml`'s `gate.needs`.

### Chore

- [#3284](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3284) pointer bump to the KAN-158 migration; [#3286](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3286) version + CHANGELOG + re-pin to Backend `main`; [#3280](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3280) back-sync (no product change).

## Backend side

Promoted `dev`→`main` in Backend [#252](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/252) (now `38736da`), back-synced in Backend [#253](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/253) so the drift count returns to 0. The pointer pins `main`'s **own** SHA rather than a dev-side commit with the same tree — v0.3.9 shipped the latter and left the deployed SHA and Backend `main` permanently disagreeing.

## Post-merge

Cookbook `main`→`dev` back-sync will be owed once this merges (`scripts/release/train-backsync.sh --only cookbook --apply --merge`). Skipping it is the most-repeated miss in this project's release history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqwHC5WeVAtgosDb469Foy



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

