### PR TITLE
feat(pm): port pi's AOTA alignment + PM snapshot into Claude session logs [KAN-202]

### DIFF
--- a/.claude/hooks/lib/pm-snapshot.sh
+++ b/.claude/hooks/lib/pm-snapshot.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# PM snapshot builder — shared by precompact-session-log.sh and
+# sessionend-session-log.sh.
+#
+# WHY THIS EXISTS
+# The auto-log summarizer runs `claude -p ... --allowedTools ''`. It can read
+# NOTHING but the prompt it is handed. So a transcript-only log can never cite
+# the PR the session opened, the daemon state, or how far the branch is ahead
+# of dev — unless those facts happened to be typed into the conversation.
+# This script gathers them from the machine and prints a markdown block that the
+# hooks paste into the prompt, so the model reports facts instead of guessing.
+#
+# Ported from the `buildPmSnapshot` function in the pi extension at
+# .pi/extensions/atlassian-aota/index.js, which had the same problem and solved
+# it the same way. The pi original is left in place and unchanged.
+#
+# Usage:  pm-snapshot.sh <project_dir> <main_repo> <branch>
+# Output: a markdown block on stdout. Always exits 0 — callers append `|| true`
+#         and treat empty output as "no snapshot", never as an error. Nothing in
+#         here may block a session teardown or a compaction.
+
+set -uo pipefail
+
+PROJECT_DIR="${1:-$(pwd)}"
+MAIN_REPO="${2:-$PROJECT_DIR}"
+BRANCH="${3:-unknown}"
+
+BACKEND_REPO="adamtasteslikegood/tasteslikegood.com"
+
+# `timeout` is GNU coreutils and is absent by default on macOS. Same fallback
+# ladder the hooks use for the summarizer. Every command below is wrapped:
+# these are network calls, and a hung `gh` must not strand the worker.
+if command -v timeout >/dev/null 2>&1; then
+  _t() { timeout "$@"; }
+elif command -v gtimeout >/dev/null 2>&1; then
+  _t() { gtimeout "$@"; }
+else
+  _t() { shift; "$@"; }  # drop the duration, run unbounded (worker is detached)
+fi
+
+echo "## PM snapshot (gathered from the machine, not the transcript)"
+echo
+echo "- Branch: \`$BRANCH\`"
+
+# --- git position ----------------------------------------------------------
+# "Ahead of dev" is the single most useful number for a reader deciding whether
+# the session's work actually landed anywhere.
+AHEAD=$(_t 10 git -C "$PROJECT_DIR" rev-list --count origin/dev..HEAD 2>/dev/null || echo "")
+[ -n "$AHEAD" ] && echo "- Commits ahead of \`origin/dev\`: $AHEAD"
+
+DIRTY=$(_t 10 git -C "$PROJECT_DIR" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+[ -n "$DIRTY" ] && echo "- Uncommitted files in working tree: $DIRTY"
+
+# Cap the file list: a big refactor would otherwise crowd out the transcript.
+CHANGED=$(_t 10 git -C "$PROJECT_DIR" diff --name-only origin/dev...HEAD 2>/dev/null | head -25)
+if [ -n "$CHANGED" ]; then
+  echo "- Files changed vs \`origin/dev\` (first 25):"
+  printf '%s\n' "$CHANGED" | sed 's/^/  - /'
+fi
+
+# --- open PRs for this branch ----------------------------------------------
+# Both repos: a session that touched Backend/ has a PR in each. Without this the
+# log says "opened a PR" with no number.
+if command -v gh >/dev/null 2>&1 && [ "$BRANCH" != "unknown" ]; then
+  for spec in "cookbook|" "Backend|-R $BACKEND_REPO"; do
+    label="${spec%%|*}"
+    repo_args="${spec#*|}"
+    # shellcheck disable=SC2086 -- repo_args is an intentional argument split
+    prs=$(_t 25 gh pr list $repo_args --head "$BRANCH" --state open \
+            --json number,title,url \
+            --jq '.[] | "  - #\(.number) \(.title) — \(.url)"' 2>/dev/null || echo "")
+    if [ -n "$prs" ]; then
+      echo "- Open $label PRs for this branch:"
+      printf '%s\n' "$prs"
+    else
+      echo "- Open $label PRs for this branch: none found"
+    fi
+  done
+else
+  echo "- Open PRs: not checked (gh unavailable or branch unknown)"
+fi
+
+# --- PM daemon + briefing freshness ----------------------------------------
+# Only `npm run pm:daemon` writes this pidfile; the per-session MCP daemons do
+# not. So "not running" is the common, harmless case — it means nobody started
+# a background daemon on this machine, NOT that PM tooling is broken. Worth
+# recording either way, because a stale briefing explains a stale session log.
+PID_FILE="$MAIN_REPO/.agent-work/pm/pm-daemon.pid"
+if [ -f "$PID_FILE" ]; then
+  PID=$(tr -d '[:space:]' <"$PID_FILE" 2>/dev/null || echo "")
+  if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+    echo "- PM daemon (pm:daemon): running, pid $PID"
+  else
+    echo "- PM daemon (pm:daemon): pidfile present but process $PID is gone (stale)"
+  fi
+else
+  echo "- PM daemon (pm:daemon): not running (normal — MCP-spawned daemons write no pidfile)"
+fi
+
+BRIEFING="$MAIN_REPO/.agent-work/pm/PROJECT_PM_BRIEFING.md"
+if [ -f "$BRIEFING" ]; then
+  # `date -r` is BSD; GNU needs -r too but with a different meaning for other
+  # flags, so use stat where available and fall back quietly.
+  MTIME=$(date -u -r "$BRIEFING" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+          || stat -c %y "$BRIEFING" 2>/dev/null || echo "unknown")
+  echo "- PM briefing last refreshed: $MTIME"
+else
+  echo "- PM briefing: absent (run \`npm run pm:brief\`)"
+fi
+
+# --- Atlassian link check ---------------------------------------------------
+# Bounded hard: run_pm_script.sh bootstraps a venv on first run, and this is a
+# network call. 25s then give up — an unreachable Jira must not cost the log.
+if [ -f "$MAIN_REPO/scripts/pm/run_pm_script.sh" ]; then
+  CHECK=$(_t 25 bash "$MAIN_REPO/scripts/pm/run_pm_script.sh" \
+            atlassian_pm_link.py check 2>/dev/null | tail -12 || echo "")
+  if [ -n "$CHECK" ]; then
+    echo "- Atlassian link check:"
+    printf '%s\n' "$CHECK" | sed 's/^/  /'
+  else
+    echo "- Atlassian link check: unavailable (timed out or errored)"
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/precompact-session-log.sh
+++ b/.claude/hooks/precompact-session-log.sh
@@ -129,6 +129,19 @@ fi
   BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo unknown)
   STAMP=$(date -u +%Y%m%d-%H%M%S)
 
+  # PM snapshot: the facts the summarizer cannot see for itself. It runs with
+  # --allowedTools '' and can read nothing but this prompt, so without this it
+  # could never cite a PR number or the branch's position — it could only repeat
+  # what happened to be typed in the conversation. Same checkout-preference rule
+  # as DIGEST_PY above; fails open to no snapshot rather than costing the log.
+  SNAP_SH="$PROJECT_DIR/.claude/hooks/lib/pm-snapshot.sh"
+  [ -f "$SNAP_SH" ] || SNAP_SH="$MAIN_REPO/.claude/hooks/lib/pm-snapshot.sh"
+  PM_SNAPSHOT=""
+  if [ -f "$SNAP_SH" ]; then
+    PM_SNAPSHOT=$(bash "$SNAP_SH" "$PROJECT_DIR" "$MAIN_REPO" "$BRANCH" 2>>"$LOG" || echo "")
+  fi
+  [ -n "$PM_SNAPSHOT" ] || PM_SNAPSHOT="(PM snapshot unavailable.)"
+
   # Haiku is deliberate here: this is compression, not reasoning. Cheap + fast.
   # --allowedTools '' keeps it from touching the repo; it only reads the digest
   # we hand it on stdin and emits markdown.
@@ -155,8 +168,38 @@ Bullets of work explicitly left undone, deferred, or flagged. If none, 'None.'
 Bullets of anything surprising, non-obvious, or that cost time — the things a
 future session would want to know. If none, 'None.'
 
+## Atlassian Alignment
+Open with exactly one verdict in bold — **Aligned**, **Partially aligned**, or
+**Drifting** — then 1-3 bullets of evidence naming the specific KAN/RCP keys and
+PR numbers you saw. Judge with this rubric (AOTA — Atlassian Outside The Agent):
+  * Git = code truth. KAN = execution truth (who is on what, blockers, handoffs).
+    RCP = delivery truth (sprint scope, epics, acceptance criteria).
+    Confluence = durable narrative and session-history truth.
+  * **Aligned** — active work is visible in KAN, delivery impact is visible in
+    RCP, durable context is in Confluence, and all three match the branch/PR
+    state shown in the PM snapshot below.
+  * **Partially aligned** — one of KAN/RCP/Confluence is stale or missing key
+    updates. The work is visible, but a fresh agent could not resume cleanly.
+  * **Drifting** — branch/PR reality materially differs from what Jira or
+    Confluence says. A future agent reading Atlassian alone would assume wrong.
+If you have too little to judge, write '**Partially aligned** — insufficient
+evidence in transcript' and say what is missing. Never guess a verdict you
+cannot support from the transcript or the snapshot.
+
 Rules: be concrete, name files and identifiers, no filler, no preamble. Do not
-invent anything not present in the transcript. Output ONLY the markdown.
+invent anything not present in the transcript or the PM snapshot. Where the two
+disagree on branch, PR, or commit facts, TRUST THE SNAPSHOT — it was read from
+the machine just now; the transcript may be stale or aspirational.
+
+NEVER reproduce secrets on this page: no API keys, bearer tokens, .env contents,
+or credentials pasted into the terminal. If sensitive material did appear in the
+session, record only the operational fact that it appeared, that it was omitted
+here, and whether rotation looks warranted.
+
+Output ONLY the markdown.
+
+--- PM SNAPSHOT (read from the machine, authoritative for branch/PR facts) ---
+$PM_SNAPSHOT
 
 --- TRANSCRIPT DIGEST ---
 $(cat "$DIGEST")"

--- a/.claude/hooks/sessionend-session-log.sh
+++ b/.claude/hooks/sessionend-session-log.sh
@@ -143,6 +143,19 @@ fi
   BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo unknown)
   STAMP=$(date -u +%Y%m%d-%H%M%S)
 
+  # PM snapshot: the facts the summarizer cannot see for itself. It runs with
+  # --allowedTools '' and can read nothing but this prompt, so without this it
+  # could never cite a PR number or the branch's position — it could only repeat
+  # what happened to be typed in the conversation. Same checkout-preference rule
+  # as DIGEST_PY above; fails open to no snapshot rather than costing the log.
+  SNAP_SH="$PROJECT_DIR/.claude/hooks/lib/pm-snapshot.sh"
+  [ -f "$SNAP_SH" ] || SNAP_SH="$MAIN_REPO/.claude/hooks/lib/pm-snapshot.sh"
+  PM_SNAPSHOT=""
+  if [ -f "$SNAP_SH" ]; then
+    PM_SNAPSHOT=$(bash "$SNAP_SH" "$PROJECT_DIR" "$MAIN_REPO" "$BRANCH" 2>>"$LOG" || echo "")
+  fi
+  [ -n "$PM_SNAPSHOT" ] || PM_SNAPSHOT="(PM snapshot unavailable.)"
+
   PROMPT="You are writing a session log for an engineering team's Confluence.
 
 Below is a condensed transcript of a Claude Code session on branch \`$BRANCH\`.
@@ -166,8 +179,38 @@ Bullets of work explicitly left undone, deferred, or flagged. If none, 'None.'
 Bullets of anything surprising, non-obvious, or that cost time — the things a
 future session would want to know. If none, 'None.'
 
+## Atlassian Alignment
+Open with exactly one verdict in bold — **Aligned**, **Partially aligned**, or
+**Drifting** — then 1-3 bullets of evidence naming the specific KAN/RCP keys and
+PR numbers you saw. Judge with this rubric (AOTA — Atlassian Outside The Agent):
+  * Git = code truth. KAN = execution truth (who is on what, blockers, handoffs).
+    RCP = delivery truth (sprint scope, epics, acceptance criteria).
+    Confluence = durable narrative and session-history truth.
+  * **Aligned** — active work is visible in KAN, delivery impact is visible in
+    RCP, durable context is in Confluence, and all three match the branch/PR
+    state shown in the PM snapshot below.
+  * **Partially aligned** — one of KAN/RCP/Confluence is stale or missing key
+    updates. The work is visible, but a fresh agent could not resume cleanly.
+  * **Drifting** — branch/PR reality materially differs from what Jira or
+    Confluence says. A future agent reading Atlassian alone would assume wrong.
+If you have too little to judge, write '**Partially aligned** — insufficient
+evidence in transcript' and say what is missing. Never guess a verdict you
+cannot support from the transcript or the snapshot.
+
 Rules: be concrete, name files and identifiers, no filler, no preamble. Do not
-invent anything not present in the transcript. Output ONLY the markdown.
+invent anything not present in the transcript or the PM snapshot. Where the two
+disagree on branch, PR, or commit facts, TRUST THE SNAPSHOT — it was read from
+the machine just now; the transcript may be stale or aspirational.
+
+NEVER reproduce secrets on this page: no API keys, bearer tokens, .env contents,
+or credentials pasted into the terminal. If sensitive material did appear in the
+session, record only the operational fact that it appeared, that it was omitted
+here, and whether rotation looks warranted.
+
+Output ONLY the markdown.
+
+--- PM SNAPSHOT (read from the machine, authoritative for branch/PR facts) ---
+$PM_SNAPSHOT
 
 --- TRANSCRIPT DIGEST ---
 $(cat "$DIGEST")"

--- a/.claude/skills/sync-and-clear/SKILL.md
+++ b/.claude/skills/sync-and-clear/SKILL.md
@@ -62,12 +62,30 @@ If the daemon is unavailable, fall back to the script path:
 bash scripts/pm/run_pm_script.sh publish_session_log.py --file <path.md>
 ```
 
-### 3. Sync any modified planning docs
+### 3. Assess Atlassian alignment
+
+Before you call the tool, decide whether Atlassian actually matches the work.
+Read [`references/AOTA_MODEL.md`](references/AOTA_MODEL.md) and commit to one
+verdict — **Aligned**, **Partially aligned**, or **Drifting** — then lead the
+`summary` with it and name the KAN/RCP keys that justify it.
+
+This is the judgement a transcript cannot supply, and it is why logs kept
+rendering "Atlassian Alignment: Not assessed". The auto-capture hooks now emit
+the same verdict from a compressed copy of the rubric inlined in their prompts,
+so manual and automatic logs stay comparable.
+
+If the verdict is anything but **Aligned**, convert the gap into concrete
+follow-ups using [`references/TODO_SCHEMA.md`](references/TODO_SCHEMA.md) —
+KAN execution, RCP delivery, and Confluence buckets kept separate — and pass
+them as `follow_up_items`. A "Drifting" verdict with no TODOs is a
+note-to-nobody.
+
+### 4. Sync any modified planning docs
 
 If this session changed anything under `specs/`, call
 `mcp__pm-daemon__sync_pm_documents` so Confluence matches the repo.
 
-### 4. Verify, then hand off
+### 5. Verify, then hand off
 
 The tool returns a Confluence URL. **Check the return value**:
 
@@ -89,3 +107,19 @@ Close with the URL and an explicit: *"Session logged. Safe to `/clear` now."*
   needs the reasoning, not the transcript.
 - If something failed this session, the log says so. Session logs that only
   record wins are how a team learns the wrong lesson twice.
+- Never put secrets on the page — no API keys, tokens, or `.env` contents. If
+  sensitive material surfaced, record only that it did, that it was omitted, and
+  whether rotation is warranted.
+
+## References
+
+- [`references/AOTA_MODEL.md`](references/AOTA_MODEL.md) — the Atlassian
+  Outside The Agent operating model and the three-way alignment rubric.
+- [`references/TODO_SCHEMA.md`](references/TODO_SCHEMA.md) — the shape for
+  splitting follow-up work across KAN, RCP, and Confluence.
+
+Both are ported from `.pi/skills/atlassian-session-log/references/`, which stays
+in place for the pi agent. The pi extension
+(`.pi/extensions/atlassian-aota/index.js`) registers pi's own `/session-log` and
+`/sync-clear` commands against the *same* publisher, `publish_session_log.py` —
+so pi and Claude write to one Confluence index, not two.

--- a/.claude/skills/sync-and-clear/references/AOTA_MODEL.md
+++ b/.claude/skills/sync-and-clear/references/AOTA_MODEL.md
@@ -1,0 +1,89 @@
+# AOTA Model
+
+> **Provenance.** Ported verbatim from
+> `.pi/skills/atlassian-session-log/references/AOTA_MODEL.md`, which remains in
+> place as the pi agent's copy. Keep the two in sync by hand if either changes —
+> the rubric is agent-agnostic on purpose, so there is no reason for them to
+> diverge. A compressed form of the alignment rubric below is ALSO inlined into
+> the prompts in `.claude/hooks/precompact-session-log.sh` and
+> `.claude/hooks/sessionend-session-log.sh`; those summarizers run with
+> `--allowedTools ''` and cannot read this file, so edits here must be mirrored
+> into those two prompts to take effect on auto-captured logs.
+
+AOTA = Atlassian Outside The Agent.
+
+This repo treats Atlassian as the cross-agent source of truth outside git.
+
+## Board / space roles
+
+- **Git** = code truth
+- **KAN** = execution truth
+- **RCP** = delivery truth
+- **Confluence** = durable planning, documentation, and session-history truth
+
+## Meaning
+
+### KAN
+Use KAN for:
+- active branch ownership
+- who is currently working on what
+- in-flight execution state
+- blockers and handoffs
+- immediate next actions
+
+### RCP
+Use RCP for:
+- release-candidate planning
+- sprint scope
+- epics and delivery slices
+- acceptance criteria
+- scope changes that affect delivery commitments
+
+### Confluence
+Use Confluence for:
+- durable planning history
+- session logs
+- documentation
+- decision narrative
+- handoff context that should outlive local chat and local files
+
+## Alignment rubric
+
+### Aligned
+- Active work is visible in KAN
+- Delivery impact is visible in RCP
+- Durable narrative/context is visible in Confluence
+- Session log matches the branch/PR state
+
+### Partially aligned
+- One of KAN, RCP, or Confluence is stale or missing key updates
+- Work is visible, but not enough for a new agent to resume cleanly
+
+### Drifting
+- Code/branch/PR work materially differs from Jira or Confluence
+- A future agent would make the wrong assumption from Atlassian alone
+
+## Non-destructive rule
+
+Session logging should be additive.
+
+Prefer:
+- new Confluence pages
+- append-only logs
+- versioned updates
+- explicit references to branch, PR, Jira issue, and timestamp
+
+Avoid destructive overwrites of historical narrative.
+
+## Sensitive data rule
+
+Durable Atlassian pages must never include:
+- raw API keys
+- raw bearer tokens
+- `.env` contents
+- secrets copied from terminal or chat transcripts
+
+If secrets appeared in-session, record only the operational fact:
+- that sensitive material was seen
+- that it was intentionally omitted from the durable page
+- whether rotation is recommended

--- a/.claude/skills/sync-and-clear/references/TODO_SCHEMA.md
+++ b/.claude/skills/sync-and-clear/references/TODO_SCHEMA.md
@@ -1,0 +1,58 @@
+# TODO Schema
+
+> **Provenance.** Ported verbatim from
+> `.pi/skills/atlassian-session-log/references/TODO_SCHEMA.md`, which remains in
+> place as the pi agent's copy. Unlike the AOTA rubric, this schema is NOT
+> inlined into the auto-capture hooks — splitting follow-ups into KAN / RCP /
+> Confluence buckets needs judgement about delivery scope that a Haiku
+> transcript-compression pass should not be making. Use it in the deliberate
+> path: when `sync-and-clear` runs and the session left real follow-up work.
+
+Use this structure when converting a session log into follow-up work.
+
+```md
+# Session Follow-up TODOs — {timestamp}
+
+## Session Refs
+- Branch:
+- Root PR:
+- Backend PR:
+- KAN issue:
+- RCP issue:
+- Session log page:
+
+## KAN Execution TODOs
+- **What:**
+  - **Why:**
+  - **Owner / actor:**
+  - **Branch / PR refs:**
+  - **Status to set:**
+  - **Done when:**
+
+## RCP Delivery TODOs
+- **What:**
+  - **Why:**
+  - **Sprint / epic impact:**
+  - **Branch / PR refs:**
+  - **Acceptance / done criteria:**
+  - **Done when:**
+
+## Confluence TODOs
+- **What page / log / doc should change:**
+  - **Why:**
+  - **Source session / branch:**
+  - **Non-destructive update pattern:**
+  - **Done when:**
+
+## Optional Drift Fixes
+- **Mismatch:**
+  - **Correction to make:**
+  - **Why it matters for the next actor:**
+```
+
+## Rules
+- KAN items should describe active execution work.
+- RCP items should describe delivery-plan work.
+- Confluence items should preserve durable context.
+- Include refs so a fresh agent can jump directly to the right board, PR, or page.
+- Every TODO should be explicit enough for a fresh agent to pick up.


### PR DESCRIPTION
## Why

Auto-captured session logs kept rendering **"Atlassian Alignment: Not assessed"**, and could never cite a PR number. Same root cause for both: the hook summarizer runs `claude -p --allowedTools ''`, so it can read *nothing* but the prompt it is handed — and that prompt asked for five transcript-only sections.

The pi agent's `.pi/` config had already solved this for its own front-end, and it publishes through the **same** `scripts/pm/publish_session_log.py` — so pi and Claude write to one Confluence index, not two. This ports the three portable ideas across.

Audited while scoping this: session logs *are* landing correctly — Confluence space **TLG**, children of page **34635777 "Agent Session Logs"**, each labelled `agent-session-log`. Placement was never the problem; content was.

## What changed

| File | Change |
|---|---|
| `.claude/hooks/lib/pm-snapshot.sh` | **new** — branch position vs `origin/dev`, open cookbook **and** Backend PRs for the branch, changed files, PM daemon state, briefing freshness, Atlassian link check |
| `precompact-session-log.sh` | pastes the snapshot into the prompt; adds `## Atlassian Alignment` + secrets rule |
| `sessionend-session-log.sh` | same two changes |
| `.claude/skills/sync-and-clear/references/AOTA_MODEL.md` | ported from `.pi/` |
| `.claude/skills/sync-and-clear/references/TODO_SCHEMA.md` | ported from `.pi/` |
| `.claude/skills/sync-and-clear/SKILL.md` | new alignment step (3), renumbered 4/5, References section |

## Design notes

- **The rubric is inlined, not referenced.** The summarizer has no tools and cannot open `AOTA_MODEL.md`. The skill copy carries a header saying edits must be mirrored into both hook prompts to affect auto-captured logs.
- **The snapshot outranks the transcript.** The prompt says to trust it on branch/PR/commit facts — it was read from the machine; the transcript may be stale or aspirational. And to write "insufficient evidence" rather than guess a verdict.
- **Fail-open everywhere.** `pm-snapshot.sh` always exits 0, every call is bounded by `timeout(1)` with a `gtimeout`/unbounded ladder for macOS. A hung `gh` must never cost a session log or block a compaction.
- **`TODO_SCHEMA.md` is deliberately NOT inlined** into the hooks — splitting follow-ups across KAN/RCP/Confluence needs delivery judgement a Haiku compression pass should not be making. It lives in the deliberate `sync-and-clear` path.
- **`.pi/` is untouched** (0 files from `.pi/` in the diff). pi keeps using the originals.

## Verification

- `bash -n` clean on all three scripts
- `scripts/pm/test_precompact_hook.py` — 4/4 pass
- `pm-snapshot.sh` live run: 2.5s, Atlassian check returns `Connection check passed`
- End-to-end: PreCompact hook run for real against a live transcript, publishing to Confluence — result appended below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9HBZQ4rRxotou198eaphu
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

