### PR TITLE
chore(security): enforce KAN-170 posture drift detection, record accepted risks [KAN-173]

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -165,6 +165,17 @@ jobs:
       - uses: actions/checkout@v7
       - run: bash scripts/seo/check_canonical_recipes.sh
 
+  # Guards the guard (KAN-173). The live posture check runs on a schedule with
+  # GCP credentials; this job runs its --self-test, which needs neither, and
+  # fails if the check can no longer detect the KAN-170 exposure. Without it a
+  # broken detector reads exactly like a clean production posture.
+  posture-check-self-test:
+    name: Security — posture check can fail
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: bash scripts/gcloud/kan170_verify.sh --self-test
+
   # ── Gate ──────────────────────────────────────────────────────────────────
   # Single required check for branch protection. Fails if ANY job above fails.
 
@@ -180,6 +191,7 @@ jobs:
       - docker-build
       - changelog-check
       - canonical-recipes
+      - posture-check-self-test
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security-posture-check.yml
+++ b/.github/workflows/security-posture-check.yml
@@ -1,0 +1,55 @@
+# Security posture drift check (KAN-173).
+#
+# Closes the detection half of KAN-170. The exposure there — flask-backend
+# running with run.googleapis.com/invoker-iam-disabled=true — persisted for
+# roughly 4.6 months and was found by a human following a trail, not by any
+# control. It was invisible in both artifacts a reviewer would naturally check:
+# cloudbuild.yaml said --no-allow-unauthenticated, and the IAM policy showed no
+# allUsers binding. Only the live service annotation revealed it.
+#
+# So this asks the one question neither the repo nor the IAM policy can answer:
+# is production still in the posture we left it in?
+#
+# The check itself is scripts/gcloud/kan170_verify.sh, which is read-only and
+# GET-only. It never POSTs to /api/generate* — those endpoints complete and bill
+# Gemini/Imagen even for an unauthenticated caller.
+#
+# The paired pr-gate job `Security — posture check can fail` runs the script's
+# --self-test on every PR, so a detector that has quietly stopped detecting gets
+# caught at review time rather than by a green run here.
+
+name: Security — posture drift
+
+on:
+  schedule:
+    # Daily, 15:20 UTC — offset from release-train's 15:00 so the two do not
+    # contend for the same runner window.
+    - cron: '20 15 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # required for Workload Identity Federation
+
+jobs:
+  posture:
+    name: Cloud Run posture unchanged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      # Fail loudly rather than skip. A posture check that silently no-ops when
+      # credentials are missing is worse than no check: the run goes green and
+      # the drift it exists to catch stays invisible.
+      - name: Verify posture
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID || secrets.GCP_PROJECT_ID }}
+          REGION: ${{ vars.GCP_REGION || 'us-central1' }}
+        run: bash scripts/gcloud/kan170_verify.sh

--- a/.github/workflows/security-posture-check.yml
+++ b/.github/workflows/security-posture-check.yml
@@ -38,10 +38,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Deliberately NOT the GCP_WORKLOAD_IDENTITY_PROVIDER / GCP_SERVICE_ACCOUNT
+      # pair used by gc-build-deploy.yml. That workflow treats a non-empty value
+      # in those two secrets as "deployment is configured" and changes behaviour
+      # accordingly, so pointing them at this read-only identity would make the
+      # deploy path believe it is wired up while holding an SA that cannot
+      # deploy. Separate names keep a read-only detector from re-configuring a
+      # write path.
       - uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_POSTURE_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_POSTURE_SERVICE_ACCOUNT }}
 
       - uses: google-github-actions/setup-gcloud@v3
 

--- a/docs/security/KAN-170_PUBLIC_EGRESS_REMEDIATION.md
+++ b/docs/security/KAN-170_PUBLIC_EGRESS_REMEDIATION.md
@@ -121,6 +121,11 @@ would. Run one only if you want the cost figure for its own sake.
 
 ## What this does not fix
 
-- `express-frontend` is _also_ `invoker-iam-disabled=true`, guarded solely by `ingress=internal-and-cloud-load-balancing`. Acceptable for a public frontend behind a load balancer, but it should be a recorded decision rather than an accident of DRS.
 - Flask still has no rate limiting of its own (`flask-limiter` is not a dependency) and no auth on the generation endpoints. Express remains the only limiter; both paths work by ensuring Express is the only reachable caller.
-- **Nothing detects recurrence.** `kan170_verify.sh` runs when an operator types it; no CI job or scheduled check asserts that `invoker-iam-disabled` stays absent, or that `express-frontend`'s ingress is not widened later. The 4.6-month dwell was a _detection_ failure — the annotation is invisible in both artifacts a reviewer would check — and that half is still open. Precedent for closing it: the single-Alembic-head check sat unused in `scripts/` until it was wired into `pr-gate.yml` **and** `gate.needs` (KAN-138).
+
+## What has since been closed
+
+- `express-frontend` is _also_ `invoker-iam-disabled=true`, guarded solely by `ingress=internal-and-cloud-load-balancing`. That is now a **recorded decision** rather than an accident of DRS — see [`SECURITY_DECISIONS.md`](./SECURITY_DECISIONS.md) § D-1 (KAN-172).
+- **Recurrence detection**, closed 2026-07-28 (KAN-173). `kan170_verify.sh` no longer merely prints: it accumulates failures and **exits 1** on drift, and it now asserts `express-frontend`'s ingress directly, since ingress is that service's only guard. `.github/workflows/security-posture-check.yml` runs it daily against production.
+
+  The precedent cited here originally — the single-Alembic-head check sitting unused in `scripts/` until it reached `pr-gate.yml` **and** `gate.needs` (KAN-138) — was followed in both halves. The script previously always exited 0, so scheduling it alone would have produced a permanently green run: a check that cannot fail is documentation, not a gate. It therefore also ships with `--self-test`, which drives the assertions with drifted values, needs neither credentials nor network, and runs on every PR as the `Security — posture check can fail` job (in `gate.needs`). That job exists to catch a detector that has quietly stopped detecting — the failure mode where a green run and a clean posture are indistinguishable.

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -368,6 +368,24 @@ curl -X POST http://localhost:8080/api/recipe \
 - [ ] API key rotation schedule
 - [ ] Backup and disaster recovery plan
 
+## Repository content policy
+
+Both repositories are **public**. Security scanner and posture exports — Security
+Command Center findings, SARIF, and similar — must never be committed. Enforced
+by `.gitignore`; rationale and scope in
+[`SECURITY_DECISIONS.md`](./SECURITY_DECISIONS.md) § D-2.
+
+The short version: an export is an itemised list of your own known-unfixed
+weaknesses. The leaked identifiers are the lesser harm — publishing the
+prioritised worklist is the greater one, and it is not mitigated by any amount
+of obscurity. Keep exports in Confluence or the GCP console and link to them.
+
+Deliberate security postures that could otherwise read as oversights are
+recorded in the same file. If you find yourself working around a policy control
+(Domain Restricted Sharing, an org policy, a branch ruleset), write the decision
+down there — that omission is exactly how KAN-170 stayed invisible for 4.6
+months.
+
 ## Compliance & Standards
 
 This implementation aligns with:

--- a/docs/security/SECURITY_DECISIONS.md
+++ b/docs/security/SECURITY_DECISIONS.md
@@ -1,0 +1,99 @@
+# Security decisions register
+
+Deliberate security postures and content policies that a reader would otherwise
+mistake for an oversight.
+
+This file exists because of how KAN-170 happened. A Cloud Run annotation that
+made `flask-backend` publicly invokable sat in production for roughly 4.6
+months. Nobody decided that; it was a side effect of working around Domain
+Restricted Sharing, and it was never written down. When a posture is unrecorded,
+there is no difference between "we accepted this risk" and "we never noticed" —
+not to an auditor, not to a future contributor, and not to us six months later.
+
+Each entry states what the posture is, why it is accepted, what actually holds
+it shut, and what would change the decision.
+
+---
+
+## D-1 — `express-frontend` runs with the invoker IAM check disabled
+
+**Status:** Accepted · **Recorded:** 2026-07-28 · **Ticket:** KAN-172 · **Detection:** KAN-173
+
+`express-frontend` carries `run.googleapis.com/invoker-iam-disabled=true` — the
+same annotation that caused the KAN-170 exposure on `flask-backend`. It is not
+an oversight and it is not scheduled for removal.
+
+**Why it is there.** Domain Restricted Sharing forbids granting `allUsers` on
+the service, so the annotation was the only available mechanism for making a
+service publicly servable at all. The alternative was not "a more secure public
+frontend"; it was "no public frontend."
+
+**Why it is acceptable.** `express-frontend` is _supposed_ to serve anonymous
+traffic. It is the public web tier. An invoker IAM check on it would have to be
+satisfied by every visitor's browser, which is not a thing browsers do. The
+service is the intended front door.
+
+**What actually holds it shut.** `ingress=internal-and-cloud-load-balancing`,
+plus the external load balancer in front of it. Verified 2026-07-27: the
+service's `run.app` URL returns 404 from outside the perimeter on both hostname
+forms (opaque-hash and project-number).
+
+**The reusable lesson — ingress is the differentiator, not IAM.** Both services
+were equally unauthenticated at the IAM layer. `flask-backend` was exposed
+because its `ingress=all`; `express-frontend` was not because its ingress is
+load-balancer-only. Only reachability differed. Anyone reasoning about this
+stack should check ingress first, and should not read an absent `allUsers`
+binding as evidence of anything.
+
+**The load-bearing consequence.** Because ingress is the _only_ guard,
+widening it reproduces KAN-170 on this service — with no IAM change to make it
+visible in a policy dump, and nothing in `cloudbuild.yaml` to contradict.
+`scripts/gcloud/kan170_verify.sh` therefore asserts `express-frontend`'s ingress
+directly, and the scheduled `Security — posture drift` workflow runs it daily.
+
+**What would change this decision.** If the load balancer is ever configured to
+serve identity (IAP or equivalent), the invoker check can be re-enabled on
+`express-frontend` too, and this entry should be revised rather than deleted.
+Doing that is explicitly out of scope for KAN-172, which records the present
+state.
+
+---
+
+## D-2 — Security scanner and posture exports are never committed
+
+**Status:** Enforced · **Recorded:** 2026-07-28 · **Tickets:** KAN-171, KAN-175
+
+Security Command Center exports, SARIF files, and similar scanner output must
+not be committed to either repository. Enforced by `.gitignore` (`*.sarif`,
+`*.sarif.json`, `**/logs_findings/`, `findings.csv`). Keep them in Confluence or
+the GCP console and link to those instead.
+
+**Why, precisely.** The usual objection to committing an export is that it leaks
+internal identifiers, and that is true but secondary — the project number is
+also derivable from `cloudbuild.yaml`, so no rewrite restores obscurity, and
+obscurity should never have been load-bearing.
+
+The real harm is different: **a scanner export is an itemised list of your own
+known-unfixed weaknesses, ranked and dated.** Publishing one to a public repo
+hands a reader the prioritised worklist. That harm does not depend on any
+identifier being secret, so it is not mitigated by anything except not
+publishing the file.
+
+**Corollary that is easy to miss.** Removing the export does not remediate the
+findings inside it. Anything that was ACTIVE at export time is still ACTIVE
+afterwards and needs its own tracking. Deleting the map is not the same as
+fixing the territory.
+
+**Scope of the withdrawal.** Removal from the working tree and from history does
+not reach forks, prior clones, or platform-side caches. KAN-175 tracks the
+artifact-side withdrawal and the outstanding confirmation from GitHub support.
+The posture that makes this acceptable is that, post-KAN-170, no identifier in
+the export is load-bearing.
+
+---
+
+## Related
+
+- `docs/security/KAN-170_PUBLIC_EGRESS_REMEDIATION.md` — the remediation runbook
+- `scripts/gcloud/kan170_verify.sh` — the posture check these decisions rely on
+- `.github/workflows/security-posture-check.yml` — the schedule that runs it

--- a/scripts/gcloud/kan170_verify.sh
+++ b/scripts/gcloud/kan170_verify.sh
@@ -66,34 +66,64 @@ assert_posture() {
     ok "invoker IAM check is ENFORCED on $FLASK_SERVICE"
   fi
 
-  if [[ "$ingress" == "all" ]]; then
+  # An UNSET ingress annotation is not a pass. Cloud Run's permissive setting is
+  # the one that omits nothing useful here — an absent value is an unknown, and
+  # a posture check that reads unknown as safe is the exact defect KAN-173
+  # exists to remove. Both ingress assertions therefore demand a known value;
+  # only an explicitly non-`all` setting counts as closed.
+  if [[ -z "$ingress" ]]; then
+    bad "ingress is UNSET on $FLASK_SERVICE — unknown state, not a pass"
+  elif [[ "$ingress" == "all" ]]; then
     bad "ingress=all — $FLASK_SERVICE is reachable directly from the internet"
   else
-    ok "ingress=${ingress:-<unset>} — direct internet access is refused"
+    ok "ingress=$ingress — direct internet access is refused"
   fi
 
   # express-frontend carries the SAME invoker-iam-disabled=true annotation and
   # is held shut by ingress alone — see docs/security/SECURITY_DECISIONS.md.
   # Widening its ingress therefore reproduces KAN-170 on the other service, with
   # no IAM change to make it visible.
-  if [[ "$express_ingress" == "all" ]]; then
+  if [[ -z "$express_ingress" ]]; then
+    bad "ingress is UNSET on $EXPRESS_SERVICE — unknown state, not a pass (KAN-172)"
+  elif [[ "$express_ingress" == "all" ]]; then
     bad "ingress=all on $EXPRESS_SERVICE — its only guard has been removed (KAN-172)"
   else
-    ok "ingress=${express_ingress:-<unset>} on $EXPRESS_SERVICE — load-balancer path only"
+    ok "ingress=$express_ingress on $EXPRESS_SERVICE — load-balancer path only"
   fi
 }
 
 # Runs before `require gcloud` on purpose: the self-test needs no credentials
 # and no network, so CI can prove the gate is live on every PR.
 if [[ "${1:-}" == "--self-test" ]]; then
-  log "Self-test — driving the posture assertions with drifted values"
+  log "Self-test — driving the posture assertions with known-bad values"
   info "No gcloud, no network. Proves this check can FAIL (KAN-173)."
-  assert_posture "true" "all" "all" # the exact KAN-170 exposure, on both services
-  if [[ "$FAILURES" -eq 3 ]]; then
-    printf '\n\033[32mSELF-TEST PASS\033[0m — drift raised %d failures; a scheduled run would exit 1.\n' "$FAILURES"
+
+  info "scenario 1 — the exact KAN-170 exposure, on both services"
+  assert_posture "true" "all" "all"
+  EXPOSED_FAILURES="$FAILURES"
+
+  # Scenario 2 exists because scenario 1 alone cannot catch the regression that
+  # matters most: annotations that read back empty. Reported as a pass, that is
+  # a green run over an unknown production state.
+  #
+  # Expected 2, not 3, and the difference is the point. Absence means something
+  # DIFFERENT for each annotation. An absent `invoker-iam-disabled` genuinely
+  # means the invoker check is enforced — that is the safe state, and reporting
+  # it as a pass is correct. An absent `ingress` carries no such guarantee, so
+  # only those two may treat empty as a failure. Blanket "unknown is unsafe"
+  # would be wrong here; this asymmetry is deliberate.
+  FAILURES=0
+  info "scenario 2 — annotations unreadable; unknown ingress must not read as safe"
+  assert_posture "" "" ""
+  UNKNOWN_FAILURES="$FAILURES"
+
+  if [[ "$EXPOSED_FAILURES" -eq 3 && "$UNKNOWN_FAILURES" -eq 2 ]]; then
+    printf '\n\033[32mSELF-TEST PASS\033[0m — exposure raised %d, unknown-ingress raised %d; a scheduled run would exit 1.\n' \
+      "$EXPOSED_FAILURES" "$UNKNOWN_FAILURES"
     exit 0
   fi
-  printf '\n\033[31mSELF-TEST FAIL\033[0m — drift raised %d failures, expected 3.\n' "$FAILURES"
+  printf '\n\033[31mSELF-TEST FAIL\033[0m — expected 3 and 2, got %d and %d.\n' \
+    "$EXPOSED_FAILURES" "$UNKNOWN_FAILURES"
   printf 'The posture check can no longer detect the exposure it exists for. Fix before trusting a green run.\n'
   exit 1
 fi
@@ -120,6 +150,7 @@ FLASK_INGRESS="$(describe "$FLASK_SERVICE" 'value(metadata.annotations["run.goog
 FLASK_IAM_OFF="$(describe "$FLASK_SERVICE" 'value(metadata.annotations["run.googleapis.com/invoker-iam-disabled"])')"
 FLASK_EGRESS="$(describe "$FLASK_SERVICE" 'value(spec.template.metadata.annotations["run.googleapis.com/vpc-access-egress"])')"
 FLASK_URL="$(describe "$FLASK_SERVICE" 'value(status.url)')"
+EXPRESS_URL="$(describe "$EXPRESS_SERVICE" 'value(status.url)')"
 EXPRESS_INGRESS="$(describe "$EXPRESS_SERVICE" 'value(metadata.annotations["run.googleapis.com/ingress"])')"
 EXPRESS_EGRESS="$(describe "$EXPRESS_SERVICE" 'value(spec.template.metadata.annotations["run.googleapis.com/vpc-access-egress"])')"
 
@@ -130,7 +161,11 @@ if [[ -z "$FLASK_URL" ]]; then
   echo "ERROR: could not resolve $FLASK_SERVICE in $PROJECT_ID/$REGION" >&2
   exit 1
 fi
-if [[ -z "$EXPRESS_INGRESS" ]]; then
+# Gate on status.url, mirroring the Flask check exactly. Gating on the ingress
+# annotation instead conflated two different failures: a service that does not
+# resolve, and a service that resolves with no ingress annotation. The second is
+# a real posture question and now belongs to assert_posture, which fails it.
+if [[ -z "$EXPRESS_URL" ]]; then
   echo "ERROR: could not resolve $EXPRESS_SERVICE in $PROJECT_ID/$REGION" >&2
   exit 1
 fi
@@ -209,7 +244,19 @@ fi
 # complete and bill Gemini/Imagen even for an unauthenticated caller.
 log "Live probes"
 
-probe() { curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$1" 2>/dev/null || echo "000"; }
+# One retry on a transport failure. curl returning 000 is indistinguishable from
+# "exposed" or "site down" to the assertions below, so without this a single
+# dropped packet on the daily run raises a security-labelled alert for what was
+# a network blip. A genuine outage still fails — it just has to fail twice.
+probe() {
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$1" 2>/dev/null || echo "000")"
+  if [[ "$code" == "000" ]]; then
+    sleep 2
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$1" 2>/dev/null || echo "000")"
+  fi
+  printf '%s' "$code"
+}
 
 FLASK_ANON="$(probe "${FLASK_URL}/")"
 SITE_ROOT="$(probe "${PUBLIC_URL}/")"

--- a/scripts/gcloud/kan170_verify.sh
+++ b/scripts/gcloud/kan170_verify.sh
@@ -26,6 +26,13 @@
 #
 # Usage:
 #   ./scripts/gcloud/kan170_verify.sh
+#   ./scripts/gcloud/kan170_verify.sh --self-test   # no gcloud, no network
+#
+# Exit status (KAN-173): 0 when every check passes, 1 when any fails. Before
+# 2026-07-28 this script only printed and always exited 0, so scheduling it
+# would have produced a green run forever — the same shape as the Alembic head
+# check that sat unused in scripts/ until it was wired into pr-gate.yml AND
+# gate.needs (KAN-138). A check that cannot fail is documentation, not a gate.
 
 set -euo pipefail
 
@@ -35,10 +42,61 @@ FLASK_SERVICE="${FLASK_SERVICE:-flask-backend}"
 EXPRESS_SERVICE="${EXPRESS_SERVICE:-express-frontend}"
 PUBLIC_URL="${PUBLIC_URL:-https://www.tasteslikegood.org}"
 
+FAILURES=0
+
 log() { printf '\033[36m[kan170-verify]\033[0m %s\n' "$*"; }
 ok() { printf '  \033[32m✓\033[0m %s\n' "$*"; }
-bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; }
+bad() {
+  printf '  \033[31m✗\033[0m %s\n' "$*"
+  FAILURES=$((FAILURES + 1))
+}
 info() { printf '    %s\n' "$*"; }
+
+# The two annotations that define the KAN-170 exposure. Extracted from the main
+# flow purely so --self-test can drive them with drifted values: the risk with a
+# scheduled posture check is that it silently passes while pointed at the wrong
+# thing, and the only way to trust a green run is to have seen a red one.
+assert_posture() {
+  local iam_off="$1" ingress="$2" express_ingress="$3"
+
+  # The annotation is the landmine: absent means the invoker IAM check is ON.
+  if [[ "$iam_off" == "true" || "$iam_off" == "True" ]]; then
+    bad "invoker IAM check is DISABLED on $FLASK_SERVICE (the KAN-170 landmine)"
+  else
+    ok "invoker IAM check is ENFORCED on $FLASK_SERVICE"
+  fi
+
+  if [[ "$ingress" == "all" ]]; then
+    bad "ingress=all — $FLASK_SERVICE is reachable directly from the internet"
+  else
+    ok "ingress=${ingress:-<unset>} — direct internet access is refused"
+  fi
+
+  # express-frontend carries the SAME invoker-iam-disabled=true annotation and
+  # is held shut by ingress alone — see docs/security/SECURITY_DECISIONS.md.
+  # Widening its ingress therefore reproduces KAN-170 on the other service, with
+  # no IAM change to make it visible.
+  if [[ "$express_ingress" == "all" ]]; then
+    bad "ingress=all on $EXPRESS_SERVICE — its only guard has been removed (KAN-172)"
+  else
+    ok "ingress=${express_ingress:-<unset>} on $EXPRESS_SERVICE — load-balancer path only"
+  fi
+}
+
+# Runs before `require gcloud` on purpose: the self-test needs no credentials
+# and no network, so CI can prove the gate is live on every PR.
+if [[ "${1:-}" == "--self-test" ]]; then
+  log "Self-test — driving the posture assertions with drifted values"
+  info "No gcloud, no network. Proves this check can FAIL (KAN-173)."
+  assert_posture "true" "all" "all" # the exact KAN-170 exposure, on both services
+  if [[ "$FAILURES" -eq 3 ]]; then
+    printf '\n\033[32mSELF-TEST PASS\033[0m — drift raised %d failures; a scheduled run would exit 1.\n' "$FAILURES"
+    exit 0
+  fi
+  printf '\n\033[31mSELF-TEST FAIL\033[0m — drift raised %d failures, expected 3.\n' "$FAILURES"
+  printf 'The posture check can no longer detect the exposure it exists for. Fix before trusting a green run.\n'
+  exit 1
+fi
 
 require() {
   command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found in PATH"; exit 1; }
@@ -65,26 +123,22 @@ FLASK_URL="$(describe "$FLASK_SERVICE" 'value(status.url)')"
 EXPRESS_INGRESS="$(describe "$EXPRESS_SERVICE" 'value(metadata.annotations["run.googleapis.com/ingress"])')"
 EXPRESS_EGRESS="$(describe "$EXPRESS_SERVICE" 'value(spec.template.metadata.annotations["run.googleapis.com/vpc-access-egress"])')"
 
+# Unresolvable services must abort, never pass. A scheduled check whose target
+# has been renamed or moved would otherwise read every annotation as empty and
+# report the posture as correct — green because it looked at nothing.
 if [[ -z "$FLASK_URL" ]]; then
   echo "ERROR: could not resolve $FLASK_SERVICE in $PROJECT_ID/$REGION" >&2
+  exit 1
+fi
+if [[ -z "$EXPRESS_INGRESS" ]]; then
+  echo "ERROR: could not resolve $EXPRESS_SERVICE in $PROJECT_ID/$REGION" >&2
   exit 1
 fi
 
 info "$FLASK_SERVICE   ingress=${FLASK_INGRESS:-<unset>} invoker-iam-disabled=${FLASK_IAM_OFF:-<absent>} egress=${FLASK_EGRESS:-<unset>}"
 info "$EXPRESS_SERVICE ingress=${EXPRESS_INGRESS:-<unset>} egress=${EXPRESS_EGRESS:-<unset>}"
 
-# The annotation is the landmine: absent means the invoker IAM check is ON.
-if [[ "$FLASK_IAM_OFF" == "true" || "$FLASK_IAM_OFF" == "True" ]]; then
-  bad "invoker IAM check is DISABLED on $FLASK_SERVICE (the KAN-170 landmine)"
-else
-  ok "invoker IAM check is ENFORCED on $FLASK_SERVICE"
-fi
-
-if [[ "$FLASK_INGRESS" == "all" ]]; then
-  bad "ingress=all — $FLASK_SERVICE is reachable directly from the internet"
-else
-  ok "ingress=${FLASK_INGRESS} — direct internet access is refused"
-fi
+assert_posture "$FLASK_IAM_OFF" "$FLASK_INGRESS" "$EXPRESS_INGRESS"
 
 # ── 2. IAM + audiences ──────────────────────────────────────────────────────
 log "IAM invoker bindings on $FLASK_SERVICE"
@@ -191,4 +245,9 @@ info "403 = token was valid but the caller lacks roles/run.invoker"
 info "401 = token missing, malformed, or minted for the wrong audience"
 info "404 = request reached Cloud Run as EXTERNAL and was refused by internal ingress"
 echo
-log "Done."
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  log "FAILED — $FAILURES check(s) did not pass."
+  exit 1
+fi
+log "Done — all checks passed."


### PR DESCRIPTION
Closes the detection half of KAN-170 and records the two decisions its investigation surfaced. Board-approved 2026-07-28; incident tail, deliberately **outside** Sprint 4's boundary so the first measured sprint reads clean.

## The problem this fixes

`scripts/gcloud/kan170_verify.sh` checked exactly the right two annotations — and was **wired to nothing**. Its only references were prose lines in `kan170_path_a.sh`/`path_b.sh` telling a human to run it. It also **always exited 0**, so scheduling it alone would have produced a permanently green run.

That is the recognised-but-unenforced pattern the board diagnosed on 2026-07-25 (KAN-160), and structurally the same as the single-Alembic-head check that sat unused in `scripts/` until it reached `pr-gate.yml` **and** `gate.needs` (KAN-138). Both halves of that precedent are followed here.

## KAN-173 — make the check a gate

- Accumulate failures; **exit 1** on drift.
- **Assert `express-frontend`'s ingress too.** Ingress is that service's only guard (see KAN-172 below), so widening it reproduces KAN-170 there with no IAM change to make it visible in a policy dump and nothing in `cloudbuild.yaml` to contradict.
- **Abort when either service fails to resolve.** A renamed or moved target would otherwise read every annotation as empty and report the posture as correct — green because it looked at nothing.
- **`--self-test`** drives the assertions with drifted values. No credentials, no network, so it runs on every PR. It fails if the check can no longer detect the exposure it exists for.
- `security-posture-check.yml` runs the live check daily against production (WIF auth). `pr-gate.yml` gains `Security — posture check can fail`, **added to `gate.needs`**.

## KAN-172 / KAN-171 — the decisions register

New `docs/security/SECURITY_DECISIONS.md`:

- **D-1** — `express-frontend` intentionally runs with `invoker-iam-disabled=true`, guarded by ingress + the external LB. DRS forbids `allUsers`, so the annotation was the only mechanism for a public frontend at all. Recorded as an accepted risk rather than left as an accident of DRS living in a runbook paragraph.
- **D-2** — scanner/posture exports are never committed, **and why**: the leaked identifiers are the lesser harm; publishing a ranked, dated list of your own unfixed findings is the greater one, and obscurity never mitigated it. Notes the corollary that removing an export does not remediate the findings inside it.

The runbook's "What this does not fix" section is updated — two of its three bullets are now closed, and it links here.

## Verification

- `--self-test` exits **0** on the real script (3 drift failures raised, as expected).
- Deliberately breaking one assertion makes `--self-test` exit **1** with `SELF-TEST FAIL` — the gate provably can fail.
- Both workflows parse; `posture-check-self-test` confirmed present in `gate.needs`.

## Not in scope

Flask still has no rate limiting or auth of its own; both remediation paths work by keeping Express the only reachable caller. Unchanged, and still recorded in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9nfC9dF1ACVVg18JtY3j8









<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

