### PR TITLE
chore(release): bump Backend pointer to 73fb091, cut v0.4.8 [KAN-155]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,69 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.4.8] - 2026-07-31
+
+Backend submodule pointer: `0de1e2b` → **`73fb091`**, carrying the KAN-155
+ownership-refusal work from Backend
+[#256](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/256),
+[#259](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/259) and
+[#261](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/261).
+Single Alembic head (`e4a7b2d9c5f1`) and no new migrations in the range, so
+`flask-backend-migrate` runs as a no-op.
+
+### Fixed
+
+- **A refused publish is no longer reported as a success** (KAN-155,
+  [#3316](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3316)
+  - Backend #256/#259). Publishing a recipe whose row belongs to another
+    account or another guest session was refused by the server and shown to the
+    user as _published_: the toggle stayed on over a row that was never written.
+    The refusal now propagates as a structured outcome instead of collapsing
+    into a bare `false`, the optimistic UI state reverts, and the toast says
+    which refusal fired rather than blaming the network for a permission
+    decision. The message also tracks the toggle direction — an unpublish that
+    was refused used to report that the recipe "can't be **published**".
+
+  Three server-side cases are distinguished, each with its own remedy: a
+  different real account owns it (final); another guest session owns it (log
+  in and retry — the RCP-61 stale-tab case, where retrying genuinely works);
+  and an unclaimed guest row with the caller authenticated (no repair exists
+  yet, so the copy does not promise that retrying helps). An unrecognised or
+  missing code degrades to a generic refusal, never to success.
+
+- **Sprint plans now reach Confluence** (KAN-187,
+  [#3315](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3315)).
+  The PM sync watched a hardcoded 7-file list that named a 182-byte
+  `SPRINT_0_PLAN.md` stub and omitted `SPRINT_1..4_PLAN.md` — roughly 91 KB of
+  real planning that had never been published, across four sprints, while
+  `sync_pm_documents` reported "Sync successful" every time. Sprint plans are
+  now matched by glob so future sprints need no code change, the file set is
+  defined once in `scripts/pm/_canonical_pm_files.py` and imported by both the
+  daemon and the SessionStart briefing hook, and the sync names how many files
+  it considered so an omission is visible instead of indistinguishable from
+  success.
+
+### Security
+
+- **`flask-backend` is no longer publicly invokable** (KAN-170/KAN-171/KAN-173,
+  [#3303](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3303),
+  [#3305](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3305),
+  [#3307](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3307)).
+  `--invoker-iam-check` is persisted in `cloudbuild.yaml` so the setting
+  survives redeploys, and posture-drift detection runs on a dedicated
+  read-only Workload Identity Federation identity. The detection workflow was
+  previously unrunnable — no WIF provider existed — so it passed while
+  detecting nothing; it is now proven to fail for the reason it exists
+  (KAN-176).
+
+### Changed
+
+- Sprint 4 re-cut to a single lane on KAN-155, with the borrowed Monte Carlo
+  forecast formally withdrawn: it was computed over KAN throughput and
+  presented as a forecast for an RCP board that has run zero sprints.
+- `gh-aw` bumped to v0.83.4; the MCP-gateway firewall-denial root cause is
+  documented (KAN-134).
+
 ## [0.4.7] - 2026-07-27
 
 Backend submodule pointer: `38736da` → **`0de1e2b`** (Backend `main` tip,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@angular/build": "22.0.8",
         "@angular/cli": "22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
Step 4 + 6 of the release train: bumps the Backend submodule pointer and cuts **v0.4.8**. Four files, nothing else — the payload itself is already on `dev`.

## Pointer

`0de1e2b` → **`73fb091`**

Picks up the KAN-155 ownership-refusal work that cookbook [#3316](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3316) — already merged to `dev` — depends on at runtime:

| Backend PR | What it adds |
| --- | --- |
| [#256](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/256) | The ownership refusal returns a legible 409 instead of a bare `None` → 500 |
| [#259](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/259) | Splits that 409 into three codes the client can act on, and logs *which* refusal fired |
| [#261](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/261) | Promotes the above to Backend `main` |

**Why #261 existed, and why it gated this PR.** Backend #258 promoted `dev → main` at 19:17 on 07-30 — *before* #259 landed on `dev` at 03:43 the next morning. So `main` carried #256 without the three-code split, and the promotion step looked complete while the code was not there. Verified by content rather than by the step list:

```
$ git merge-base --is-ancestor 9ceb360 origin/main     # #259's merge commit
  -> false
$ git show origin/main:repositories/db_recipe_repository.py | grep -c OWNERSHIP_OTHER_ACCOUNT
  0
$ git show origin/dev:repositories/db_recipe_repository.py  | grep -c OWNERSHIP_OTHER_ACCOUNT
  1
```

Pinning ahead of that would not have crashed anything — #3316's degrade path is tested and falls back to a generic `'ownership'` message — which is exactly why it would have shipped unnoticed, with the three specific refusals dark and a post-release walkthrough reading as a failed fix. #261 has since merged; `73fb091` is now an ancestor of Backend `main`, so the pin exists on both lanes as the release order requires.

## Version and tag

`0.4.7` → **`0.4.8`** in `package.json` and both self-references in `package-lock.json`.

No tag is pushed here. On the follow-up `dev → main` merge, `release.yml` reads `version` from `package.json`, creates and pushes **`v0.4.8`**, and publishes the GitHub Release from the matching CHANGELOG section. That tag push is what hits the Cloud Build trigger (`^v[0-9]+\.[0-9]+\.[0-9]+$`) and deploys. **Merging *this* PR to `dev` fires no build.**

## CHANGELOG

New `## [0.4.8]` section covering what actually reaches users:

- **Fixed** — a refused publish is no longer reported as a success (KAN-155, #3316 + Backend #256/#259), including the direction-tracking verb fix and the three distinct refusal remedies.
- **Fixed** — sprint plans now reach Confluence (KAN-187, [#3315](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3315)); ~91 KB of planning across four sprints had never synced while the tool reported success every time.
- **Security** — `flask-backend` no longer publicly invokable (KAN-170/171/173, #3303/#3305/#3307), with the posture-drift detector now running on a real WIF identity rather than passing while detecting nothing (KAN-176).
- **Changed** — Sprint 4 single-lane re-cut, withdrawn Monte Carlo forecast, `gh-aw` v0.83.4.

## Verification

- **Alembic:** `flask db heads` at `73fb091` → `e4a7b2d9c5f1`, exactly one head. No new migrations in `0de1e2b..73fb091`, so the `flask-backend-migrate` Job runs as a no-op. A second head here would have broken the deploy.
- **Pointer is on `main`:** `git merge-base --is-ancestor 73fb091 origin/main` → true.
- **CHANGELOG gate:** section `[0.4.8]` matches `package.json`, so *CHANGELOG entry for this version* passes.
- **`format:check`** clean (the CHANGELOG needed one Prettier pass).
- Branch is current with `origin/dev` — zero commits behind at time of opening.

## Release order from here

1. **this PR → `dev`** — no build
2. cookbook `dev → main` — no build; `release.yml` tags `v0.4.8`
3. tag push → Cloud Build → migrate Job → `flask-backend` → `express-frontend`
4. back-sync `main → dev`, and Backend `main → dev` (owed: `main` is 1 ahead after #261)

Post-deploy, KAN-155 still needs its production walkthrough — with no staging environment (KAN-182) that verification cannot happen before the deploy, and it is the gate Sprint 4 closes on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJTYg2F4r5Bcy6aX6hW8Ga




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

