### PR TITLE
ci: review every push to open PRs via synchronize (TAS-3006) [KAN-183]

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,10 +34,14 @@ name: Claude Review (independent model)
 
 on:
   pull_request:
-    # Auto once per PR (opened / un-drafted) + on-demand via the `claude-review`
-    # label. Deliberately NOT `synchronize` — one review per PR keeps cost bounded;
-    # re-request by re-applying the label. To review every push, add `synchronize`.
-    types: [opened, ready_for_review, labeled]
+    # Auto on PR open / un-draft AND on every push (`synchronize`) so commits
+    # pushed after the first review are reviewed too (TAS-3006 / KAN-183) — the PR
+    # lifecycle in CLAUDE.md ("monitor it, answer every comment, loop until
+    # merged") depends on the review loop covering later pushes, not just the first.
+    # Also on-demand via the `claude-review` label. The bot's own `--fix` pushes do
+    # NOT re-trigger (the `if:` guard below skips `github.event.sender.type == 'Bot'`),
+    # and `concurrency: cancel-in-progress` collapses rapid pushes to one review.
+    types: [opened, ready_for_review, labeled, synchronize]
     branches: [main, dev, 'dev/**']
   workflow_dispatch:
     inputs:

--- a/docs/ci/refresh/SPEC-03-claude-independent-review.md
+++ b/docs/ci/refresh/SPEC-03-claude-independent-review.md
@@ -63,9 +63,13 @@ with the model + effort used.
 - **Advisory:** `continue-on-error: true`; the job is **never** added to required
   status checks (SPEC-02). A missing `ANTHROPIC_API_KEY` or a flaky call cannot
   block a merge.
-- **Cost bounded:** triggers on `opened` / `ready_for_review` (once per PR) + the
-  `claude-review` label (on-demand re-review) + `workflow_dispatch` —
-  **not** on every `synchronize` push. `concurrency` cancels superseded runs.
+- **Reviews every push:** triggers on `opened` / `ready_for_review` + every
+  `synchronize` push (TAS-3006 / KAN-183 — commits pushed after the first review
+  must be reviewed too) + the `claude-review` label (on-demand re-review) +
+  `workflow_dispatch`. `concurrency: cancel-in-progress` collapses rapid pushes to
+  a single review, and the `sender.type != 'Bot'` guard stops the action's own
+  `--fix` pushes from re-triggering it — so cost stays bounded without dropping
+  `synchronize`.
   Model is always the cheaper Opus 4.x tier. `--max-turns 60` caps the agent loop
   (raised from 15 in cookbook #3129 after real reviews hit the ceiling mid-diff).
 - **Pushes to the PR branch:** `--fix` commits fixes back. Because it only runs on
@@ -104,7 +108,7 @@ with the model + effort used.
 
 | Choice | Default | Flip to |
 |---|---|---|
-| When it runs | once per PR + label + dispatch | add `synchronize` for every push |
+| When it runs | every push (`synchronize`) + open + label + dispatch (TAS-3006) | drop `synchronize` for once-per-PR |
 | Fix behavior | applies fixes (`--fix`) + comments | comment-only (drop `--fix` from prompt) |
 | Model | `claude-opus-4-7` (placeholder) | set `CLAUDE_REVIEW_MODEL` variable |
 | Effort | reviewer reasons per-diff | pin an effort in the prompt |

--- a/docs/ci/refresh/diagram-claude-review.md
+++ b/docs/ci/refresh/diagram-claude-review.md
@@ -12,7 +12,7 @@ fixes, and leaves a comment per fix. It is **never** a required check
 
 ```mermaid
 flowchart TD
-    PR[PR opened / ready / labeled 'claude-review'] --> GUARD{same-repo &&<br/>not bot/Dependabot &&<br/>not draft?}
+    PR[PR opened / ready / pushed 'synchronize' / labeled 'claude-review'] --> GUARD{same-repo &&<br/>not bot/Dependabot &&<br/>not draft?}
     GUARD -->|no| SKIP([skip cleanly — no secrets on forks])
     GUARD -->|yes| PICK["Pick model (deterministic):<br/>vars.CLAUDE_REVIEW_MODEL,<br/>default claude-opus-4-7<br/>(≠ authoring 4.8 / Fable 5 → cheaper + independent)"]
     PICK --> DIFF["Read the diff vs base branch"]
@@ -31,7 +31,9 @@ flowchart TD
     style SKIP fill:#6b7280,color:#fff
 ```
 
-**Cost controls:** runs once per PR (`opened` / `ready_for_review`), on-demand via
-the `claude-review` label or `workflow_dispatch` — **not** on every `synchronize`
-push; `concurrency` cancels superseded runs; the model is always the cheaper
-Opus 4.x tier.
+**Cost controls:** runs on PR open (`opened` / `ready_for_review`), on every push
+(`synchronize`, so later commits are reviewed too — TAS-3006), on-demand via the
+`claude-review` label, and via `workflow_dispatch`; `concurrency:
+cancel-in-progress` collapses rapid pushes to one review and the `sender.type !=
+'Bot'` guard stops the action's own `--fix` pushes from re-triggering it; the
+model is always the cheaper Opus 4.x tier.


### PR DESCRIPTION
## What

Adds `synchronize` to the `pull_request` triggers of `.github/workflows/claude-review.yml` so the independent Claude review fires on **every push** to an open PR — not just the first (`opened`/`ready_for_review`) or on-demand (`claude-review` label). Docs (SPEC-03 + diagram) updated to match.

## Why

The review workflow **deliberately excluded** `synchronize`, so commits pushed after the first review were **never reviewed** — silently. That defeats the PR review loop CLAUDE.md depends on: *monitor it, answer every comment, loop until merged*.

TAS-3006 (execution KAN-183) requires the review workflows to trigger on `synchronize` in **both** repos. This is the cookbook half; Backend is [PR #266](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/266).

## Cost safety (minimal diff, existing guards)

No new debounce logic — redundant firing is already bounded by two guards already in the workflow:
- `github.event.sender.type != 'Bot'` (`if:` guard) — the action's own `--fix` pushes do **not** re-trigger it, so no review→fix→review loop.
- `concurrency: cancel-in-progress` — rapid successive pushes collapse to a single review.

Still advisory / fail-open (`continue-on-error: true`); never a required check.

## Done when

A push to an open PR produces a fresh review — verifiable on this PR itself once merged, or on any subsequent push.

_Authored by Claude on Adam's behalf_

<!-- generated-by-cyrus -->






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

