### PR TITLE
fix(gcp-monitor): bound every requirements floor so mcp 2.0.0 can't break the image [KAN-207]

### DIFF
--- a/scripts/monitoring/requirements.txt
+++ b/scripts/monitoring/requirements.txt
@@ -1,14 +1,23 @@
 # Runtime dependencies for scripts/monitoring/gcp_mcp_server.py
 # Install with: pip install -r scripts/monitoring/requirements.txt
 #
+# EVERY floor here carries a major-version ceiling. There is no lockfile and
+# nothing in CI builds this image, so a bare floor means the next `docker build`
+# silently adopts whatever major shipped that morning. That is not theoretical:
+# mcp 2.0.0 (2026-07-28) deleted mcp/server/fastmcp/ and the Railway service
+# crash-looped on `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`
+# from the next rebuild onward. Raise a ceiling deliberately, with a test.
+#
 # mcp >= 1.10 is required for the Streamable HTTP transport used by the hosted
 # Cloud Run connector (mcp.streamable_http_app()); stdio mode works on older
 # releases but the pin is unified so both transports share one venv/image.
-mcp>=1.10.0
-google-cloud-monitoring>=2.21.0
+# < 2.0 because 2.x replaces mcp.server.fastmcp with mcp.server.mcpserver;
+# gcp_mcp_server.py imports FastMCP directly and has not been ported.
+mcp>=1.10.0,<2.0.0
+google-cloud-monitoring>=2.21.0,<3.0.0
 # Only used by the HTTP transport (_run_http); both ship with mcp's server
 # extra, but gcp_mcp_server.py imports starlette directly and uvicorn is the
 # HTTP entrypoint, so both are pinned explicitly — the Cloud Run image must
 # not depend on mcp's dependency graph keeping them around.
-starlette>=0.40.0
-uvicorn>=0.30.0
+starlette>=0.40.0,<2.0.0
+uvicorn>=0.30.0,<1.0.0


### PR DESCRIPTION
Fixes the crash-looping gcp-monitor Railway service (Jira: [KAN-207](https://tasteslikegood.atlassian.net/browse/KAN-207)).

## Symptom

Railway project `content-fascination` → service `tasteslikegoodtheangularsvegancookbook` (root `/scripts/monitoring`, branch `dev`) has been crash-looping since 2026-08-04. Latest deployment `70b23e97`, commit `27a09a9`, instance `CRASHED`:

```
File "/app/gcp_mcp_server.py", line 75, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

## Root cause

`scripts/monitoring/requirements.txt` declared floors with **no ceilings**. Upstream, four minutes apart:

| version | released | `fastmcp` entries in wheel |
| --- | --- | --- |
| `mcp 1.29.0` | 2026-07-28 13:41:40 UTC | **19** — `FastMCP` exported, `streamable_http_app` + `streamable_http_path` present |
| `mcp 2.0.0` | 2026-07-28 13:45:28 UTC | **0** — `mcp/server/fastmcp/` deleted, replaced by `mcp/server/mcpserver/` |

The service has `watchPatterns: []`, so **every** push to `dev` rebuilds it. The first one after mcp 2.0.0 shipped was 2026-08-04 (dependabot npm bumps #3339/#3340). That rebuild resolved `mcp>=1.10.0` to 2.0.0.

The dependabot merges are the **trigger, not the cause** — nothing they change is inside this Python image. Redeploying just re-resolves the same unpinned floor, which is why the retry crashed too. Merging the remaining open dependabot PRs would crash it a third time.

No lockfile, and nothing in `pr-gate.yml` builds or imports `scripts/monitoring`, so nothing constrained or detected the resolution. The local venv holds `mcp 1.28.1` and imports fine — works-locally / fails-in-fresh-build drift.

## Change

A major-version ceiling on all four floors, not just `mcp` — same defect class, and `starlette` had already silently crossed 0.x → 1.4.1 through the same gap.

```
mcp>=1.10.0,<2.0.0
google-cloud-monitoring>=2.21.0,<3.0.0
starlette>=0.40.0,<2.0.0
uvicorn>=0.30.0,<1.0.0
```

PR #3056 (`fix: declare starlette explicitly in gcp-monitor requirements`) was this same class of bug in this same 5-line file. Second occurrence, hence the comment block explaining why the ceilings are load-bearing.

## Verification

Docker, against the real `scripts/monitoring/Dockerfile`:

**Before** — reproduces the Railway crash exactly:
```
Downloading mcp-2.0.0-py3-none-any.whl.metadata
$ docker run --rm gcpmon-repro:before
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

**After** — resolves `mcp-1.29.0`, container stays up:
```
Downloading mcp-1.29.0-py3-none-any.whl
gcp-monitor MCP serving at path /********/mcp (token redacted) on port 8080
INFO:     Started server process [1]
StreamableHTTP session manager started
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8080
status after 10s: running
GET /testtoken/mcp -> HTTP 406
```

`406` on a bare GET is correct: the MCP streamable-HTTP layer requires `Accept: text/event-stream`. That's a live app routing properly, not a crash.

## Follow-ups (deliberately not in this PR)

1. No CI job builds or imports `scripts/monitoring`, so this class of break can't be caught before deploy. A build-and-import smoke job would close it.
2. The Railway service's empty `watchPatterns` means unrelated commits redeploy it. Scoping to `scripts/monitoring/**` is a dashboard setting — Adam's call.
3. `scripts/pm/requirements.txt` has the same unbounded-floor pattern and hasn't been audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoJHnLQi9JDkh87sSZYDuB

[KAN-207]: https://tasteslikegood.atlassian.net/browse/KAN-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

