### PR TITLE
docs+ci(release): lock the train procedure, gate the stations, add an interactive driver [KAN-191]

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -176,6 +176,48 @@ jobs:
       - uses: actions/checkout@v7
       - run: bash scripts/gcloud/kan170_verify.sh --self-test
 
+  # Release-train stations, on main-targeting PRs ONLY (KAN-191).
+  #
+  # train-verify.sh has existed since KAN-138 and correctly exits 1 on blocking
+  # drift — but release-train.yml runs it on workflow_dispatch and a daily cron,
+  # so nothing ever merged on its result. v0.4.8 shipped a pointer that Station 3
+  # blocked; it was corrected because a human read the output, not because CI
+  # stopped the merge. This job is what makes the station a gate.
+  #
+  # dev-targeting PRs skip it deliberately: a lagging pointer and an unpaid
+  # back-sync are normal mid-cycle states, and blocking them would train people
+  # to ignore this check. `gate` treats `skipped` as passing.
+  release-train:
+    name: Release train — verify stations
+    if: github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+          fetch-depth: 0
+      # checkout fetches only the PR ref; the stations compare origin/dev against
+      # origin/main in BOTH repos, so those remote-tracking refs must exist.
+      # Without this the script dies at exit 2 ("could not determine") rather
+      # than passing — the right failure, but a useless one.
+      - name: Fetch full refs for both repos
+        run: |
+          git config --unset-all remote.origin.fetch || true
+          git config --add remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+          git fetch origin --prune --tags
+          git -C Backend fetch origin --prune
+      # --no-fetch because the step above already did it; --for-release still
+      # queries origin for the tag regardless, which is the one lookup that must
+      # not be guessed.
+      #
+      # This exact checkout+fetch pair is proven, not assumed: release-train.yml
+      # runs it daily, and run 30557811029 (2026-07-30) exited 1 with
+      # "BLOCK Backend main→dev back-sync owed" — i.e. it resolved refs in BOTH
+      # repos and failed for the reason the check exists, rather than dying at
+      # exit 2 on its own plumbing.
+      - name: Verify release-train stations
+        run: ./scripts/release/train-verify.sh --for-release --no-fetch
+
   # ── Gate ──────────────────────────────────────────────────────────────────
   # Single required check for branch protection. Fails if ANY job above fails.
 
@@ -192,6 +234,7 @@ jobs:
       - changelog-check
       - canonical-recipes
       - posture-check-self-test
+      - release-train
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,12 +163,23 @@ Never commit directly to `main` or `dev`. Always branch off `dev`.
 
 Since 2026-07-18 this is enforced by branch protection: `dev` and `main` both carry required status checks `Gate — all checks passed` (the pr-gate aggregate, which includes the Express Docker image build), `Analyze (javascript-typescript)`, and `Dependency Review` (strict off, 0 approvals, admin break-glass audited; SPEC-01 §4.3, `docs/ci/refresh/`).
 
-The `.gitmodules` `Backend` entry tracks `dev`, so `git submodule update --remote Backend` fast-forwards to the Backend integration tip. To ship a Backend change:
+To ship a Backend change:
 
 1. PR into Backend `dev` (in `Backend/` submodule).
-2. After it lands, in this repo: `git submodule update --remote Backend`, commit the new pointer in a cookbook PR off `dev`, merge to `main`, release.
+2. Promote Backend `dev` → `main`, then back-sync `main` → `dev`. No build fires on either — only the cookbook tag push reaches Cloud Build.
+3. In this repo, pin **Backend `main`'s own SHA** and commit that pointer in a cookbook PR off `dev`; then `dev` → `main`, which tags and releases.
+
+```bash
+git -C Backend fetch origin --prune
+git -C Backend checkout origin/main   # main's tip, NOT --remote
+git add Backend
+```
+
+**Do not use `git submodule update --remote Backend` to bump the release pointer.** `.gitmodules` tracks `dev`, so `--remote` resolves to Backend **`dev`**'s tip, and `scripts/release/train-verify.sh` Station 3 requires **`main`**'s tip. They can never agree: each promotion + back-sync cycle creates two distinct merge commits (`main = merge(old_main, dev)`, `dev = merge(dev, main)`), so `dev`'s tip is structurally never `main`'s tip again. This instruction previously said `--remote` and produced a Station 3 block every release — v0.3.9 shipped that way and v0.4.8 nearly did (KAN-191). Trees are identical either way, so this is not about what runs in production; it is about "which Backend commit is in production?" being answerable from one ref.
 
 There is no path that ships Backend code without a corresponding cookbook PR — production deploys whatever SHA the cookbook submodule pins at the moment of the release tag.
+
+**The full ordered procedure is `scripts/release/RUNBOOK.md`**, driven interactively by `scripts/release/train-run.sh`. Follow it rather than reconstructing the order from memory; the traps it documents each cost a real release.
 
 ## Commit and push cadence
 
@@ -327,7 +338,7 @@ To verify the daemon is running during a session: `ps -ef | grep pm_daemon | gre
   - `git -C Backend fetch && git -C Backend log --oneline HEAD..origin/dev` — commits on `dev` the pointer hasn't picked up yet
   - `git -C Backend log --oneline origin/main..origin/dev` — commits on `dev` not yet promoted to Backend `main`
   - `cd Backend && uv run flask db heads` — must print exactly one line with `(head)`. Two heads = unmerged migrations, deploy will break.
-  - `git submodule update --remote Backend` — fast-forward the pointer to the latest `dev` tip when ready
+  - `git -C Backend checkout origin/main && git add Backend` — pin the release pointer. **Backend `main`'s tip, not `--remote`** (which resolves to `dev` and always blocks train-verify Station 3 — see the branching section and `scripts/release/RUNBOOK.md`)
 - **gbrain and the Backend submodule** — if gbrain is configured on your machine, `Backend/` is indexed as a _separate, non-federated_ source (`gstack-code-backend`), so `code-def`/`code-refs`/`search`/`query` against Backend Python need an explicit `--source gstack-code-backend` or they silently miss. Never run a bare `/sync-gbrain` from inside `Backend/`: it has no `.gbrain-source` pin, so the code stage registers the cwd as a _new_ federated source and re-indexes the whole repo alongside the existing one. The nested-path guard does not catch it (the real source lives in gbrain's managed clone dir, so there is no path overlap). Verified with `--dry-run` 2026-07-24. Re-sync with `gbrain sync --source gstack-code-backend --strategy code`.
 - **CI auto-formats** — `ci.yml` is now just a push-only Prettier auto-commit safety net: PRs are already gated by `format:check` in pr-gate and direct pushes to `dev`/`main` are blocked by branch protection, so it's a near-no-op and bot format commits are rare rather than routine
 - **TypeScript is pinned exactly** (`6.0.3`) — Angular majors peer-require specific TS majors (Angular 22 needs TS >=6.0 <6.1), so TS and Angular must move together, manually. Dependabot ignores `@angular/*` semver-major updates; when upgrading Angular, bump `typescript`, all `@angular/*`, and `@angular-eslint/*` in the same PR

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -45,6 +45,11 @@ Backend refs with the default token.
 # Pay down back-sync debt (dry run by default)
 ./scripts/release/train-backsync.sh
 ./scripts/release/train-backsync.sh --apply --merge
+
+# Drive the whole train (stops before every mutating step)
+./scripts/release/train-run.sh --status        # state + checklist, changes nothing
+./scripts/release/train-run.sh                 # walk to the next action
+./scripts/release/train-run.sh --verify-only --marker '<string new in this release>'
 ```
 
 Exit codes are the contract: `0` clean, `1` blocking drift, `2` could not
@@ -125,10 +130,12 @@ The convention already existed informally (v0.3.7, v0.3.9, v0.4.0); the station
 makes it checkable, and accepts any abbreviation, which is how those entries are
 written.
 
-## The freeze window (spec — for when the driver lands)
+## The freeze window (partially implemented)
 
-Today's scripts verify and back-sync; they do not drive the train. When a driver
-does exist it needs a freeze, because the train's payload is mutable underneath
+The driver landed in KAN-191 (`train-run.sh`), so the first half of this is live:
+it prints the freeze warning before the release PR and re-reads state on every
+run rather than trusting a checklist tick. The **enforcement** layer below is
+still a spec. A freeze matters because the train's payload is mutable underneath
 it: **a `dev → main` PR merges the live tip of `dev`, not the tip as of when the
 PR was opened.** Anything merged to `dev` between opening the release PR and
 merging it ships silently, outside the CHANGELOG, under a version that never
@@ -190,9 +197,11 @@ Deliberately, not from lack of time — these carry judgment or a credential the
 automation should not hold:
 
 - choosing the version number and writing the CHANGELOG section
-- the Backend `dev → main` promotion
+- the Backend `dev → main` promotion (the driver opens the PR; a human merges it)
 - the release PR `dev → main` and its merge (which fires the tag and the deploy)
-- live verification after Cloud Build
+- accepting the live verification after Cloud Build — `train-run.sh --verify-only`
+  runs the check and reports, but choosing the marker string, and believing the
+  result, stay human
 
 The full ordered runbook is **[`RUNBOOK.md`](./RUNBOOK.md)**, driven by
 **[`train-run.sh`](./train-run.sh)**. It no longer lives on KAN-138 — a procedure

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -4,11 +4,18 @@ Automation for the two-repo release train. This is the **thin slice**: the
 mechanical, no-judgment steps. Version choice, Backend promotion, and the
 release PR itself stay human.
 
-| Piece | Where it runs | What it does |
-| --- | --- | --- |
-| `train-verify.sh` | anywhere (local + CI) | read-only drift stations; exit 1 on blocking drift |
-| `.github/workflows/release-train.yml` | GitHub Actions (dispatch + daily) | runs the verifier, publishes a job summary, fails on blocking drift |
-| `train-backsync.sh` | **local only** | opens (and optionally merges) the `main → dev` back-sync PRs |
+**The ordered procedure is [`RUNBOOK.md`](./RUNBOOK.md)** — it used to live on
+KAN-138, where a checkout could not reach it and it drifted from `CLAUDE.md`
+(KAN-191). Follow it rather than reconstructing the order from memory.
+
+| Piece                                 | Where it runs                     | What it does                                                                                      |
+| ------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `RUNBOOK.md`                          | —                                 | the procedure: 10 ordered steps and the traps that bite at each                                   |
+| `train-run.sh`                        | **local only**                    | interactive driver: walks the runbook, prints state before every mutating step, keeps a checklist |
+| `train-verify.sh`                     | anywhere (local + CI)             | read-only drift stations; exit 1 on blocking drift                                                |
+| `.github/workflows/pr-gate.yml`       | GitHub Actions (PRs to `main`)    | runs `--for-release` as a **required** check — this is what makes the stations a gate             |
+| `.github/workflows/release-train.yml` | GitHub Actions (dispatch + daily) | runs the verifier, publishes a job summary, fails on blocking drift                               |
+| `train-backsync.sh`                   | **local only**                    | opens (and optionally merges) the `main → dev` back-sync PRs                                      |
 
 ## Why the split
 
@@ -48,15 +55,15 @@ could not actually check is how a broken gate ships green.
 
 Pulled from the live rulesets, not from memory:
 
-| | cookbook | Backend |
-| --- | --- | --- |
-| default branch | `dev` | `dev` |
-| `main` merge methods | `merge`, `rebase` (**squash blocked**) | `merge`, `rebase` (**squash blocked**) |
-| `main` rules | deletion, non-fast-forward, PR required, code scanning, code quality | + required status checks |
-| `dev` merge methods | `merge`, `squash`, `rebase` | same |
-| `dev` extra rule | **`required_linear_history`** | **`required_linear_history`** |
-| approvals required | 0 | 0 |
-| bypass | repo admin (`RepositoryRole/5`) on PR merge, plus several GitHub Apps | same |
+|                      | cookbook                                                              | Backend                                |
+| -------------------- | --------------------------------------------------------------------- | -------------------------------------- |
+| default branch       | `dev`                                                                 | `dev`                                  |
+| `main` merge methods | `merge`, `rebase` (**squash blocked**)                                | `merge`, `rebase` (**squash blocked**) |
+| `main` rules         | deletion, non-fast-forward, PR required, code scanning, code quality  | + required status checks               |
+| `dev` merge methods  | `merge`, `squash`, `rebase`                                           | same                                   |
+| `dev` extra rule     | **`required_linear_history`**                                         | **`required_linear_history`**          |
+| approvals required   | 0                                                                     | 0                                      |
+| bypass               | repo admin (`RepositoryRole/5`) on PR merge, plus several GitHub Apps | same                                   |
 
 ## The `action_required` gate — resolved
 
@@ -130,15 +137,15 @@ described it.
 ### When it opens
 
 The moment the version bump + CHANGELOG land on `dev`. That is when `dev`'s tip
-*becomes* the release payload — earlier than the release PR, which is already
+_becomes_ the release payload — earlier than the release PR, which is already
 too late.
 
 ### When it closes — asymmetric, and this is the part worth getting right
 
-| ref | unlocks at | why there |
-| --- | --- | --- |
-| `dev` (both repos) | **tag `vX.Y.Z` exists on origin** | The tag is the moment the version becomes immutable, which is precisely what makes "any new push means a patch bump" true. It also *has* to be here: step 8/9 back-sync writes to `dev`. |
-| `main` (both repos) | **deploy verified live** | If Cloud Build fails, the only correct recovery is a patch bump through the normal train. Holding `main` through that window is what stops a panic hotfix pushed straight to it — the one move that would break `main === deployed`. |
+| ref                 | unlocks at                        | why there                                                                                                                                                                                                                            |
+| ------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `dev` (both repos)  | **tag `vX.Y.Z` exists on origin** | The tag is the moment the version becomes immutable, which is precisely what makes "any new push means a patch bump" true. It also _has_ to be here: step 8/9 back-sync writes to `dev`.                                             |
+| `main` (both repos) | **deploy verified live**          | If Cloud Build fails, the only correct recovery is a patch bump through the normal train. Holding `main` through that window is what stops a panic hotfix pushed straight to it — the one move that would break `main === deployed`. |
 
 Not a hypothetical: v0.3.0 died in the migrate job and v0.3.4 died parsing the
 Express Dockerfile. Both recovered exactly this way, as v0.3.1 and v0.3.5.
@@ -151,7 +158,7 @@ mutating step. Any movement aborts and names the ref that moved. No GitHub
 config is written, so a crashed run leaves nothing to clean up, and it catches
 the real failure at the moment it would do damage.
 
-**2. Enforcement (needs a decision + one experiment).** Note what does *not*
+**2. Enforcement (needs a decision + one experiment).** Note what does _not_
 work: the `update` rule ("Restrict updates") governs direct pushes, and both
 branches already block those by requiring a PR — so it adds nothing against the
 actual threat, which is a **merge**. The primitive that blocks merges is a
@@ -165,7 +172,7 @@ agent sessions, Dependabot merges, and UI merges are held.
 
 This layer is unverified here — it needs the ruleset created and one throwaway
 PR to confirm the block actually lands. It also needs a standalone `--unfreeze`
-escape hatch, and the freeze state written locally *before* the API call, or an
+escape hatch, and the freeze state written locally _before_ the API call, or an
 aborted train leaves both repos frozen with no record of why.
 
 ### Already enforced
@@ -187,4 +194,6 @@ automation should not hold:
 - the release PR `dev → main` and its merge (which fires the tag and the deploy)
 - live verification after Cloud Build
 
-The full ordered runbook lives on **KAN-138**.
+The full ordered runbook is **[`RUNBOOK.md`](./RUNBOOK.md)**, driven by
+**[`train-run.sh`](./train-run.sh)**. It no longer lives on KAN-138 — a procedure
+a checkout cannot read is a procedure that drifts (KAN-191).

--- a/scripts/release/RUNBOOK.md
+++ b/scripts/release/RUNBOOK.md
@@ -1,0 +1,228 @@
+# Release train — the runbook
+
+**This file is the procedure.** It replaces the copy that lived on KAN-138, where
+it was unreachable from a checkout and drifted from `CLAUDE.md` until the two
+disagreed about the one command that matters (KAN-191).
+
+Read [`README.md`](./README.md) for _why_ the tooling is split the way it is.
+This file is _what to do, in order_.
+
+- **Driver:** [`train-run.sh`](./train-run.sh) walks these steps interactively and
+  checks them off. It stops before every mutating step and prints the state it is
+  about to act on. Use it. This document is the reference it implements, and the
+  fallback when you are doing something the driver does not cover.
+- **Gate:** `train-verify.sh --for-release` must exit 0 before the release PR
+  merges. Since KAN-191 that also runs in `pr-gate.yml` on `main`-targeting PRs,
+  so it blocks rather than merely reports.
+
+---
+
+## The one-paragraph version
+
+Backend lands on Backend `dev`, gets promoted to Backend `main`, and **only then**
+does the cookbook pin `Backend main`'s own SHA. The version bump and CHANGELOG go
+to cookbook `dev`. Cookbook `dev → main` is the release: merging it pushes the tag,
+and **the tag is what deploys**. Then back-sync both repos. Verify against
+production by content, never by "the merge went green".
+
+---
+
+## Step order
+
+Each step names its precondition, the command, and how you know it worked. The
+step numbers are the ones `train-run.sh` prints.
+
+### 0. Establish the starting state
+
+```bash
+git fetch origin --prune && git submodule update --init Backend && git -C Backend fetch --prune
+./scripts/release/train-verify.sh
+```
+
+You are looking for what is _already_ owed — usually a back-sync from the last
+release. Pay that down first (step 8's command works any time); starting a release
+on top of unpaid drift means every later count is ambiguous.
+
+### 1. Backend change → Backend `dev`
+
+Normal PR into Backend `dev`. Nothing release-specific.
+
+### 2. Backend `dev` → `main`
+
+```bash
+gh pr create -R adamtasteslikegood/tasteslikegood.com --base main --head dev \
+  --title "release: promote Backend dev → main for <topic> [KAN-###]"
+```
+
+**No build fires.** Backend has no push-to-`main` trigger; only the cookbook tag
+push reaches Cloud Build. This is a lane move.
+
+> **TRAP — a promotion goes stale the moment anything else lands on Backend `dev`.**
+> This is not hypothetical: on v0.4.8, Backend #258 promoted at 19:17 and #259
+> merged to `dev` at 03:43 the next morning. The step list said "promotion: done";
+> `main` did not have the code. It cost a second promotion (#261).
+>
+> **Never trust the step list here. Check the content:**
+>
+> ```bash
+> git -C Backend merge-base --is-ancestor <the-PR-merge-sha> origin/main && echo OK || echo STALE
+> ```
+>
+> If anything landed on Backend `dev` after your promotion PR merged, promote again.
+
+### 3. Backend `main` → `dev` back-sync
+
+```bash
+./scripts/release/train-backsync.sh --apply --merge
+```
+
+The promotion leaves a merge commit on `main` that `dev` lacks. Skipping it is the
+most repeated miss in this project's history. Not release-blocking on its own, but
+it makes every later drift count non-zero, and a check nobody trusts is a check
+that stops being read.
+
+### 4. Pin the pointer to Backend **`main`**
+
+```bash
+git switch -c chore/release-vX.Y.Z-KAN-### origin/dev
+git -C Backend fetch origin --prune
+git -C Backend checkout origin/main      # main's OWN SHA — see below
+git add Backend
+```
+
+> **TRAP — `git submodule update --remote Backend` is the wrong command here,**
+> and `CLAUDE.md` said to use it until KAN-191. `.gitmodules` sets
+> `submodule.Backend.branch = dev`, so `--remote` resolves to Backend **`dev`**'s
+> tip. Station 3 requires **`main`**'s tip. These can never agree, because every
+> promotion + back-sync cycle produces two distinct merge commits:
+>
+> ```
+> main = merge(old_main, dev_tip)     7b6347e = merge(d48f06a, 73fb091)
+> dev  = merge(dev_tip,  main)        3fac56b = merge(73fb091, 7b6347e)
+> ```
+>
+> So `dev`'s tip is structurally never `main`'s tip again. Following the old
+> instruction produced a Station 3 block **every release** — v0.3.9 shipped that
+> way, and v0.4.8 nearly did (fixed by #3320).
+>
+> The trees are identical, so this is not about what runs in production. It is
+> about "which Backend commit is in production?" being answerable from one ref.
+
+### 5. Version + CHANGELOG, same branch
+
+Bump `package.json` **and both self-references in `package-lock.json`**. Add a
+`## [X.Y.Z]` section to `CHANGELOG.md` that **names the pinned Backend SHA** —
+`train-verify` checks the section against the _actual pointer_, so the SHA in the
+prose and the gitlink must be the same value.
+
+```bash
+npx prettier --write CHANGELOG.md      # the section will not be Prettier-clean by hand
+./scripts/release/train-verify.sh --for-release   # must exit 0
+```
+
+Open the PR into **`dev`**, not `main`.
+
+> **Release PRs are `dev → main` only.** Never point a `chore/*` branch at `main`.
+> The bump lands on `dev` first; `dev → main` is what ships and tags.
+
+### 6. Cookbook `dev` → `main` — this is the release
+
+```bash
+gh pr create --base main --head dev --title "release: vX.Y.Z — <summary> [KAN-###]"
+gh pr merge <n> --merge      # merge commit; squash is blocked by the main ruleset
+```
+
+The freeze window opens at **step 5**, not here: a `dev → main` PR merges the live
+tip of `dev`, so anything landing on `dev` in between ships silently, outside the
+CHANGELOG, under a version that never described it.
+
+### 7. The tag deploys
+
+`release.yml` reads `version` from `package.json`, pushes `vX.Y.Z`, and publishes
+the Release. **That tag push is the deploy**, via a Cloud Build trigger configured
+GCP-side on:
+
+```
+^v[0-9]+\.[0-9]+\.[0-9]+$
+```
+
+Anchored and digits-only. `v0.4.8` matches. `v0.4.8-rc.1` and `v0.4.8+abc1234` do
+**not** — which is why the rewritten immutable-release tags (`v0.4.5+0ff0e4e` …)
+never redeployed anything.
+
+> **TRAP — a spent version deploys nothing, silently.** If `vX.Y.Z` already exists,
+> `release.yml` skips the tag, the Release, and therefore the trigger — and reports
+> success. Green PR, green workflow, no deploy, no error anywhere.
+> `--for-release` blocks on this; do not override it.
+
+### 8. Back-sync both repos
+
+```bash
+./scripts/release/train-backsync.sh --apply --merge
+```
+
+Must be a **merge commit**. Squashing rewrites the commits, ancestry never
+converges, and the drift count never returns to zero. `dev` carries
+`required_linear_history` in both repos, so this only lands for an actor with
+ruleset bypass — a repo admin merging a PR. That is why this step is local and not
+in CI.
+
+### 9. Verify against production — by content
+
+```bash
+./scripts/release/train-run.sh --verify-only     # or the manual form below
+```
+
+> **TRAP — verify the code, not the bundle name, and not `main-*.js` alone.**
+> On v0.4.8 the deploy was live while a poller grepping only `main-*.js` reported
+> "not deployed" for twenty minutes. The app is code-split: `publishFailureMessage`
+> ships in a shared `chunk-*.js`. A hash change alone also proves nothing about
+> _which_ build landed.
+>
+> Grep every served asset for a string unique to this release:
+>
+> ```bash
+> for a in $(curl -s https://www.tasteslikegood.org/ | grep -oE '(main|chunk|polyfills)-[A-Z0-9]+\.js' | sort -u); do
+>   curl -s "https://www.tasteslikegood.org/$a" | grep -c "<a string only this release has>"
+> done
+> ```
+>
+> Pick a string that is **new in this release and absent from the previous one**.
+> "Check your connection" was useless on v0.4.8 — the new code kept it for the
+> genuine sync case, so it appeared in both builds.
+
+Also confirm: `/`, `/browse`, `/sitemap.xml` return 200, and if the release
+touched Backend, that a canonical `/r/<slug>` still resolves.
+
+If `gcloud` is authenticated, `gcloud builds list --region=us-central1` shows the
+build — **regional; a global list shows nothing recent**. The content check above
+is decisive on its own and needs no credentials.
+
+### 10. Close out
+
+`train-verify.sh` back to exit 0, drift counts zero on both repos, Jira rows moved
+with evidence rather than on the merge alone.
+
+---
+
+## Rollback
+
+There is no rollback to a previous tag. The recovery for a failed deploy is a
+**patch bump forward through this same runbook** — v0.3.0 died in the migrate Job
+and v0.3.4 died parsing the Express Dockerfile; both recovered as v0.3.1 and
+v0.3.5. That is also why `main` stays frozen until the deploy is verified: the one
+move that breaks `main === deployed` is a panic hotfix pushed straight to `main`.
+
+## Migrations
+
+`flask db heads` must print exactly one line before the release. Two heads and
+`flask db upgrade` refuses, the `flask-backend-migrate` Job fails, and the build
+aborts — the old Flask revision keeps serving, which is the desired failure, but
+the release is dead until you merge the heads. `train-verify` checks this, and
+`pr-gate.yml`'s `alembic-heads` job shares the same script so the two can never
+disagree.
+
+## What is deliberately still human
+
+Version choice and CHANGELOG prose; the Backend promotion; merging the release PR;
+and accepting the production verification. Everything else the driver does.

--- a/scripts/release/train-run.sh
+++ b/scripts/release/train-run.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# Release-train driver (KAN-191) — the interactive half of scripts/release/.
+#
+# Walks the ordered procedure in RUNBOOK.md, keeps a checklist on disk, and
+# STOPS BEFORE EVERY MUTATING STEP to print the exact state it is about to act
+# on. Nothing here merges, tags, or deploys without a typed confirmation.
+#
+# Why a driver at all: the train spans two repos, ten steps, and four traps that
+# have each cost a real release. Every one of those misses was an ordering or
+# staleness error a human made while holding the whole sequence in their head —
+# not a hard step. This holds the sequence instead.
+#
+# Why interactive rather than full auto: the mutating steps need a credential or
+# a judgment the automation should not own (version choice, CHANGELOG prose,
+# merging the release PR = deploying). Run it enough times with confirmations
+# and the safe steps can graduate to --yes; the checklist is the record of which
+# ones have earned it.
+#
+# Exit codes:
+#   0  the run reached its end state
+#   1  a step failed, or a precondition was violated
+#   2  usage / environment error (could not determine)
+#
+# Usage:
+#   ./scripts/release/train-run.sh                 # walk from where you are
+#   ./scripts/release/train-run.sh --status        # print checklist + state, do nothing
+#   ./scripts/release/train-run.sh --verify-only   # step 9 (production check) alone
+#   ./scripts/release/train-run.sh --verify-only --marker 'some new string'
+#                                                # non-interactive: pass the marker
+#   ./scripts/release/train-run.sh --reset         # clear the checklist, start a fresh release
+#   ./scripts/release/train-run.sh --dry-run       # print every command, run none of them
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$ROOT" || exit 2
+
+STATE_DIR="$ROOT/.agent-work/release"
+STATE="$STATE_DIR/train-state.json"
+BACKEND_REPO="adamtasteslikegood/tasteslikegood.com"
+PROD="https://www.tasteslikegood.org"
+
+DRY_RUN=0
+MODE="walk"
+MARKER=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --status) MODE="status" ;;
+    --verify-only) MODE="verify" ;;
+    --reset) MODE="reset" ;;
+    --dry-run) DRY_RUN=1 ;;
+    --marker)
+      shift
+      [ $# -gt 0 ] || { echo "--marker needs a value" >&2; exit 2; }
+      MARKER="$1"
+      ;;
+    -h | --help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# ── output ──────────────────────────────────────────────────────────────────
+if [ -t 1 ]; then
+  B=$'\033[1m'; DIM=$'\033[2m'; R=$'\033[31m'; G=$'\033[32m'; Y=$'\033[33m'; C=$'\033[36m'; X=$'\033[0m'
+else
+  B=""; DIM=""; R=""; G=""; Y=""; C=""; X=""
+fi
+
+say()  { printf '%s\n' "$*"; }
+head2(){ printf '\n%s%s%s\n' "$B" "$*" "$X"; }
+ok()   { printf '  %s✓%s %s\n' "$G" "$X" "$*"; }
+bad()  { printf '  %s✗%s %s\n' "$R" "$X" "$*"; }
+warn() { printf '  %s!%s %s\n' "$Y" "$X" "$*"; }
+info() { printf '  %s·%s %s\n' "$DIM" "$X" "$*"; }
+die()  { printf '%serror:%s %s\n' "$R" "$X" "$*" >&2; exit 2; }
+
+# ── checklist state ─────────────────────────────────────────────────────────
+# One JSON object: {"version": "...", "steps": {"2": "done", ...}}. Kept under
+# .agent-work/ (gitignored) so a half-finished train is never committed.
+mkdir -p "$STATE_DIR" 2>/dev/null || die "cannot create $STATE_DIR"
+[ -f "$STATE" ] || printf '{"version":null,"steps":{}}\n' > "$STATE"
+
+state_get() {
+  python3 - "$STATE" "$1" <<'PY' 2>/dev/null || echo ""
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    print(""); raise SystemExit
+print(d.get("steps", {}).get(sys.argv[2], "") or "")
+PY
+}
+
+state_set() {
+  python3 - "$STATE" "$1" "$2" <<'PY' || die "could not write $STATE"
+import json, sys
+p = sys.argv[1]
+try:
+    d = json.load(open(p))
+except Exception:
+    d = {"version": None, "steps": {}}
+d.setdefault("steps", {})[sys.argv[2]] = sys.argv[3]
+json.dump(d, open(p, "w"), indent=2)
+PY
+}
+
+state_version_set() {
+  python3 - "$STATE" "$1" <<'PY' || true
+import json, sys
+p = sys.argv[1]
+try:
+    d = json.load(open(p))
+except Exception:
+    d = {"version": None, "steps": {}}
+d["version"] = sys.argv[2]
+json.dump(d, open(p, "w"), indent=2)
+PY
+}
+
+if [ "$MODE" = "reset" ]; then
+  printf '{"version":null,"steps":{}}\n' > "$STATE"
+  ok "checklist cleared — $STATE"
+  exit 0
+fi
+
+# ── confirmation ────────────────────────────────────────────────────────────
+# Typed word, not y/n. A mutating step that fires the production deploy should
+# cost more than a reflexive keystroke.
+confirm() {
+  local word="$1" prompt="$2"
+  if [ "$DRY_RUN" = "1" ]; then
+    info "dry-run: would ask to confirm with '$word'"
+    return 1
+  fi
+  if [ ! -t 0 ]; then
+    warn "not a TTY — cannot confirm interactively. Re-run in a terminal, or do this step by hand."
+    return 1
+  fi
+  printf '\n  %s%s%s\n  type %s%s%s to proceed (anything else skips): ' "$Y" "$prompt" "$X" "$B" "$word" "$X"
+  local answer=""
+  read -r answer
+  [ "$answer" = "$word" ]
+}
+
+run() {
+  if [ "$DRY_RUN" = "1" ]; then
+    info "would run: $*"
+    return 0
+  fi
+  "$@"
+}
+
+# ── state gathering (read-only, always safe) ────────────────────────────────
+gather() {
+  git fetch origin --prune --quiet 2>/dev/null || warn "git fetch failed — state below may be stale"
+  if [ -e Backend/.git ] || [ -f Backend/.git ]; then
+    git -C Backend fetch origin --prune --quiet 2>/dev/null || warn "Backend fetch failed — state below may be stale"
+  else
+    die "Backend/ submodule is not initialized — run: git submodule update --init Backend"
+  fi
+
+  VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "unknown")
+  CB_DEV=$(git rev-parse --short origin/dev)
+  CB_MAIN=$(git rev-parse --short origin/main)
+  CB_PENDING=$(git rev-list --count origin/main..origin/dev)
+  CB_BACKSYNC=$(git rev-list --count origin/dev..origin/main)
+  BE_DEV=$(git -C Backend rev-parse --short origin/dev)
+  BE_MAIN=$(git -C Backend rev-parse --short origin/main)
+  BE_PENDING=$(git -C Backend rev-list --count origin/main..origin/dev)
+  BE_BACKSYNC=$(git -C Backend rev-list --count origin/dev..origin/main)
+  POINTER=$(git rev-parse origin/dev:Backend)
+  POINTER_SHORT=${POINTER:0:12}
+  BE_MAIN_FULL=$(git -C Backend rev-parse origin/main)
+  TAG_EXISTS=$(git ls-remote --tags origin "refs/tags/v$VERSION" 2>/dev/null | head -1)
+
+  # Trees, not commit counts. After a back-sync, Backend dev is permanently 1
+  # ahead of main (dev = merge(dev, main)) with an IDENTICAL tree — that is the
+  # steady state, not unshipped work. Counting commits alone reports a promotion
+  # owed forever and trains the reader to ignore the line. Caught by running this
+  # driver against a just-released repo, where it did exactly that.
+  BE_DEV_TREE=$(git -C Backend rev-parse origin/dev^{tree})
+  BE_MAIN_TREE=$(git -C Backend rev-parse origin/main^{tree})
+  if [ "$BE_DEV_TREE" = "$BE_MAIN_TREE" ]; then
+    BE_PROMOTION_OWED=0
+  else
+    BE_PROMOTION_OWED=1
+  fi
+}
+
+print_state() {
+  head2 "State"
+  printf '  %-34s %s\n' "cookbook dev / main"  "$CB_DEV / $CB_MAIN"
+  printf '  %-34s %s\n' "  dev→main pending"   "$CB_PENDING"
+  printf '  %-34s %s\n' "  main→dev back-sync owed" "$CB_BACKSYNC"
+  printf '  %-34s %s\n' "Backend dev / main"   "$BE_DEV / $BE_MAIN"
+  printf '  %-34s %s\n' "  dev→main pending"   "$BE_PENDING"
+  printf '  %-34s %s\n' "  main→dev back-sync owed" "$BE_BACKSYNC"
+  printf '  %-34s %s\n' "submodule pointer"    "$POINTER_SHORT"
+  if [ "$POINTER" = "$BE_MAIN_FULL" ]; then
+    ok "pointer == Backend main"
+  else
+    bad "pointer != Backend main (${BE_MAIN_FULL:0:12}) — see RUNBOOK step 4"
+  fi
+  printf '  %-34s %s\n' "version"              "$VERSION"
+  if [ -n "$TAG_EXISTS" ]; then
+    bad "v$VERSION is ALREADY TAGGED — a re-merge deploys nothing and reports success"
+  else
+    ok "v$VERSION not yet tagged"
+  fi
+}
+
+STEPS=(
+  "0|Establish starting state (fetch both repos, read the stations)"
+  "1|Backend change merged to Backend dev"
+  "2|Backend dev → main promotion"
+  "3|Backend main → dev back-sync"
+  "4|Pin pointer to Backend main's own SHA"
+  "5|Version bump + CHANGELOG on a branch → cookbook dev"
+  "6|Cookbook dev → main release PR"
+  "7|Tag vX.Y.Z pushed → Cloud Build fires"
+  "8|Back-sync both repos"
+  "9|Verify production by content"
+)
+
+print_checklist() {
+  head2 "Checklist  ${DIM}($STATE)${X}"
+  local id label mark
+  for entry in "${STEPS[@]}"; do
+    id=${entry%%|*}; label=${entry#*|}
+    mark=$(state_get "$id")
+    case "$mark" in
+      done)    printf '  %s[x]%s %s. %s\n' "$G" "$X" "$id" "$label" ;;
+      skipped) printf '  %s[-]%s %s. %s %s(skipped)%s\n' "$Y" "$X" "$id" "$label" "$DIM" "$X" ;;
+      *)       printf '  [ ] %s. %s\n' "$id" "$label" ;;
+    esac
+  done
+}
+
+# ── step 9: production verification ─────────────────────────────────────────
+# Greps EVERY served asset, not main-*.js. On v0.4.8 the deploy was live while a
+# main-only poller reported "not deployed" for twenty minutes, because the
+# publish code ships in a shared chunk-*.js. A bundle-hash change alone proves a
+# deploy happened, not WHICH build landed.
+verify_prod() {
+  local marker="${1:-}"
+  head2 "Step 9 — verify production by content"
+
+  local code
+  for path in "/" "/browse" "/sitemap.xml"; do
+    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$PROD$path" || echo "000")
+    if [ "$code" = "200" ]; then ok "$path → 200"; else bad "$path → $code"; fi
+  done
+
+  if [ -z "$marker" ]; then
+    warn "no marker string given — cannot prove WHICH build is live"
+    info "re-run as: $0 --verify-only   then enter a string that is new in this release"
+    if [ -t 0 ] && [ "$DRY_RUN" != "1" ]; then
+      printf '\n  %smarker string (new in this release, absent from the previous one):%s ' "$Y" "$X"
+      read -r marker
+    fi
+  fi
+  [ -n "$marker" ] || { warn "skipping content check"; return 1; }
+
+  local assets hits total=0
+  assets=$(curl -s --max-time 20 "$PROD/" | grep -oE '(main|chunk|polyfills)-[A-Z0-9]+\.js' | sort -u)
+  [ -n "$assets" ] || { bad "could not list served JS assets"; return 1; }
+
+  info "searching every served asset for: $marker"
+  local tmp; tmp=$(mktemp)
+  for a in $assets; do
+    curl -s --max-time 30 "$PROD/$a" -o "$tmp" || continue
+    # `grep -c` ALREADY prints 0 when it matches nothing, and exits 1. A
+    # `|| echo 0` on top of that yields the two-line string "0\n0", which then
+    # blows up $(( )) with an arithmetic syntax error and derails the whole
+    # mode. Found by running this against the live v0.4.8 deploy.
+    hits=$(grep -c -- "$marker" "$tmp" 2>/dev/null)
+    [ -n "$hits" ] || hits=0
+    total=$((total + hits))
+    printf '    %-28s %8s bytes  hits=%s\n' "$a" "$(wc -c < "$tmp")" "$hits"
+  done
+  rm -f "$tmp"
+
+  if [ "$total" -gt 0 ]; then
+    ok "marker found in $total place(s) — this release IS live"
+    return 0
+  fi
+  bad "marker not found in any served asset — the deploy is not live yet (or the marker is wrong)"
+  info "a marker present in BOTH builds proves nothing; pick one only this release has"
+  return 1
+}
+
+# ── modes ───────────────────────────────────────────────────────────────────
+gather
+
+if [ "$MODE" = "verify" ]; then
+  verify_prod "$MARKER"
+  exit $?
+fi
+
+print_state
+print_checklist
+
+if [ "$MODE" = "status" ]; then
+  head2 "Stations"
+  "$SCRIPT_DIR/train-verify.sh" --no-fetch || true
+  exit 0
+fi
+
+# ── walk ────────────────────────────────────────────────────────────────────
+head2 "Stations"
+"$SCRIPT_DIR/train-verify.sh" --no-fetch
+VERIFY_RC=$?
+
+[ "$VERSION" = "unknown" ] && die "could not read package.json version"
+state_version_set "$VERSION"
+
+head2 "Next action"
+
+# Step 2/3 — Backend promotion and its back-sync.
+if [ "$BE_PROMOTION_OWED" -eq 1 ]; then
+  bad "Backend dev has content main lacks — promotion owed (RUNBOOK step 2)"
+  git -C Backend log --oneline origin/main..origin/dev | sed 's/^/      /'
+  say ""
+  info "TRAP: a promotion goes stale the moment anything else lands on Backend dev."
+  info "After it merges, re-run this driver rather than ticking step 2 off by memory."
+  if confirm "PROMOTE" "Open the Backend dev → main PR?"; then
+    run gh pr create -R "$BACKEND_REPO" --base main --head dev \
+      --title "release: promote Backend dev → main [KAN-###]" \
+      --body "Promotes Backend dev → main so the cookbook pointer can pin main's own SHA. No build fires on this merge." \
+      && state_set 2 "done"
+  else
+    info "skipped — nothing was opened"
+  fi
+  exit 1
+fi
+if [ "$BE_PENDING" -gt 0 ]; then
+  ok "Backend dev content == main ($BE_PENDING ancestry-only commit(s): the back-sync merge)"
+else
+  ok "Backend dev == main (nothing to promote)"
+fi
+[ -n "$(state_get 2)" ] || state_set 2 "done"
+
+if [ "$BE_BACKSYNC" -gt 0 ] || [ "$CB_BACKSYNC" -gt 0 ]; then
+  bad "back-sync owed — cookbook $CB_BACKSYNC, Backend $BE_BACKSYNC (RUNBOOK step 3/8)"
+  info "must be a MERGE commit; squashing rewrites commits and the count never reaches zero"
+  if confirm "BACKSYNC" "Run train-backsync.sh --apply --merge?"; then
+    run "$SCRIPT_DIR/train-backsync.sh" --apply --merge && state_set 8 "done"
+  else
+    info "skipped — run it before cutting, the stations block on this"
+  fi
+  exit 1
+fi
+ok "no back-sync debt on either repo"
+
+# Step 4 — pointer.
+if [ "$POINTER" != "$BE_MAIN_FULL" ]; then
+  bad "pointer $POINTER_SHORT != Backend main ${BE_MAIN_FULL:0:12} (RUNBOOK step 4)"
+  info "do NOT use 'git submodule update --remote Backend' — .gitmodules tracks dev,"
+  info "and dev's tip is structurally never main's tip after a promotion+back-sync."
+  say ""
+  info "  git -C Backend checkout origin/main && git add Backend"
+  exit 1
+fi
+ok "pointer pins Backend main"
+[ -n "$(state_get 4)" ] || state_set 4 "done"
+
+# Step 7 — spent version is the quietest failure in the train.
+if [ -n "$TAG_EXISTS" ]; then
+  bad "v$VERSION is already tagged"
+  info "release.yml would skip the tag, the Release, and the Cloud Build trigger — and report success."
+  info "Bump package.json (patch at minimum) and add a CHANGELOG section before cutting."
+  exit 1
+fi
+
+# Step 6 — the release PR. This is the deploy.
+if [ "$CB_PENDING" -eq 0 ]; then
+  ok "nothing pending: cookbook dev == main — the train is at rest"
+  [ "$VERIFY_RC" -eq 0 ] && exit 0 || exit 1
+fi
+
+if [ "$VERIFY_RC" -ne 0 ]; then
+  bad "stations are blocking — fix those before opening the release PR"
+  exit 1
+fi
+
+ok "stations clean, $CB_PENDING commit(s) ready to ship as v$VERSION"
+say ""
+warn "The NEXT step merges cookbook dev → main. That pushes tag v$VERSION,"
+warn "which fires Cloud Build and DEPLOYS TO PRODUCTION."
+warn "The freeze is already open: dev→main merges dev's LIVE tip, so anything"
+warn "landing on dev between now and the merge ships silently, outside the CHANGELOG."
+
+if confirm "RELEASE" "Open the cookbook dev → main release PR? (opening only — merging stays manual)"; then
+  run gh pr create --base main --head dev \
+    --title "release: v$VERSION [KAN-###]" \
+    --body "Release v$VERSION. Pointer $POINTER_SHORT (Backend main). Stations clean via train-verify --for-release. Merging this pushes the tag and deploys." \
+    && state_set 6 "done"
+  say ""
+  info "Merge it with: gh pr merge <n> --merge     (merge commit; squash is blocked on main)"
+  info "Then:          $0            # picks up at back-sync + verification"
+else
+  info "skipped — nothing was opened"
+fi
+
+print_checklist
+exit 0


### PR DESCRIPTION
Closes the loop opened by KAN-191: the release train's procedure now lives in the repo, the station that catches pointer drift now gates a merge, and a driver holds the ten-step sequence so a human does not have to.

Three commits, in the order Adam asked for: **docs → gate → runner**.

## 1. Docs — `scripts/release/RUNBOOK.md`

The ordered procedure lived on **KAN-138**, where a checkout cannot read it. Predictably it drifted from `CLAUDE.md`, and the copy in the repo was the wrong one.

Ten numbered steps, each with its precondition, command, and how you know it worked. Four traps written in **at the step where they bite**, each because it cost a real release:

| Trap | Evidence |
| --- | --- |
| A Backend promotion goes stale the moment anything else lands on Backend `dev` | v0.4.8: #258 promoted 19:17, #259 merged 03:43. The step list said "done"; `main` did not have the code. Cost promotion #261. |
| `git submodule update --remote Backend` can never satisfy Station 3 | `.gitmodules` tracks `dev`; Station 3 wants `main`. See below. |
| A spent version deploys nothing and reports success | `release.yml` skips the tag, the Release, and the trigger — green PR, green workflow, no deploy, no error. |
| Production verification must grep every served chunk | v0.4.8 was live for ~20 min while a `main-*.js`-only poller said "not deployed". |

### The CLAUDE.md fix

`CLAUDE.md` step 2 said `git submodule update --remote Backend`. That resolves to Backend **`dev`**'s tip; `train-verify.sh` Station 3 requires **`main`**'s tip. **These can never agree**, because each promotion + back-sync cycle produces two distinct merge commits:

```
main = merge(old_main, dev_tip)     7b6347e = merge(d48f06a, 73fb091)
dev  = merge(dev_tip,  main)        3fac56b = merge(73fb091, 7b6347e)
```

So `dev`'s tip is structurally never `main`'s tip again. Following the documented instruction produced a Station 3 block **every release** — v0.3.9 shipped that way, v0.4.8 nearly did (fixed by #3320). Replaced with the correct command plus the reason, in both places CLAUDE.md mentioned it.

## 2. Gate — `train-verify` now blocks main-targeting PRs

`train-verify.sh` has been correct since KAN-138 and **gated nothing**: `release-train.yml` runs it on `workflow_dispatch` and a daily cron, so no merge ever depended on it. v0.4.8's bad pointer was corrected because a human read the output.

New `release-train` job in `pr-gate.yml`, `if: github.base_ref == 'main'`, wired into the `gate` aggregator's `needs`. `dev`-targeting PRs skip it deliberately — a lagging pointer and unpaid back-sync are normal mid-cycle, and blocking them teaches people to ignore the check. `gate` already treats `skipped` as passing.

**The plumbing is proven, not assumed.** It is copied verbatim from `release-train.yml`, and scheduled run [30557811029](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/actions/runs/30557811029) exited 1 with `BLOCK Backend main→dev back-sync owed` — meaning that checkout+fetch pair resolves refs in **both** repos and fails for the reason the check exists, rather than dying at exit 2 on its own broken plumbing. That distinction is the one this repo keeps relearning.

## 3. Runner — `scripts/release/train-run.sh`

Stops before every mutating step, prints the state it is about to act on, and requires a **typed word** (`PROMOTE` / `BACKSYNC` / `RELEASE`) rather than y/n. A checklist persists in `.agent-work/` (gitignored), so an interrupted train resumes instead of restarting from memory.

`--status` and `--verify-only` are read-only, `--dry-run` runs nothing, and a **non-TTY refuses to confirm** rather than proceeding — verified.

### Two bugs found by running it, not reasoning about it

1. **False "promotion owed" against a just-released repo.** After a back-sync, Backend `dev` is *permanently* 1 ahead of `main` with an identical tree — the steady state, not unshipped work. Counting commits reports a promotion owed forever, which trains the reader to ignore the line. Now discriminates by tree, as `train-verify` does.
2. **`grep -c || echo 0` produced the two-line string `0\n0`** — `grep -c` already prints `0` and exits 1 — which blew up `$(( ))` with an arithmetic syntax error and derailed the entire verify mode.

### Step 9 verified in both directions against the live v0.4.8 deploy

```
POSITIVE  marker OWNERSHIP_ORPHANED_GUEST_ROW
  chunk-KLTA5W4T.js  257687 bytes  hits=1
  chunk-L4HQU7XA.js   41135 bytes  hits=1
  main-QIIFTY6Y.js   560638 bytes  hits=0      <-- the whole point
  ✓ marker found in 2 place(s) — this release IS live        exit 0

NEGATIVE  marker ZZZ_NOT_IN_ANY_BUILD_ZZZ
  ✗ marker not found in any served asset                     exit 1
```

`main-*.js` has **zero** hits while the chunks have them — exactly the shape that made a main-only poller report "not deployed" while v0.4.8 was serving. And a marker no build contains fails, so the check can fail for the reason it exists.

## Verification

- `bash -n` clean; exit codes checked: walk `1` (real back-sync debt), `--status` `0`, bad arg `2`, negative verify `1`.
- YAML parsed: `release-train` present, `if: github.base_ref == 'main'`, in `gate.needs` (11 entries).
- `train-verify.sh --for-release` exits 1 locally right now for three real reasons — the script fails, it is not a no-op.
- `format:check` clean; checklist state confirmed gitignored (`.gitignore:79`).

## Still owed on KAN-191

**A red test PR against `main` proving this job blocks the merge.** A green run proves the job exists, not that it can fail — that is the acceptance criterion on the ticket and it is not satisfied by this PR. Doing it here would mean opening a throwaway `dev → main` PR, which is a release-shaped action; better as its own deliberate step.

Related follow-ups filed from the v0.4.8 review: KAN-189, KAN-190, KAN-192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJTYg2F4r5Bcy6aX6hW8Ga

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

