### PR TITLE
docs(sprint): close out Sprint 3, charter Sprint 4, repair the KAN/RCP sprint lane [KAN-136]

### DIFF
--- a/scripts/pm/check_sprint_lane.sh
+++ b/scripts/pm/check_sprint_lane.sh
@@ -32,12 +32,18 @@ set -a; source .env; set +a
 : "${ATLASSIAN_API_TOKEN:?FAIL(2): ATLASSIAN_API_TOKEN unset}"
 
 SITE="https://tasteslikegood.atlassian.net"
-LABEL="${1:-}"
 
-python3 - "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN" "$SITE" "$LABEL" <<'PY'
-import base64, json, sys, urllib.error, urllib.parse, urllib.request
+# Credentials go through the environment, never argv — argv is world-readable in `ps`,
+# and every other scripts/pm/*.py already reads ATLASSIAN_API_TOKEN from os.environ.
+export ATLASSIAN_SITE="$SITE"
+export SPRINT_LANE_LABEL="${1:-}"
 
-auth, site, label = sys.argv[1], sys.argv[2], sys.argv[3]
+python3 <<'PY'
+import base64, json, os, sys, urllib.error, urllib.parse, urllib.request
+
+site = os.environ["ATLASSIAN_SITE"]
+label = os.environ.get("SPRINT_LANE_LABEL", "")
+auth = f'{os.environ["ATLASSIAN_EMAIL"]}:{os.environ["ATLASSIAN_API_TOKEN"]}'
 hdr = {"Authorization": "Basic " + base64.b64encode(auth.encode()).decode(),
        "Accept": "application/json"}
 
@@ -50,9 +56,16 @@ def jql(q, fields):
             p["nextPageToken"] = tok
         url = f"{site}/rest/api/3/search/jql?" + urllib.parse.urlencode(p)
         try:
-            d = json.load(urllib.request.urlopen(urllib.request.Request(url, headers=hdr)))
+            # timeout matches atlassian_pm_link.py:101 — an unbounded urlopen would hang
+            # forever on a stalled connection, which matters the moment this is wired
+            # into CI rather than run by hand.
+            req = urllib.request.Request(url, headers=hdr)
+            d = json.load(urllib.request.urlopen(req, timeout=30))
         except urllib.error.HTTPError as e:
             print(f"FAIL(2): Jira API {e.code} on {q!r}", file=sys.stderr)
+            sys.exit(2)
+        except (urllib.error.URLError, TimeoutError) as e:
+            print(f"FAIL(2): Jira API unreachable ({e}) on {q!r}", file=sys.stderr)
             sys.exit(2)
         out += d.get("issues", [])
         tok = d.get("nextPageToken")

--- a/scripts/pm/check_sprint_lane.sh
+++ b/scripts/pm/check_sprint_lane.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# check_sprint_lane.sh — assert the KAN/RCP sprint lane has not collapsed again.
+#
+# WHY THIS EXISTS (Sprint 4 risk R1, specs/SPRINT_4_PLAN.md):
+# KAN board 34 is type `simple` and the Agile API refuses to attach a sprint to it
+# (`GET /rest/agile/1.0/board/34/sprint` → "The board does not support sprints").
+# Sprints 1-3 were therefore `sprint-N` LABELS, not Jira sprints, and no burndown or
+# velocity report has ever been possible. Sprint 4 restored the documented split:
+# RCP holds sprint scope + acceptance, KAN holds execution, linked by issue links.
+#
+# That split already collapsed once, and the reason was structural, not moral: KAN is
+# team-managed (one createJiraIssue away for an agent) while RCP is company-managed.
+# A convention that isn't asserted is how the drift happened. This is the assertion.
+#
+# HONEST LIMIT: this is a script, NOT a blocking CI gate. It fails locally / on demand.
+# Wiring it into pr-gate.yml + `gate.needs` is what would make it a gate — the same
+# distinction that made the Alembic head-check look like a gate for weeks while only
+# running on release-train dispatch. Do not describe this as a gate until it is one.
+#
+# Exit codes:
+#   0  every non-Done sprint-labelled KAN row is linked to an RCP row
+#   1  at least one orphan — the lane is drifting
+#   2  setup/credential/API failure (NOT a pass; never treat as success)
+#
+# Usage: bash scripts/pm/check_sprint_lane.sh [sprint-label]   # default: newest sprint-N in KAN
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+[[ -f .env ]] || { echo "FAIL(2): .env not found; need ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN" >&2; exit 2; }
+set -a; source .env; set +a
+: "${ATLASSIAN_EMAIL:?FAIL(2): ATLASSIAN_EMAIL unset}"
+: "${ATLASSIAN_API_TOKEN:?FAIL(2): ATLASSIAN_API_TOKEN unset}"
+
+SITE="https://tasteslikegood.atlassian.net"
+LABEL="${1:-}"
+
+python3 - "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN" "$SITE" "$LABEL" <<'PY'
+import base64, json, sys, urllib.error, urllib.parse, urllib.request
+
+auth, site, label = sys.argv[1], sys.argv[2], sys.argv[3]
+hdr = {"Authorization": "Basic " + base64.b64encode(auth.encode()).decode(),
+       "Accept": "application/json"}
+
+
+def jql(q, fields):
+    out, tok = [], None
+    while True:
+        p = {"jql": q, "maxResults": "100", "fields": fields}
+        if tok:
+            p["nextPageToken"] = tok
+        url = f"{site}/rest/api/3/search/jql?" + urllib.parse.urlencode(p)
+        try:
+            d = json.load(urllib.request.urlopen(urllib.request.Request(url, headers=hdr)))
+        except urllib.error.HTTPError as e:
+            print(f"FAIL(2): Jira API {e.code} on {q!r}", file=sys.stderr)
+            sys.exit(2)
+        out += d.get("issues", [])
+        tok = d.get("nextPageToken")
+        if d.get("isLast") or not tok:
+            return out
+
+
+# Discover the newest sprint-N label in KAN unless one was named.
+# NOTE: Jira's `labels` field does NOT support wildcard matching — `labels ~ "sprint-*"`
+# silently returns zero rows, which made an earlier version of this script report PASS
+# while three sprint-4 rows sat right there. Enumerate labelled rows and filter here.
+if not label:
+    rows = jql("project = KAN AND labels IS NOT EMPTY ORDER BY created DESC", "labels")
+    if not rows:
+        print("FAIL(2): no labelled KAN issues returned at all — the query or credentials "
+              "are wrong, not the board. Refusing to report a pass.", file=sys.stderr)
+        sys.exit(2)
+    nums = {int(l.split("-", 1)[1]) for i in rows for l in (i["fields"].get("labels") or [])
+            if l.startswith("sprint-") and l.split("-", 1)[1].isdigit()}
+    if not nums:
+        print("PASS: no sprint-N labels in KAN — nothing to assert.")
+        sys.exit(0)
+    label = f"sprint-{max(nums)}"
+
+rows = jql(f'project = KAN AND labels = "{label}" AND statusCategory != Done', "summary,issuelinks")
+if not rows:
+    print(f"PASS: no open KAN rows labelled {label}.")
+    sys.exit(0)
+
+orphans = []
+for i in rows:
+    linked_rcp = [
+        (lk.get("inwardIssue") or lk.get("outwardIssue") or {}).get("key", "")
+        for lk in (i["fields"].get("issuelinks") or [])
+    ]
+    if not any(k.startswith("RCP-") for k in linked_rcp):
+        orphans.append((i["key"], i["fields"]["summary"][:64]))
+
+print(f"lane check: {label} — {len(rows)} open KAN row(s), {len(orphans)} orphan(s)")
+for k, s in orphans:
+    print(f"  ORPHAN {k}  {s}")
+
+if orphans:
+    print(f"\nFAIL(1): {len(orphans)} open KAN row(s) labelled {label} have no linked RCP row.")
+    print("The KAN/RCP lane is drifting (Sprint 4 risk R1). Either link them to their RCP")
+    print("acceptance row, or drop the sprint label if the work is not sprint scope.")
+    sys.exit(1)
+
+print(f"PASS: every open KAN row labelled {label} is linked to an RCP row.")
+PY

--- a/specs/SPRINT_3_PLAN.md
+++ b/specs/SPRINT_3_PLAN.md
@@ -182,3 +182,123 @@ sprint (8 children). KAN-143/144 had placeholder summaries of literally "P2" —
 Imageless-recipe disposition rules (post-dedupe decision item) · #3147 canonical-slug-on-rename
 decision · Phase-2 automated rubric scoring · home-page redesign · Valkey KAN-16/KAN-17 ·
 Backend dependabot PR #243 (actions bump, unrelated to sprint).
+
+---
+
+## Sprint 3 CLOSE-OUT — 2026-07-26 (epic KAN-136 → Done)
+
+Closed via `/cs:pm-loop` after `/cs:grill-pm` locked 7/7 branches with Adam the same day.
+Close gate as written above, item by item:
+
+| Gate | Result |
+| --- | --- |
+| 1. B1 · B3 · **B2** merged to `dev` | ✅ B2 = `a10d8a5` (PR #3271, KAN-143/144) |
+| 2. Release cut, tag fired, both services live-verified | ✅ **overshot** — v0.4.5 *and* v0.4.6 shipped; prod `200` |
+| 3. Walkthrough round 2 | ✅ ran 2026-07-25 — cited in the CHANGELOG v0.4.6 preamble |
+| 4. Epic KAN-136 → Done with the close-out written here | ✅ this section |
+
+**Walkthrough round 2 produced six tickets, not ≤3** — the gate allowed "accept, or file ≤3 new
+gaps." Three were fixed inside the sprint and shipped in v0.4.6; three carry forward as Sprint 4's
+committed scope. That overrun is recorded rather than smoothed over: the acceptance gate has now
+generated a sprint's worth of work twice running (round 1 → KAN-149; round 2 → six tickets), which
+is why Sprint 4 carries **R4** — round-3 findings go to the backlog by default.
+
+| Round-2 finding | Disposition |
+| --- | --- |
+| KAN-154 · public SSR pages 429 during normal browsing | shipped v0.4.6 — `4f57907` (PR #3281) |
+| KAN-158 · promote orange-chicken seitan to canonical (cap → 8) | shipped v0.4.6 — `af87c001` (PR #3283) + pointer `ccf7c7a` (PR #3284) |
+| KAN-159 · SPA deep-link reload returns a blank, dead page | shipped v0.4.6 — `3be0216` (PR #3282) |
+| KAN-155 · publish fails "Recipe ID collision" on foreign-owned rows | → **Sprint 4** committed |
+| KAN-156 · duplicate "you already have this recipe" toast | → **Sprint 4** committed |
+| KAN-157 · unpublish 4 dedup-suffixed public recipes | → **Sprint 4** committed |
+
+### Board reconciliation — the third occurrence, and what it cost
+
+Every sprint-3 child had shipped code on `origin/main` while the board read In Review / In Progress.
+Ten rows were transitioned to Done, each carrying its landing SHA, PR and release tag as a comment
+(`git tag --contains <sha>` verified per row, not asserted):
+
+| Issue | Landed | PR | Released |
+| --- | --- | --- | --- |
+| KAN-126 | `1974f4d` | #3268 | v0.4.5 |
+| KAN-137 | `d747b6e` | #3244 | v0.4.3 |
+| KAN-139 | `e40f14b` | #3250 (+ Backend #239) | v0.4.4 |
+| KAN-140 | `7c6d732` | #3252 (+ Backend #240) | v0.4.4 |
+| KAN-143 | `a10d8a5` | #3271 | v0.4.5 |
+| KAN-144 | `a10d8a5` | #3271 | v0.4.5 |
+| KAN-149 | `f0ef889` | #3265 | v0.4.5 |
+| KAN-154 | `4f57907` | #3281 | v0.4.6 |
+| KAN-158 | `af87c001` | #3283 | v0.4.6 |
+| KAN-159 | `3be0216` | #3282 | v0.4.6 |
+
+KAN-141 was already Done. **KAN-155/156/157 were deliberately NOT closed** — they have zero commits
+in either repo, so closing them would have been a false Done in the opposite direction. They were
+re-labelled `sprint-3` → `sprint-4`.
+
+This is the second hand-reconciliation in three days (the 07-24 re-plan closed eight such rows).
+Two occurrences is a system property, not bad luck. The real fix already exists as an unbuilt
+backlog row — **KAN-97** "auto-transition on PR merge" (twin: RCP-39) — and is now named, accepted
+and scheduled for Sprint 5 rather than silently re-paid a third time (Sprint 4 **R2**).
+
+### The KAN/RCP lane was structurally broken, not just neglected
+
+Adam raised this during the grill; verified against the Agile API rather than the docs:
+
+```
+GET /rest/agile/1.0/board/34/sprint      (KAN)
+  → {"errorMessages":["The board does not support sprints"]}
+
+id=34  simple  KAN board        project=KAN
+id=166 scrum   RCP board        project=RCP
+id=168 scrum   RCP Scrum Board  project=RCP
+  sprint id=9 "RCP Sprint 1"  state=ACTIVE  2026-04-28 → 2026-05-12   (11 weeks overdue)
+  sprint id=3 "RCP Sprint 1"  state=future                             (duplicate)
+```
+
+**No work this project has ever called a sprint has been a Jira sprint.** Sprints 1–3 were
+`sprint-N` labels on a board the API refuses to attach a sprint to — which is why every flow
+measure has to be hand-rolled through `jira_snapshot_bridge.py` and why no burndown or velocity
+report has ever existed. `docs/guides/agile/SCRUM_BOOTSTRAP_AND_BOARD_PLAN.md` recorded "Sprint
+support: not supported by this board" on 2026-04-27 and recommended a Scrum board; that
+recommendation was never executed.
+
+The cause is structural, not discipline: KAN's issue types carry `scope: {PROJECT, 10034}`
+(team-managed — one `createJiraIssue` away for an agent), RCP's carry none (company-managed, shared
+schemes). The easier project pulled the work.
+
+Actions taken: stale sprint **id 9 closed** (its 5 incomplete rows returned to the RCP backlog,
+nothing deleted), duplicate future sprint **id 3 deleted**, and a real sprint **"Sprint 4"
+(id 43) created on board 168**. Five shadow RCP rows were reconciled to the same evidence standard
+as KAN — RCP-44 (→ KAN-137/KAN-149, v0.4.3/v0.4.5), RCP-46 (→ KAN-140 + KAN-141, v0.4.4),
+RCP-51 (→ KAN-139, v0.4.4), RCP-52 (→ KAN-118 `2cb90e1` PR #3207, v0.4.2) → Done; **RCP-43 closed
+as a duplicate of KAN-156**, not as delivered, so the pair collapses onto one live row. RCP-49
+(manual toggle/unpublish/delete field-test loop) stays open deliberately — it *is* the walkthrough.
+
+### Found but deliberately not acted on
+
+Closing sprint 9 surfaced five more RCP rows describing the **v0.2 Anti-Recipe Site**, which has
+been live in production for months: **RCP-3** (the v0.2 epic), **RCP-1**, **RCP-7**, **RCP-20**,
+**RCP-4**. They are stale in exactly the way this close-out just fixed elsewhere. They were left
+alone under the sprint's own budget rule — hygiene is capped at one pass and agents may not
+self-authorize scope. Filed here as the first Sprint 5 candidate.
+
+### Flow metrics, measured after the reconciliation (never before)
+
+Measuring before transitioning would have left ten shipped items' cycle-time clocks still running.
+Raw vs. filtered (`daily-status`, `agentic-workflows`, `report` excluded — 21 bot-filed rows of 125):
+
+| Measure | Raw (125 rows) | Filtered (104 rows) |
+| --- | --- | --- |
+| Done / WIP | 57 / 4 | 49 / 4 |
+| Cycle time p50 | 1 d | 1 d |
+| **Cycle time p85** | **78 d** | **3 d** |
+| SLE @ p85 (conformance) | 78 d (86.0%) | 3 d (85.7%) |
+
+The bot rows were not a rounding error — they moved p85 cycle time by a factor of 26 and would have
+set the Service Level Expectation at 78 days. Filtered is the real number.
+
+**Throughput is now contaminated by this very close-out and must not be used to forecast.** Batch-
+closing ten rows dated today, for work delivered across four releases, reads as 32 resolved/week
+(7-day) and 18.5/week (14-day) against a 2.77/week lifetime average. That spike is an artifact of
+the reconciliation, not capacity. See Sprint 4's forecast section for how that was handled instead
+of quietly using the flattering number.

--- a/specs/SPRINT_4_PLAN.md
+++ b/specs/SPRINT_4_PLAN.md
@@ -1,0 +1,96 @@
+# Sprint 4 Plan — Walkthrough round-2 tail: publish collision, duplicate toast, dedup-suffix unpublish
+
+_Chartered:_ 2026-07-26 · _Owner:_ Adam Schoen
+_Jira epic:_ **RCP-54** (delivery/acceptance) · _Jira sprint:_ **"Sprint 4", id 43, board 168**
+_Execution tickets:_ **KAN-155 · KAN-156 · KAN-157** (KAN = execution, RCP = scope/acceptance)
+_Status:_ ✅ **LOCKED via `/cs:grill-pm` — 7/7 branches confirmed by Adam, 2026-07-26.**
+Charter only. **No implementation started this session** by explicit scope bound.
+
+**This is the first real Jira sprint this project has ever had.** Sprints 1–3 were `sprint-N`
+labels on KAN board 34, which the Agile API refuses to attach a sprint to
+(`{"errorMessages":["The board does not support sprints"]}`). See the Sprint 3 close-out for the
+full finding and the lane repair.
+
+## Charter (locked decisions)
+
+| #   | Branch                 | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Outcome / DONE**     | Two machine gates. **(a) Sprint 3 close-out:** `project in (KAN, RCP) AND labels = sprint-3 AND statusCategory != Done` returns **zero rows** — done 2026-07-26. **(b) Sprint 4 planning:** this file carries all six charter rows, epic RCP-54 exists with ≤3 committed children in sprint 43, and `python3 .claude/skills/harness-qa-loop/plan_qa.py` exits 0. Sprint 4 *delivery* closes when KAN-155/156/157 each pass their own gate below.                                                                                                                                                     |
+| 2   | **Measurement**        | WIP ≤ 3, no story points. Four mandatory measures reported **filtered** — `daily-status`, `agentic-workflows` and `report` rows excluded (21 of 125 KAN rows are bot-filed). Measure **after** status reconciliation, never before: shipped work reading In Review leaves its cycle-time clock running. The filter is not cosmetic — it moved p85 cycle time from **78 d → 3 d** and would otherwise have set the SLE at 78 days.                                                                                                                                                                     |
+| 3   | **Forecast honesty**   | Zero invented dates, and **no trailing-throughput forecast this sprint** — see the amendment below. Monte Carlo over lifetime throughput (filtered, 10k trials, seed 42): **p50 3 weeks · p70 4 · p85 7 · p95 10** for 3 items. Range only, never a date. Sprint 43 was created with **no start/end dates**; setting the timebox is Adam's call and is recorded as his override.                                                                                                                                                                                                                     |
+| 4   | **Ownership**          | Owner = Adam on all three; agent authors; **reviewer is never the author.** Per-item reviewers in the scope table below. Escalation → Adam, reason written into this file at the moment of escalation. `delivery_loop_gate.py` refuses a plan with an unnamed owner or reviewer.                                                                                                                                                                                                                                                                                                                    |
+| 5   | **Jira lane**          | **RCP holds the sprint, KAN keeps execution** — the model `docs/ATLASSIAN_PM_LINK.md` already specified and practice had abandoned. Hard cap: RCP gets this epic + ≤3 acceptance rows per sprint, nothing else. Acceptance rows RCP-55/56/57 are `Relates`-linked to KAN-155/156/157.                                                                                                                                                                                                                                                                                                               |
+| 6   | **Risk (pre-mortem)**  | Six owned risks, R1–R6, below. R1 (the lane collapses again) and R2 (status drifts a third time) are both **recurrences**, not hypotheticals.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| 7   | **Budgets**            | 3 attempts/task · 12 iterations/goal · escalation reviewer Adam. Terminal states are exactly three: **verified-close, escalated, explicitly waived by Adam** — "looks done" is not one. **Blocked-on-human is a pause, not an attempt.** Hygiene capped at one pass. **No agent-initiated scope.** Copilot/Codex spend stays under the fixed blocking budget set 2026-07-24.                                                                                                                                                                                                                        |
+
+## Committed scope — WIP ≤ 3
+
+All three are the tail of walkthrough round 2 (2026-07-25). Each has **zero commits** in either
+repo, verified by `git log --grep` across `origin/main` and `origin/dev` in both repos.
+
+| #      | Item                                                                                              | Jira                | Proving gate (machine unless noted)                                                                                                                                        | Reviewer                                            |
+| ------ | ------------------------------------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| **S1** | Publish fails **"Recipe ID collision"** when the row is owned by another account or a guest session — P1, breaks the core publish path | KAN-155 ↔ RCP-55 | `Gate — all checks passed` SUCCESS **+** a regression test that **fails on today's code** (mutation-checked, per the KAN-126 precedent)                                     | machine + **Adam-as-user, reproducing the collision *before* the fix** |
+| **S2** | Duplicate "you already have this recipe" toast fires after a **successful first-time save**        | KAN-156 ↔ RCP-56 | Vitest asserts a first-time save emits **exactly one** toast; `npm test` exit 0; PR gate                                                                                    | machine + PR gate                                   |
+| **S3** | Unpublish 4 dedup-suffixed public recipes competing with their originals — **prod data**           | KAN-157 ↔ RCP-57 | dry-run listing → **Adam approves the exact 4 slugs as printed** → backup → strict-assert → re-verify: the 4 `/r/<slug>` resolve per Adam's call, originals still 200, canonical + crawl CI gates green | **Adam as explicit human gate** + machine re-verify  |
+
+S1 sequencing lock: this is likely Backend ownership/slug logic → **Backend PR into Backend `dev`
+first, then a cookbook pointer-bump PR.** Per CLAUDE.md no path ships Backend code without the
+cookbook PR. S3 reuses the Sprint 3 dedupe pattern verbatim, because it is the same class of action:
+irreversible writes to production rows.
+
+## Forecast — and why the flattering number was refused
+
+The charter's original forecast statement cited trailing throughput of ~12 items/week (24 items /
+14 days), measured **before** the Sprint 3 reconciliation. That number is now unusable, and the
+reason matters more than the number:
+
+closing ten stale rows on 2026-07-26 — for work actually delivered across v0.4.3, v0.4.4, v0.4.5 and
+v0.4.6 — injected ten resolutions dated today. Trailing throughput consequently reads **32/week
+(7-day)** and **18.5/week (14-day)** against a **2.77/week** lifetime average. That is an artifact of
+board hygiene, not capacity. Forecasting from it would have been the mirror image of the defect this
+sprint just fixed: letting Jira timestamps stand in for what actually shipped when.
+
+**Forecast of record (verbatim):** _"3 committed items. Monte Carlo over filtered lifetime weekly
+throughput (10k trials, seed 42): p50 3 weeks, p70 4, p85 7, p95 10. This is deliberately the
+pessimistic basis — trailing throughput is contaminated by the 2026-07-26 batch reconciliation and
+is not used. No delivery date is promised; the range is re-derived after each item completes, and
+trailing throughput becomes usable again once the batch ages out (~2 weeks) or is recomputed from
+release dates rather than Jira resolution dates."_
+
+Flow baseline at charter time (filtered, 104 rows): Done 49 · WIP 4 · cycle time p50 1 d / **p85 3 d**
+· SLE 3 d at 85.7% conformance.
+
+## Owned risks
+
+| ID     | Risk                                                                             | Mitigation                                                                                                                                                                                        |
+| ------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **R1** | **The KAN/RCP lane collapses again** — highest probability; it already did once, and the structural pull (team-managed KAN is one `createJiraIssue` away) is unchanged | Assert it, don't exhort it: the close JQL spans both projects, and `scripts/pm/check_sprint_lane.sh` fails when a non-Done `sprint-N` KAN row has no linked RCP row. Honest limit: this is a script, **not yet a blocking CI gate** |
+| **R2** | **Status drifts a third time** — hand-reconciled 07-24 and again 07-26; two occurrences in three days is a system property | Real fix exists unbuilt: **KAN-97** auto-transition on PR merge (twin RCP-39). Named, accepted, **scheduled Sprint 5** rather than silently re-paid                                                |
+| **R3** | **Sprint 4 becomes a board-hygiene sprint and ships nothing for users**           | Hygiene is close-out work, **not committed scope**, one pass, time-boxed. If hygiene is unfinished when KAN-155/156/157 are done, **the sprint still closes**                                      |
+| **R4** | **Walkthrough round 3 never lets the sprint close** — round 1 → KAN-149; round 2 → six tickets | Round-3 findings go to the **backlog by default**. Only a P1 production break may interrupt, and interrupting is Adam's call                                                                       |
+| **R5** | **KAN-157 unpublishes the wrong production rows**                                 | Sprint 3 proven pattern: dry-run table → approve **as printed** → backup → strict-assert (exists ∧ expected owner ∧ in approved list, else abort) → in-transaction re-verify                        |
+| **R6** | **KAN-155 drags a migration**                                                    | Check on **day one**. If a migration is required this is a **release, not a hotfix**. Alembic single-head is a blocking pr-gate check since #3285; `train-verify.sh` covers cross-repo drift        |
+
+## Decision item awaiting Adam — not started
+
+**KAN-160 and KAN-161 are both labelled `held` by Adam's own instruction, and KAN-161's hold
+condition has lapsed.**
+
+- **KAN-161** — rate limiters key on raw `req.ip`, so one IPv6 /56 client can bypass per-IP limits
+  including the 20/hr AI budget. The hold was explicitly _"until after the current release"_;
+  **v0.4.6 shipped 2026-07-25**, so that condition is satisfied. Security-relevant.
+- **KAN-160** — the board finding that per-incident URL/request-classification patches would keep
+  recurring. v0.4.6's KAN-154 fix was another one (`isPageSubresource()` allowlist), which is the
+  predicted fourth instance of the pattern. The board's own trigger for building it was "a fourth
+  instance appears."
+
+Both are Adam's go/no-go. Neither is in Sprint 4 scope and neither has been started.
+
+## Not in this sprint
+
+KAN-160 / KAN-161 (held, above) · KAN-97 auto-transition (Sprint 5, R2) · the bot-noise source fix
+(filed as its own row; see close-out) · the five stale v0.2 RCP rows RCP-3/1/7/20/4 (Sprint 5
+candidate) · RCP-47 unpublish-confirmation dialog · RCP-49 (standing walkthrough story, stays open)
+· KAN-151 Valkey response-cache read paths · KAN-104/105 (#3146/#3147 slug decisions) · imageless-
+recipe disposition rules · home-page redesign.


### PR DESCRIPTION
Closes Sprint 3 (epic **KAN-136**) and charters Sprint 4. Docs + one new PM script; no application code.

## Sprint 3 close gate — met

| Gate | Result |
| --- | --- |
| B1 · B3 · **B2** merged | ✅ B2 = `a10d8a5` (#3271) |
| Release cut + live-verified | ✅ **overshot** — v0.4.5 *and* v0.4.6 shipped, prod `200` |
| Walkthrough round 2 | ✅ ran 2026-07-25 (CHANGELOG v0.4.6 preamble) |
| Epic → Done + close-out written | ✅ this PR |

Round 2 filed **six** tickets, not the ≤3 the gate allowed. Three shipped in v0.4.6 (KAN-154/158/159); three carry forward as Sprint 4 scope (KAN-155/156/157). Recorded rather than smoothed over — the acceptance gate has now generated a sprint's worth of work twice running, which is why Sprint 4 carries risk **R4**.

## Board reconciliation — third occurrence

Ten KAN rows read In Review/In Progress while their code sat on `origin/main`. Each transitioned to Done carrying its landing SHA, PR and release tag, **verified per row with `git tag --contains`** rather than asserted:

KAN-126 `1974f4d` v0.4.5 · KAN-137 `d747b6e` v0.4.3 · KAN-139 `e40f14b` v0.4.4 · KAN-140 `7c6d732` v0.4.4 · KAN-143/144 `a10d8a5` v0.4.5 · KAN-149 `f0ef889` v0.4.5 · KAN-154 `4f57907` v0.4.6 · KAN-158 `af87c001` v0.4.6 · KAN-159 `3be0216` v0.4.6

**KAN-155/156/157 were deliberately NOT closed** — zero commits in either repo, so closing them would be a false Done in the opposite direction. Re-labelled `sprint-3` → `sprint-4`.

This is the second hand-reconciliation in three days. Two occurrences is a system property, so the real fix — **KAN-97** auto-transition on PR merge — is named, accepted and scheduled Sprint 5 instead of being silently re-paid (risk **R2**).

## The KAN/RCP lane was structurally broken

Verified against the Agile API, not the docs:

```
GET /rest/agile/1.0/board/34/sprint   (KAN)
  → {"errorMessages":["The board does not support sprints"]}
```

**No work this project has called a sprint has ever been a Jira sprint.** Sprints 1–3 were `sprint-N` labels on a board that cannot hold one — which is why every flow measure is hand-rolled and no burndown has ever existed. `docs/guides/agile/SCRUM_BOOTSTRAP_AND_BOARD_PLAN.md` recorded this on 2026-04-27; the remedy was never executed.

Cause is structural, not discipline: KAN issue types carry `scope {PROJECT, 10034}` (team-managed, one `createJiraIssue` away for an agent); RCP's carry none (company-managed). The easier project pulled the work.

Repaired: stale sprint **id 9** (`RCP Sprint 1`, ACTIVE since 2026-04-28, 11 weeks overdue) closed with its 5 incomplete rows returned to the backlog; duplicate future sprint **id 3** deleted; real sprint **"Sprint 4" (id 43)** created on board 168 with **no invented dates**. Epic **RCP-54** + acceptance rows **RCP-55/56/57** created and `Relates`-linked to KAN-155/156/157. Five shadow RCP rows reconciled with SHAs; **RCP-43 closed as a duplicate of KAN-156**, not as delivered.

## Measurement — and a refused number

Flow measured **after** reconciliation (measuring first leaves ten shipped items' clocks running). Filtering 21 bot-filed rows of 125:

| Measure | Raw | Filtered |
| --- | --- | --- |
| Cycle time p85 | **78 d** | **3 d** |
| SLE @ p85 | 78 d (86.0%) | 3 d (85.7%) |

A factor of 26. Filed **KAN-168** to fix at source rather than hand-closing symptom rows that regenerate.

**Trailing throughput is not used to forecast.** Batch-closing ten rows dated today, for work shipped across four releases, reads as 32/wk against a 2.77/wk lifetime average — board hygiene, not capacity. Forecast of record is the pessimistic Monte Carlo range (p50 3 wks, p85 7 wks) with the contamination stated in the charter.

## New script

`scripts/pm/check_sprint_lane.sh` (risk **R1**) asserts every open sprint-labelled KAN row is linked to an RCP row. **Proven to pass and to fail** — an earlier version used `labels ~ "sprint-*"`, which Jira silently matches against nothing, and it reported PASS with three `sprint-4` rows sitting right there. The negative test was run against a live unlinked row and reverted. Its header states plainly that it is a script, **not** a blocking CI gate.

## Gates

- **(a)** `project in (KAN, RCP) AND labels = sprint-3 AND statusCategory != Done` → **0 rows** ✅
- **(b)** `python3 .claude/skills/harness-qa-loop/plan_qa.py` → **PASS**, 0 blockers, 0 warnings ✅

## Left alone deliberately

Closing sprint 9 surfaced five more stale RCP rows for the v0.2 site (RCP-3/1/7/20/4), live in production for months. Not touched — hygiene is capped at one pass and agents may not self-authorize scope. Filed as the first Sprint 5 candidate.

Sprint 4 charter locked via `/cs:grill-pm`, 7/7 branches, with Adam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstkxgzHvb87vJub5sJVHc






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

