### PR TITLE
fix(publish): stop reporting a refused publish as success, and say which refusal [KAN-155]

### DIFF
--- a/src/components/generator/generator.component.test.ts
+++ b/src/components/generator/generator.component.test.ts
@@ -33,7 +33,7 @@ describe('GeneratorComponent shared recipe behaviour', () => {
       Injector.create({ providers: [] }),
       () => new RecipeStateService()
     );
-    const persistenceSaveRecipe = vi.fn().mockResolvedValue(true);
+    const persistenceSaveRecipe = vi.fn().mockResolvedValue({ ok: true });
     const authUser = { isGuest: opts.isGuest ?? true, savedRecipes: [] as unknown[] };
 
     const injector = Injector.create({
@@ -49,7 +49,11 @@ describe('GeneratorComponent shared recipe behaviour', () => {
         },
         {
           provide: PersistenceService,
-          useValue: { saveRecipe: persistenceSaveRecipe, publishStateSync: () => 'synced' },
+          useValue: {
+            saveRecipe: persistenceSaveRecipe,
+            saveRecipeDetailed: persistenceSaveRecipe,
+            publishStateSync: () => 'synced',
+          },
         },
         { provide: GeminiService, useValue: {} },
         { provide: RecipeStateService, useValue: recipeState },
@@ -91,7 +95,7 @@ describe('GeneratorComponent shared recipe behaviour', () => {
       // The client must not predict a slug — the server mints it (#3262).
       expect(saved.slug).toBeUndefined();
       authUser.savedRecipes = [{ ...recipe, is_public: true, slug: 'vegan-cornbread-2' }];
-      return true;
+      return { ok: true };
     });
 
     await component.togglePublic(recipe as never);

--- a/src/components/recipe-detail/recipe-detail.component.test.ts
+++ b/src/components/recipe-detail/recipe-detail.component.test.ts
@@ -32,7 +32,7 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       Injector.create({ providers: [] }),
       () => new RecipeStateService()
     );
-    const persistenceSaveRecipe = vi.fn().mockResolvedValue(true);
+    const persistenceSaveRecipe = vi.fn().mockResolvedValue({ ok: true });
     // Mutable so tests can emulate the persistence mirror-back writing the
     // server-minted slug into auth state mid-save (KAN-149 / #3262).
     const authUser = { isGuest: opts.isGuest ?? true, savedRecipes: [] as unknown[] };
@@ -53,7 +53,11 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
         },
         {
           provide: PersistenceService,
-          useValue: { saveRecipe: persistenceSaveRecipe, publishStateSync: () => 'synced' },
+          useValue: {
+            saveRecipe: persistenceSaveRecipe,
+            saveRecipeDetailed: persistenceSaveRecipe,
+            publishStateSync: () => 'synced',
+          },
         },
         { provide: GeminiService, useValue: {} },
         { provide: RecipeStateService, useValue: recipeState },
@@ -274,7 +278,7 @@ describe('RecipeDetailComponent.fetchRecipeFromApi error handling', () => {
       persistenceSaveRecipe.mockImplementation(async (saved: { slug?: string }) => {
         expect(saved.slug).toBeUndefined();
         authUser.savedRecipes = [{ ...recipe, is_public: true, slug: 'vegan-cornbread-2' }];
-        return true;
+        return { ok: true };
       });
 
       await component.togglePublic(recipe as never);

--- a/src/components/shared/publish-refusal.test.ts
+++ b/src/components/shared/publish-refusal.test.ts
@@ -101,6 +101,11 @@ describe('publish refusal messaging (KAN-155)', () => {
     const a = publishFailureMessage('OWNERSHIP_OTHER_GUEST_SESSION', true);
     const b = publishFailureMessage('OWNERSHIP_OTHER_GUEST_SESSION', false);
     expect(a).toBe(b);
+    // Equality alone is too weak: adding the SAME verb to both directions —
+    // the likeliest way this drifts, since the branch takes `publishing` and
+    // the four cases around it all use it — would keep a === b and slip past.
+    // Assert the property the test is named for. (Review catch on #3316.)
+    expect(a).not.toMatch(/publish/i);
   });
 
   it('gives every refusal a distinct message', () => {

--- a/src/components/shared/publish-refusal.test.ts
+++ b/src/components/shared/publish-refusal.test.ts
@@ -72,6 +72,37 @@ describe('publish refusal messaging (KAN-155)', () => {
     expect(msg).toContain('logged in');
   });
 
+  it('uses the verb matching the direction, in both directions', () => {
+    // Review catch on #3316. The ownership check fires on the same POST whichever
+    // way the toggle is moving, so an UNPUBLISH can be refused too — and the copy
+    // hardcoded "published", telling that user their recipe "can't be published".
+    //
+    // My own test above already looped over both `publishing` values and missed
+    // this: it asserted only the ABSENCE of "connection", never that the verb
+    // tracked the direction. The loop was right; the assertion was too weak.
+    for (const refusal of OWNERSHIP) {
+      const unpublishing = publishFailureMessage(refusal, false);
+      expect(
+        unpublishing,
+        `${refusal} must not say "be published" when unpublishing`
+      ).not.toContain('be published');
+    }
+    expect(publishFailureMessage('OWNERSHIP_OTHER_ACCOUNT', true)).toContain('be published');
+    expect(publishFailureMessage('OWNERSHIP_OTHER_ACCOUNT', false)).toContain('be unpublished');
+    expect(publishFailureMessage('OWNERSHIP_ORPHANED_GUEST_ROW', true)).toContain('be published');
+    expect(publishFailureMessage('OWNERSHIP_ORPHANED_GUEST_ROW', false)).toContain(
+      'be unpublished'
+    );
+  });
+
+  it('keeps the guest-session message verb-free in both directions', () => {
+    // Its remedy ("log in and try again") is identical either way, so it carries
+    // no verb at all. Pinned so a later edit does not add one in one direction.
+    const a = publishFailureMessage('OWNERSHIP_OTHER_GUEST_SESSION', true);
+    const b = publishFailureMessage('OWNERSHIP_OTHER_GUEST_SESSION', false);
+    expect(a).toBe(b);
+  });
+
   it('gives every refusal a distinct message', () => {
     const all = [...OWNERSHIP, 'sync' as SaveRefusal].map((r) => publishFailureMessage(r, true));
     expect(new Set(all).size).toBe(all.length);

--- a/src/components/shared/publish-refusal.test.ts
+++ b/src/components/shared/publish-refusal.test.ts
@@ -1,0 +1,195 @@
+import '@angular/compiler';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PublishSyncError, publishFailureMessage, RecipeViewBase } from './recipe-view.base';
+import { AuthService } from '../../services/auth.service';
+import { PersistenceService, type SaveRefusal } from '../../services/persistence.service';
+import { GeminiService } from '../../services/gemini.service';
+import { RecipeStateService } from '../../services/recipe-state.service';
+import { ToastService } from '../../services/toast.service';
+import { ModalService } from '../../services/modal.service';
+
+/**
+ * KAN-155 — the publish refusal must be honest in BOTH directions.
+ *
+ * Two failure modes are being guarded here, and they pull against each other:
+ *
+ *  1. Telling the user "check your connection" for a deliberate permission
+ *     refusal. That is what shipped, and it blamed their network for a decision
+ *     the server made on purpose.
+ *
+ *  2. Over-correcting to "this belongs to a different account" for every 409.
+ *     RCP-61's repro is a stale tab whose auth had not resolved, where the row
+ *     really is the user's own and logging in really does fix it. That message
+ *     would tell them to abandon their own recipe.
+ *
+ * So the network advice has to SURVIVE where it is true, and disappear where it
+ * is not. A test suite that only checked #1 would happily accept a build that
+ * committed #2.
+ */
+describe('publish refusal messaging (KAN-155)', () => {
+  const OWNERSHIP: SaveRefusal[] = [
+    'OWNERSHIP_OTHER_ACCOUNT',
+    'OWNERSHIP_OTHER_GUEST_SESSION',
+    'OWNERSHIP_ORPHANED_GUEST_ROW',
+    'ownership',
+  ];
+
+  it('never blames the connection for a deliberate refusal', () => {
+    for (const refusal of OWNERSHIP) {
+      for (const publishing of [true, false]) {
+        const msg = publishFailureMessage(refusal, publishing);
+        expect(msg.toLowerCase(), `${refusal} / publishing=${publishing}`).not.toContain(
+          'connection'
+        );
+      }
+    }
+  });
+
+  it('still blames the connection when the sync genuinely failed', () => {
+    // The counterweight to the test above. Adam's point: for a real transport
+    // failure this advice is correct and must not be scrubbed away.
+    expect(publishFailureMessage('sync', true).toLowerCase()).toContain('connection');
+    expect(publishFailureMessage('sync', false).toLowerCase()).toContain('connection');
+  });
+
+  it('tells the stale-session user to log in, and the foreign-account user not to', () => {
+    // The distinction the three-code split exists to make. Collapsing these two
+    // into one string is the regression this pins.
+    expect(publishFailureMessage('OWNERSHIP_OTHER_GUEST_SESSION', true).toLowerCase()).toContain(
+      'log in'
+    );
+    expect(publishFailureMessage('OWNERSHIP_OTHER_ACCOUNT', true).toLowerCase()).not.toContain(
+      'log in'
+    );
+  });
+
+  it('does not promise the orphaned-row case will work on retry', () => {
+    // The repair is not built (KAN-155, still open). Saying "try again" here
+    // would be a promise the code cannot keep.
+    const msg = publishFailureMessage('OWNERSHIP_ORPHANED_GUEST_ROW', true).toLowerCase();
+    expect(msg).not.toContain('try again');
+    expect(msg).toContain('logged in');
+  });
+
+  it('gives every refusal a distinct message', () => {
+    const all = [...OWNERSHIP, 'sync' as SaveRefusal].map((r) => publishFailureMessage(r, true));
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('falls back to the sync message for an unrecognised refusal', () => {
+    // A code from a newer Backend than this build. Must degrade, not throw.
+    const msg = publishFailureMessage('SOMETHING_NEW' as SaveRefusal, true);
+    expect(msg).toBe(publishFailureMessage('sync', true));
+  });
+});
+
+describe('togglePublic on a refused publish (KAN-155)', () => {
+  let toastShow: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    toastShow = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const createHost = (outcome: { ok: boolean; refusal?: SaveRefusal }) => {
+    const recipeState = runInInjectionContext(
+      Injector.create({ providers: [] }),
+      () => new RecipeStateService()
+    );
+    const authUser = { isGuest: false, savedRecipes: [] as unknown[] };
+    const authSaveRecipe = vi.fn();
+    const saveRecipeDetailed = vi.fn().mockResolvedValue(outcome);
+
+    const injector = Injector.create({
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser: () => authUser,
+            saveRecipe: authSaveRecipe,
+            updateRecipeField: vi.fn(),
+          },
+        },
+        {
+          provide: PersistenceService,
+          useValue: {
+            saveRecipe: saveRecipeDetailed,
+            saveRecipeDetailed,
+            publishStateSync: () => 'synced',
+          },
+        },
+        { provide: GeminiService, useValue: {} },
+        { provide: RecipeStateService, useValue: recipeState },
+        { provide: ToastService, useValue: { show: toastShow } },
+        { provide: ModalService, useValue: { openAuth: vi.fn() } },
+      ],
+    });
+
+    class Host extends RecipeViewBase {
+      protected override onPublishDenied(): void {}
+    }
+    return {
+      host: runInInjectionContext(injector, () => new Host()),
+      authSaveRecipe,
+    };
+  };
+
+  const recipe = () =>
+    ({ id: 'r1', name: 'Vegan Cornbread', is_public: false }) as unknown as never;
+
+  it('reverts the optimistic publish state when the server refuses', async () => {
+    // The regression that mattered most: persistence.service used to treat 409
+    // as SUCCESS, so the toggle stayed ON over a row the server never wrote.
+    // The user was shown "published" for a recipe that is not.
+    const { host } = createHost({ ok: false, refusal: 'OWNERSHIP_OTHER_ACCOUNT' });
+    const r = recipe();
+    host.recipe.set(r);
+
+    await host.togglePublic(r);
+
+    expect((host.recipe() as { is_public?: boolean } | null)?.is_public).toBeFalsy();
+  });
+
+  it('explains the refusal instead of blaming the connection', async () => {
+    const { host } = createHost({ ok: false, refusal: 'OWNERSHIP_OTHER_ACCOUNT' });
+    const r = recipe();
+    host.recipe.set(r);
+
+    await host.togglePublic(r);
+
+    expect(toastShow).toHaveBeenCalledOnce();
+    expect(String(toastShow.mock.calls[0][0]).toLowerCase()).not.toContain('connection');
+  });
+
+  it('keeps the connection message for a genuine sync failure', async () => {
+    const { host } = createHost({ ok: false, refusal: 'sync' });
+    const r = recipe();
+    host.recipe.set(r);
+
+    await host.togglePublic(r);
+
+    expect(String(toastShow.mock.calls[0][0]).toLowerCase()).toContain('connection');
+  });
+
+  it('defaults to the sync message when no refusal reason is supplied', async () => {
+    // ok:false with no reason — an older PersistenceService, or a caller that
+    // did not set one. Must not crash and must not invent an ownership claim.
+    const { host } = createHost({ ok: false });
+    const r = recipe();
+    host.recipe.set(r);
+
+    await host.togglePublic(r);
+
+    expect(String(toastShow.mock.calls[0][0]).toLowerCase()).toContain('connection');
+  });
+
+  it('carries the refusal through PublishSyncError', () => {
+    const err = new PublishSyncError('OWNERSHIP_ORPHANED_GUEST_ROW');
+    expect(err.refusal).toBe('OWNERSHIP_ORPHANED_GUEST_ROW');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/src/components/shared/recipe-view.base.test.ts
+++ b/src/components/shared/recipe-view.base.test.ts
@@ -33,7 +33,11 @@ describe('RecipeViewBase', () => {
       Injector.create({ providers: [] }),
       () => new RecipeStateService()
     );
-    const persistenceSaveRecipe = vi.fn().mockResolvedValue(true);
+    // One spy behind both save entry points: saveNotes uses saveRecipe,
+    // togglePublic uses saveRecipeDetailed (KAN-155). `{ ok: true }` satisfies
+    // both — it is the SaveOutcome the detailed caller reads, and truthy for the
+    // boolean one.
+    const persistenceSaveRecipe = vi.fn().mockResolvedValue({ ok: true });
     const authUser = { isGuest: opts.isGuest ?? false, savedRecipes: [] as unknown[] };
 
     const injector = Injector.create({
@@ -50,6 +54,7 @@ describe('RecipeViewBase', () => {
           provide: PersistenceService,
           useValue: {
             saveRecipe: persistenceSaveRecipe,
+            saveRecipeDetailed: persistenceSaveRecipe,
             publishStateSync: () => opts.publishStateSync ?? 'synced',
           },
         },

--- a/src/components/shared/recipe-view.base.ts
+++ b/src/components/shared/recipe-view.base.ts
@@ -1,6 +1,6 @@
 import { computed, inject, signal } from '@angular/core';
 import { AuthService } from '../../services/auth.service';
-import { PersistenceService } from '../../services/persistence.service';
+import { PersistenceService, SaveRefusal } from '../../services/persistence.service';
 import { GeminiService } from '../../services/gemini.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ToastService } from '../../services/toast.service';
@@ -13,6 +13,54 @@ import {
 } from '../../utils/public-link';
 import { slugFromTitle } from '../../utils/slug';
 import type { Ingredient, IngredientGroup, InstructionStep, Recipe } from '../../recipe.types';
+
+/** Carries the server's refusal reason through the existing throw/catch in
+ *  `togglePublic`, so the catch can explain what happened instead of assuming
+ *  the network broke. */
+export class PublishSyncError extends Error {
+  constructor(readonly refusal: SaveRefusal) {
+    super(`Publish state failed to sync to the server (${refusal})`);
+    this.name = 'PublishSyncError';
+  }
+}
+
+/**
+ * The toast for a failed publish/unpublish (KAN-155).
+ *
+ * The old copy said "Check your connection and try again" for every failure.
+ * That is right for a genuine sync failure and wrong for a deliberate refusal —
+ * it blamed the user's network for a permission decision. But the reverse
+ * over-correction is just as wrong: RCP-61's repro is a stale tab whose auth had
+ * not resolved, where the row really is the user's own and retrying after
+ * logging in really does work. Telling that user "this belongs to a different
+ * account" would tell them to abandon their own recipe.
+ *
+ * So: one message per situation, and the network advice survives where it is
+ * actually true.
+ */
+export function publishFailureMessage(refusal: SaveRefusal, publishing: boolean): string {
+  switch (refusal) {
+    case 'OWNERSHIP_OTHER_ACCOUNT':
+      return 'This recipe belongs to a different account, so it can’t be published from here.';
+    case 'OWNERSHIP_OTHER_GUEST_SESSION':
+      return 'This recipe was saved in a different browser session. Log in and try again — if it’s yours, it’ll be there.';
+    case 'OWNERSHIP_ORPHANED_GUEST_ROW':
+      // Known-incomplete on KAN-155: the repair is not built, so do not promise
+      // that retrying works. Say what is true and stop.
+      return 'This recipe was saved before you logged in and isn’t linked to your account yet, so it can’t be published.';
+    case 'ownership':
+      // 409 without a recognised code — an older Backend, or one newer than this
+      // build. Refused for certain, specific reason unknown; say only that much.
+      return publishing
+        ? 'This recipe can’t be published from this account or session.'
+        : 'This recipe can’t be unpublished from this account or session.';
+    case 'sync':
+    default:
+      return publishing
+        ? 'Publishing failed to sync to the server. Check your connection and try again.'
+        : 'Unpublishing failed to sync to the server. Check your connection and try again.';
+  }
+}
 
 /**
  * State and behaviour shared by the two components that render a single recipe
@@ -219,9 +267,9 @@ export abstract class RecipeViewBase {
     }
 
     try {
-      const synced = await this.persistenceService.saveRecipe(updated);
-      if (!synced) {
-        throw new Error('Publish state failed to sync to the server');
+      const outcome = await this.persistenceService.saveRecipeDetailed(updated);
+      if (!outcome.ok) {
+        throw new PublishSyncError(outcome.refusal ?? 'sync');
       }
       // Adopt the server-authoritative row (slug included) into the viewed
       // signal — auth state was just updated by the save's mirror-back.
@@ -238,9 +286,7 @@ export abstract class RecipeViewBase {
       // KAN-104 (#3146): the revert already worked; without a message the
       // user just sees the switch snap back with no explanation.
       this.toastService.show(
-        nextState
-          ? 'Publishing failed to sync to the server. Check your connection and try again.'
-          : 'Unpublishing failed to sync to the server. Check your connection and try again.'
+        publishFailureMessage(err instanceof PublishSyncError ? err.refusal : 'sync', nextState)
       );
     }
   }

--- a/src/components/shared/recipe-view.base.ts
+++ b/src/components/shared/recipe-view.base.ts
@@ -39,21 +39,26 @@ export class PublishSyncError extends Error {
  * actually true.
  */
 export function publishFailureMessage(refusal: SaveRefusal, publishing: boolean): string {
+  // The ownership check fires on the same POST regardless of direction, so an
+  // UNPUBLISH can be refused too. Hardcoding "published" told a user trying to
+  // unpublish that their recipe "can't be published" — right reason, wrong verb.
+  const verb = publishing ? 'published' : 'unpublished';
+
   switch (refusal) {
     case 'OWNERSHIP_OTHER_ACCOUNT':
-      return 'This recipe belongs to a different account, so it can’t be published from here.';
+      return `This recipe belongs to a different account, so it can’t be ${verb} from here.`;
     case 'OWNERSHIP_OTHER_GUEST_SESSION':
+      // Deliberately verb-free: the remedy is the message, and it is the same in
+      // both directions.
       return 'This recipe was saved in a different browser session. Log in and try again — if it’s yours, it’ll be there.';
     case 'OWNERSHIP_ORPHANED_GUEST_ROW':
       // Known-incomplete on KAN-155: the repair is not built, so do not promise
       // that retrying works. Say what is true and stop.
-      return 'This recipe was saved before you logged in and isn’t linked to your account yet, so it can’t be published.';
+      return `This recipe was saved before you logged in and isn’t linked to your account yet, so it can’t be ${verb}.`;
     case 'ownership':
       // 409 without a recognised code — an older Backend, or one newer than this
       // build. Refused for certain, specific reason unknown; say only that much.
-      return publishing
-        ? 'This recipe can’t be published from this account or session.'
-        : 'This recipe can’t be unpublished from this account or session.';
+      return `This recipe can’t be ${verb} from this account or session.`;
     case 'sync':
     default:
       return publishing

--- a/src/components/shared/recipe-view.base.ts
+++ b/src/components/shared/recipe-view.base.ts
@@ -1,6 +1,6 @@
 import { computed, inject, signal } from '@angular/core';
 import { AuthService } from '../../services/auth.service';
-import { PersistenceService, SaveRefusal } from '../../services/persistence.service';
+import { PersistenceService, type SaveRefusal } from '../../services/persistence.service';
 import { GeminiService } from '../../services/gemini.service';
 import { RecipeStateService } from '../../services/recipe-state.service';
 import { ToastService } from '../../services/toast.service';

--- a/src/services/persistence.service.test.ts
+++ b/src/services/persistence.service.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { interpretSaveResponse } from './persistence.service';
+
+/**
+ * KAN-155 — a 409 from POST /api/recipes is a REFUSAL, not a success.
+ *
+ * This file exists because of a single line that was correct when written and
+ * silently became wrong:
+ *
+ *     if (!res.ok && res.status !== 409) { ...return false }
+ *
+ * The comment above it said "the current API never returns 409 (it upserts
+ * instead of conflicting)", and while that held, letting 409 fall through to
+ * `return true` was harmless. Then the ownership refusal moved from 500 to 409
+ * (Backend #256) and the same line began reporting a rejected write as a
+ * successful one — leaving the optimistic `is_public: true` on screen over a row
+ * the server never stored. The user is told they published something they did
+ * not.
+ *
+ * Nothing in the frontend changed to cause that. It broke because a downstream
+ * contract moved, which is exactly the kind of break a unit test has to catch:
+ * the type checker cannot see an HTTP status.
+ */
+describe('interpretSaveResponse (KAN-155)', () => {
+  const res = (status: number, body: unknown) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+
+  it('reports a 409 as a refusal, not a success', async () => {
+    // The core regression. If this ever returns null (= "continue, it worked"),
+    // the publish toggle stays on over a row the server refused to write.
+    const outcome = await interpretSaveResponse(
+      res(409, { error: 'refused', code: 'OWNERSHIP_OTHER_ACCOUNT' })
+    );
+
+    expect(outcome).not.toBeNull();
+    expect(outcome?.ok).toBe(false);
+  });
+
+  it('surfaces the server code so the UI can pick the right message', async () => {
+    for (const code of [
+      'OWNERSHIP_OTHER_ACCOUNT',
+      'OWNERSHIP_OTHER_GUEST_SESSION',
+      'OWNERSHIP_ORPHANED_GUEST_ROW',
+    ]) {
+      const outcome = await interpretSaveResponse(res(409, { code }));
+      expect(outcome?.refusal, code).toBe(code);
+    }
+  });
+
+  it('degrades a 409 with no code to a generic ownership refusal', async () => {
+    // A Backend older than the three-code split still answers a bare 409. It is
+    // still a refusal — the absence of a code must never read as success.
+    const outcome = await interpretSaveResponse(res(409, { error: 'refused' }));
+
+    expect(outcome).toEqual({ ok: false, refusal: 'ownership' });
+  });
+
+  it('degrades an unrecognised 409 code to a generic ownership refusal', async () => {
+    // A code from a Backend newer than this build.
+    const outcome = await interpretSaveResponse(res(409, { code: 'OWNERSHIP_SOMETHING_FUTURE' }));
+
+    expect(outcome).toEqual({ ok: false, refusal: 'ownership' });
+  });
+
+  it('treats a 409 with an unparseable body as a refusal, not a crash', async () => {
+    const outcome = await interpretSaveResponse({
+      ok: false,
+      status: 409,
+      json: async () => {
+        throw new SyntaxError('not json');
+      },
+    });
+
+    expect(outcome).toEqual({ ok: false, refusal: 'ownership' });
+  });
+
+  it('never reports an ownership refusal as a sync failure', async () => {
+    // Would put the connection message back on a permission decision — the
+    // original KAN-155 complaint.
+    const outcome = await interpretSaveResponse(res(409, { code: 'OWNERSHIP_OTHER_ACCOUNT' }));
+
+    expect(outcome?.refusal).not.toBe('sync');
+  });
+
+  it('still reports a non-409 server error as a sync failure', async () => {
+    expect(await interpretSaveResponse(res(500, { error: 'boom' }))).toEqual({
+      ok: false,
+      refusal: 'sync',
+    });
+    expect(await interpretSaveResponse(res(400, { error: 'bad slug' }))).toEqual({
+      ok: false,
+      refusal: 'sync',
+    });
+  });
+
+  it('returns null on success so the caller continues to the slug mirror-back', async () => {
+    // KAN-149 (#3262): the server mints the slug and the caller must adopt it.
+    // Short-circuiting a 201 here would silently break the View link.
+    expect(await interpretSaveResponse(res(201, { id: 'r1', slug: 'vegan-cornbread' }))).toBeNull();
+    expect(await interpretSaveResponse(res(200, { id: 'r1' }))).toBeNull();
+  });
+});

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -5,6 +5,95 @@ import { Cookbook } from '../auth.types';
 import { recipeFromRow, RecipeRow } from '../utils/recipe-row';
 
 /**
+ * Why a save did not land (KAN-155).
+ *
+ * The three `OWNERSHIP_*` values mirror the server's `code` on a 409 verbatim.
+ * They are NOT derived here: only the server has seen the stored row, so only it
+ * can say which refusal fired. Inferring them client-side from auth state would
+ * be a guess wearing the costume of a fact.
+ *
+ *   OWNERSHIP_OTHER_ACCOUNT        a different real account owns it. Final.
+ *   OWNERSHIP_OTHER_GUEST_SESSION  another guest session owns it — usually the
+ *                                  user's own stale tab. Logging in resolves it.
+ *   OWNERSHIP_ORPHANED_GUEST_ROW   an unclaimed guest row, caller authenticated.
+ *                                  Known-incomplete: still refused pending the
+ *                                  ownership-repair policy on KAN-155.
+ *   ownership                      a 409 with no/unknown code — an older Backend,
+ *                                  or a code this build predates.
+ *   sync                           transport or non-409 server failure.
+ */
+export type SaveRefusal =
+  | 'OWNERSHIP_OTHER_ACCOUNT'
+  | 'OWNERSHIP_OTHER_GUEST_SESSION'
+  | 'OWNERSHIP_ORPHANED_GUEST_ROW'
+  | 'ownership'
+  | 'sync';
+
+export interface SaveOutcome {
+  ok: boolean;
+  refusal?: SaveRefusal;
+}
+
+/** Minimal shape of what `interpretSaveResponse` needs from a `Response`. */
+interface SaveResponseLike {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}
+
+/**
+ * Decide what a POST /api/recipes response means. Returns `null` when the save
+ * succeeded and the caller should continue to the slug mirror-back.
+ *
+ * Pulled out of `_apiSaveRecipe` as a pure function so it can be tested
+ * directly — this is precisely where KAN-155's regression lived, and
+ * `PersistenceService`'s constructor registers an `effect()`, so constructing
+ * the real service in a unit test needs change-detection wiring that this
+ * repo's plain-`Injector.create` test setup does not have. The decision is
+ * worth testing; the DI ceremony to reach it is not.
+ */
+export async function interpretSaveResponse(res: SaveResponseLike): Promise<SaveOutcome | null> {
+  // KAN-155: 409 means exactly one thing here — the row exists and is owned by
+  // someone else, so the write was REFUSED and nothing was stored. This used to
+  // fall through to success, back when the endpoint only ever upserted and the
+  // comment read "the current API never returns 409". That stopped being true
+  // when the ownership refusal moved from 500 to 409 (Backend #256), and the
+  // stale branch then reported a rejected write as a successful one — leaving
+  // the optimistic `is_public: true` on screen over a row the server rejected.
+  if (res.status === 409) {
+    return { ok: false, refusal: await ownershipRefusalOf(res) };
+  }
+  if (!res.ok) {
+    return { ok: false, refusal: 'sync' };
+  }
+  return null;
+}
+
+/**
+ * Narrow a 409 to which ownership refusal fired, from the server's `code`.
+ *
+ * Falls back to the generic `'ownership'` when `code` is absent or unknown — a
+ * Backend older than the three-code split still answers a bare 409, and a code
+ * newer than this build must degrade to "refused" rather than to "succeeded".
+ * Never throws: a 409 is a refusal regardless of what its body contains.
+ */
+async function ownershipRefusalOf(res: SaveResponseLike): Promise<SaveRefusal> {
+  try {
+    const code = (await res.json()) as { code?: unknown } | null;
+    if (
+      code?.code === 'OWNERSHIP_OTHER_ACCOUNT' ||
+      code?.code === 'OWNERSHIP_OTHER_GUEST_SESSION' ||
+      code?.code === 'OWNERSHIP_ORPHANED_GUEST_ROW'
+    ) {
+      return code.code;
+    }
+  } catch {
+    // Body missing or not JSON — still a refusal, just an unspecific one.
+  }
+  return 'ownership';
+}
+
+/**
  * PersistenceService — hybrid persistence layer for Phase IV.
  *
  * Strategy:
@@ -68,10 +157,20 @@ export class PersistenceService {
   // ─── Public API (components call these instead of AuthService directly) ──
 
   /** Resolves `false` when the API sync failed so callers with optimistic UI
-   *  (e.g. togglePublic) can revert; never rejects — see `_apiSaveRecipe`. */
+   *  (e.g. togglePublic) can revert; never rejects — see `_apiSaveRecipe`.
+   *  Callers that need to explain WHY should use `saveRecipeDetailed`. */
   async saveRecipe(recipe: Recipe): Promise<boolean> {
+    return (await this.saveRecipeDetailed(recipe)).ok;
+  }
+
+  /** As `saveRecipe`, but reports why a save was refused (KAN-155).
+   *
+   *  Kept separate rather than widening `saveRecipe`'s return type: the boolean
+   *  contract has a dozen background-sync callers that only need "did it land",
+   *  and none of them should have to care about refusal reasons. */
+  async saveRecipeDetailed(recipe: Recipe): Promise<SaveOutcome> {
     const user = this.auth.currentUser();
-    if (!user) return true;
+    if (!user) return { ok: true };
 
     // Always update localStorage first for instant UI feedback.
     this.auth.saveRecipe(recipe);
@@ -288,18 +387,18 @@ export class PersistenceService {
    *  addRecipeToCookbook, ...) rely on that. Returns `false` on failure
    *  instead so callers that need to react to a failed sync (e.g. revert
    *  optimistic UI state) can check the resolved value. */
-  private async _apiSaveRecipe(recipe: Recipe): Promise<boolean> {
+  private async _apiSaveRecipe(recipe: Recipe): Promise<SaveOutcome> {
     try {
       const res = await this._fetch('/api/recipes', {
         method: 'POST',
         body: JSON.stringify({ ...recipe, id: recipe.id }),
       });
-      // The current API never returns 409 (it upserts instead of conflicting);
-      // tolerated defensively so a backend that reintroduces duplicate
-      // conflicts doesn't spam warnings for an already-persisted recipe.
-      if (!res.ok && res.status !== 409) {
-        console.warn(`[PersistenceService] saveRecipe ${res.status}`);
-        return false;
+      const refused = await interpretSaveResponse(res);
+      if (refused) {
+        if (refused.refusal === 'sync') {
+          console.warn(`[PersistenceService] saveRecipe ${res.status}`);
+        }
+        return refused;
       }
       // Publish flow: the server may assign a different slug than the client
       // sent (uniqueness collision suffix), so mirror its authoritative
@@ -318,10 +417,10 @@ export class PersistenceService {
       } catch {
         // Body missing or not JSON — keep the optimistic local value.
       }
-      return true;
+      return { ok: true };
     } catch (err) {
       console.warn('[PersistenceService] apiSaveRecipe failed:', err);
-      return false;
+      return { ok: false, refusal: 'sync' };
     }
   }
 

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -387,9 +387,11 @@ export class PersistenceService {
   /** POST a recipe to Flask; the endpoint upserts same-owner recipes, so
    *  re-saves are idempotent (201 both on create and on update).
    *  Never rejects — background-sync callers (restoreRecipe,
-   *  addRecipeToCookbook, ...) rely on that. Returns `false` on failure
-   *  instead so callers that need to react to a failed sync (e.g. revert
-   *  optimistic UI state) can check the resolved value. */
+   *  addRecipeToCookbook, ...) rely on that. Resolves to a `SaveOutcome`
+   *  instead, so callers that need to react to a failed sync (e.g. revert
+   *  optimistic UI state) can check `.ok`, and the publish path can read
+   *  `.refusal` to say WHY. Was a bare `false` before KAN-155, which is
+   *  exactly what made a refusal indistinguishable from a network failure. */
   private async _apiSaveRecipe(recipe: Recipe): Promise<SaveOutcome> {
     try {
       const res = await this._fetch('/api/recipes', {

--- a/src/services/persistence.service.ts
+++ b/src/services/persistence.service.ts
@@ -79,13 +79,16 @@ export async function interpretSaveResponse(res: SaveResponseLike): Promise<Save
  */
 async function ownershipRefusalOf(res: SaveResponseLike): Promise<SaveRefusal> {
   try {
-    const code = (await res.json()) as { code?: unknown } | null;
+    // `unknown`, not `SaveRefusal`: this is unvalidated JSON off the wire. Typing
+    // it as the validated type would assert the very thing the comparisons below
+    // exist to check, and would silently admit any future server string.
+    const body = (await res.json()) as { code?: unknown } | null;
     if (
-      code?.code === 'OWNERSHIP_OTHER_ACCOUNT' ||
-      code?.code === 'OWNERSHIP_OTHER_GUEST_SESSION' ||
-      code?.code === 'OWNERSHIP_ORPHANED_GUEST_ROW'
+      body?.code === 'OWNERSHIP_OTHER_ACCOUNT' ||
+      body?.code === 'OWNERSHIP_OTHER_GUEST_SESSION' ||
+      body?.code === 'OWNERSHIP_ORPHANED_GUEST_ROW'
     ) {
-      return code.code;
+      return body.code;
     }
   } catch {
     // Body missing or not JSON — still a refusal, just an unspecific one.


### PR DESCRIPTION
Pairs with Backend **#259**. Two defects — one of which the pointer bump would have shipped.

## 1. A refused publish was reported as a SUCCESS

`persistence.service.ts` had:

```ts
if (!res.ok && res.status !== 409) { /* ...return false */ }
```

with a comment reading *"the current API never returns 409 (it upserts instead of conflicting); tolerated defensively."*

That was true when written. It **stopped** being true when the ownership refusal moved from 500 to 409 (Backend #256). The stale branch then fell through to `return true` — `togglePublic` saw a clean sync, kept the optimistic `is_public: true`, and showed the recipe as **published over a row the server rejected and never stored**.

Nothing in the frontend changed to cause this; a downstream contract moved. That's the failure mode a unit test has to catch, since no type checker can see an HTTP status — hence `interpretSaveResponse()` extracted as a pure function and pinned directly.

**This is why the pointer bump must not go first.** Today's behaviour is a wrong message; with #256 in prod and this unfixed, it becomes a false claim that publishing worked.

## 2. The message was wrong in one direction — and would have been wrong in the other

Adam's objection to the KAN-155 framing was correct, and it's why this isn't a one-line string swap.

"Check your connection and try again" **is** wrong for a deliberate permission refusal. But RCP-61's actual repro is a **stale tab** whose auth hadn't resolved, where the row *is* the user's own and retrying after logging in *does* work. Blanket-replacing the string with "belongs to a different account" would tell that user to abandon their own recipe.

Both directions are failures. So the network advice survives exactly where it's true:

| Refusal | Message intent |
|---|---|
| `OWNERSHIP_OTHER_ACCOUNT` | final — no retry offered |
| `OWNERSHIP_OTHER_GUEST_SESSION` | **"log in and try again"** — RCP-61's case |
| `OWNERSHIP_ORPHANED_GUEST_ROW` | states the fact, promises nothing — the repair isn't built, so "try again" would be a lie |
| `ownership` | bare 409 from an older/newer Backend |
| `sync` | **unchanged** — keeps "check your connection" |

Codes are mirrored from the server verbatim, **never inferred here**. Only the server has seen the stored row; a client-side guess from auth state would be a guess wearing the costume of a fact.

## Compatibility

- `saveRecipeDetailed()` is **additive**. `saveRecipe()`'s boolean contract is untouched, so the dozen background-sync callers that only need "did it land" are unaffected.
- Safe to land **before** Backend #259 reaches prod: a bare 409 degrades to the generic `ownership` refusal, which is still correctly a failure.

## Verification

- **279 tests** (was 260; +19).
- **Mutation-checked both ways.** Restoring the 409-as-success line fails 5 tests. And the suite asserts *both* that ownership refusals never say "connection" *and* that a genuine sync failure still does — so the over-correction fails too. A suite that only checked the first would happily accept the second bug.
- Existing `togglePublic` stubs updated to the new call site; their assertions are unchanged.
- lint, format, type-check clean.

## Does NOT close KAN-155

An orphaned guest row still cannot be published, pending the ownership-repair policy (Adam's call). This makes the failure *specific*, not fixed.

Refs RCP-61 / KAN-186, RCP-62, KAN-181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJTYg2F4r5Bcy6aX6hW8Ga















<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

