### PR TITLE
chore(kan170): persist --invoker-iam-check in cloudbuild + fix verify audiences reader [KAN-170]

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -235,6 +235,26 @@ steps:
       # below; created by scripts/gcloud/setup_valkey_ca.sh.
       - --set-secrets=GOOGLE_API_KEY=GOOGLE_API_KEY:latest,FLASK_SECRET_KEY=FLASK_SECRET_KEY:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,DATABASE_URL=DATABASE_URL:latest,VALKEY_CA_CERT=VALKEY_CA_CERT:latest,DD_API_KEY=DD_API_KEY:latest
       - --labels=service=flask-backend,dd_sls_mcp_tool=true
+      # KAN-170. --no-allow-unauthenticated is NOT what secures this service and
+      # never was. It edits the IAM policy (removing allUsers), while the
+      # annotation run.googleapis.com/invoker-iam-disabled=true switches the
+      # invoker IAM check off wholesale — so the annotation wins and the flag is
+      # inert. It cannot even clear it: from 2026-03-09 to 2026-07-27 this line
+      # sat here unchanged across ~100 deploys while the service accepted
+      # anonymous requests from the public internet, and both artifacts a
+      # reviewer would check (this file, and the IAM policy) said the opposite
+      # of the truth.
+      #
+      # --invoker-iam-check is the flag that actually clears the annotation.
+      # Keep BOTH: the line below is the real control, and --no-allow-unauthenticated
+      # stays only because removing it would re-add allUsers on the next deploy.
+      #
+      # Note this is a SERVICE-level setting, applied the moment this step runs —
+      # before the Express step below rolls out. Never land this flag in the same
+      # release that first ships the Express ID-token code (server/flask-auth.ts):
+      # the old Express revision would be serving without a token for the ~60s
+      # between the two deploy steps and every proxied route would 403.
+      - --invoker-iam-check
       - --no-allow-unauthenticated
       - --quiet
       - --network=default

--- a/scripts/gcloud/kan170_verify.sh
+++ b/scripts/gcloud/kan170_verify.sh
@@ -93,7 +93,12 @@ gcloud run services get-iam-policy "$FLASK_SERVICE" \
   --format='value(bindings.role,bindings.members)' 2>/dev/null | sed 's/^/    /' \
   || info "(none)"
 
-CUSTOM_AUD="$(describe "$FLASK_SERVICE" 'value(spec.template.metadata.annotations["run.googleapis.com/custom-audiences"])')"
+# Custom audiences live on the SERVICE-level metadata annotations, not the
+# revision template. The template path read here before 2026-07-27 is never
+# populated by `gcloud run services update --add-custom-audiences`, so this
+# line reported "<none>" during the KAN-170 cutover while the live service
+# annotation provably listed both worker endpoints.
+CUSTOM_AUD="$(describe "$FLASK_SERVICE" 'value(metadata.annotations["run.googleapis.com/custom-audiences"])')"
 info "custom audiences: ${CUSTOM_AUD:-<none>}"
 
 # ── 3. Pub/Sub push subscriptions ───────────────────────────────────────────


### PR DESCRIPTION
## Description

The two post-cutover follow-ups from the KAN-170 remediation, now that the operator cutover ran and verified on 2026-07-27 (~15:25 UTC — anonymous direct requests 403, all proxied routes 200 on the ID token):

1. **`cloudbuild.yaml` — re-apply `--invoker-iam-check` on the flask-backend deploy step** (re-applies `7636815`, which was deliberately reverted in `51d37d9` to keep v0.4.7 behaviour-neutral). The ordering constraint in that revert — never land this flag in the same release that first ships the token code — is now satisfied. The flag makes the build config state the enforced truth so a future deploy cannot silently undo the cutover, closing the "config reads as secure while production is open" failure mode in the forward direction.

2. **`scripts/gcloud/kan170_verify.sh` — read custom audiences from service-level `metadata.annotations`**, not `spec.template.metadata.annotations`, which `gcloud run services update --add-custom-audiences` never populates. During the cutover this bug reported `custom audiences: <none>` while the live service annotation provably listed both worker endpoints — sending the operator chasing a phantom missing-audiences problem (prepare had in fact applied them; the gcloud "Proxy locally with:" success hint in its output was the tell).

Considered and deliberately left unchanged: `kan170_path_a.sh`'s warn-and-skip branch for the no-push-subscriptions case. It never fired (the initial suspicion that prepare skipped the audiences was falsified by the verify-reader bug above), and hardening an unfired branch mid-incident-cleanup would be speculative scope.

## Related Issues

- Relates to [KAN-170](https://tasteslikegood.atlassian.net/browse/KAN-170) — closes out the "land the follow-up after the cutover" step from the #3300 plan
- Follows #3300 (token path), #3301 (v0.4.7 release), #3302 (back-sync)
- [KAN-173](https://tasteslikegood.atlassian.net/browse/KAN-173) remains the scheduled-detection layer on top of this

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — the verify.sh reader
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] CI/CD changes — the cloudbuild flag

## Testing

- [x] Tests pass locally (`npm run test`) — no TS/server code touched; suite unaffected
- [x] Linting passes (`npm run lint`) — n/a to these files; `bash -n` clean on both scripts
- [x] Code is formatted (`npm run format`)
- [ ] Build succeeds (`npm run build`) — unaffected (yaml + shell only); CI validates
- [x] Type checking passes (`npm run type-check`) — no TS changes

Deploy-behaviour note: `--invoker-iam-check` is a no-op relative to current production state (the check is already enabled service-side by the cutover); the next tag deploy simply re-asserts it.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

n/a

## Additional Notes

With this merged, the KAN-170 code trail is complete: token path (v0.4.7) → operator cutover (done, verified) → config pinned (this PR). Remaining hardening lives in KAN-172 (decision record) and KAN-173 (scheduled recurrence detection + mint-failure alerting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PGtwnhzVKYNdTevbVMcfL

---
_Generated by [Claude Code](https://claude.ai/code/session_012PGtwnhzVKYNdTevbVMcfL)_

[KAN-170]: https://tasteslikegood.atlassian.net/browse/KAN-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

