### PR TITLE
fix(release): pin the Backend pointer to main's own SHA, not its parent [KAN-155]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.4.8] - 2026-07-31
 
-Backend submodule pointer: `0de1e2b` → **`73fb091`**, carrying the KAN-155
-ownership-refusal work from Backend
+Backend submodule pointer: `0de1e2b` → **`7b6347e`** — Backend `main`'s own tip,
+the merge commit of
+[#261](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/261), rather
+than the dev-side SHA it promoted. Both have identical trees, so this pins the
+same code; pinning main's own SHA is what keeps "which Backend commit is in
+production?" answerable from a single ref. Carries the KAN-155 ownership-refusal
+work from Backend
 [#256](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/256),
 [#259](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/259) and
 [#261](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/261).


### PR DESCRIPTION
Fixes the Station 3 block that `scripts/release/train-verify.sh --for-release` reports against the v0.4.8 release, and answers the review suggestion on [#3318](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3318#discussion_r3687979566) — which identified the right problem and proposed a fix that would have made it worse.

## The block

```
submodule pointer                  73fb0913350d (differs-from-backend-main)   <- BLOCK
Backend  main tip                  7b6347ea2e87
pointer content vs Backend main    matches-backend-main-content
CHANGELOG names pinned SHA         present
alembic heads                      1

BLOCK submodule pointer pins 73fb0913350d, Backend main is 7b6347ea2e87 (identical tree)
      — bump the pointer to main's own SHA
```

Exit code **1**.

`73fb091` is the dev-side SHA that Backend #261 promoted; `7b6347e` is the merge commit that promotion produced on `main`. **Identical trees** — `matches-backend-main-content` — so this changes nothing about what deploys. What it changes is whether "which Backend commit is in production?" can be answered from a single ref, instead of the deployed SHA and Backend `main` disagreeing permanently. The station's own comment names v0.3.9 as the release that shipped this way.

## Why the suggested fix was the wrong half

The suggestion edited only the CHANGELOG line to read `7b6347e`, leaving the gitlink at `73fb091`. But the *CHANGELOG names pinned SHA* station compares the CHANGELOG against the **actual pointer**, not against Backend main's tip:

```python
for token in re.findall(r"\b[0-9a-f]{7,40}\b", match.group(1)):
    if pointer.startswith(token):
        print("present")
```

That station is currently **passing** precisely because the CHANGELOG names `73fb091`, which is what the pointer pins. A doc-only edit would flip it `present` → `absent` *and* leave the Station 3 block untouched — two failures instead of one, with the CHANGELOG now actively lying about the deployed SHA.

So the gitlink moves first, and the CHANGELOG follows it. Both are in this PR.

## What nothing caught

`release-train.yml` runs on `workflow_dispatch` and a daily `cron` only — it is **not** a check on the release PR. The detector is correct and exits 1, and no merge blocks on it, so [#3319](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3319) would have merged green, deployed, and the drift would have surfaced on tomorrow's cron.

That is the same shape as the recurring finding that a check living in `scripts/` is not a gate: wired, able to fail, observed failing for the right reason — and still not blocking anything. Whether to wire this station into `pr-gate` for main-targeting PRs is a separate call and deliberately not in this PR.

## Verification

- Gitlink at HEAD: `7b6347ea2e87` = `git -C Backend rev-parse origin/main`.
- CHANGELOG `[0.4.8]` section names `7b6347e`, satisfying the pointer station against the new pointer.
- Backend `main` and `dev` trees identical; back-sync [#262](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/262) landed, both drift counts 0.
- Single Alembic head `e4a7b2d9c5f1`, no new migrations — migrate Job stays a no-op.
- `format:check` clean.

Merges to `dev`; [#3319](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3319) (`dev → main`, v0.4.8) picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJTYg2F4r5Bcy6aX6hW8Ga

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

