### PR TITLE
ci(deps): exempt lightningcss (MPL-2.0) so vite bumps stop failing Dependency Review [KAN-208]

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,9 +28,41 @@ jobs:
           retry-on-snapshot-warnings: true
           # Only allow permissive licenses; blocks GPL, AGPL, and other copyleft licenses
           allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, BlueOak-1.0.0, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Unlicense, WTFPL, Python-2.0
+          # Package-level exemptions. Each entry needs a recorded reason — an
+          # unexplained purl here is indistinguishable from a policy hole.
+          #
           # protobufjs >=7.6.3 declares 'BSD-3-Clause AND LicenseRef-scancode-protobuf'.
           # The LicenseRef component is Google's protobuf license (BSD-style with a
           # sublicensing clause) — permissive, but the compound SPDX expression fails
           # the allow-list above. Exempt the package so security bumps aren't blocked
-          # (see issue #3010).
-          allow-dependencies-licenses: pkg:npm/protobufjs
+          # (see issue #3010, KAN-90).
+          #
+          # lightningcss and its platform binaries declare MPL-2.0, which is file-level
+          # copyleft rather than the project-level copyleft this allow-list exists to
+          # block. It is a Rust-compiled CSS transformer that runs at BUILD time, reached
+          # transitively through vite (devDependency) and @angular/build; no MPL source is
+          # redistributed in the browser bundle and we do not modify it.
+          #
+          # It is also already in the tree at 1.32.0 — dependency-review only license-checks
+          # packages with change_type 'added', so the copy on dev was never gated, and only
+          # a version bump re-adds it and trips the check. Without these entries EVERY vite
+          # or @angular/build bump that moves the lightningcss version fails a required
+          # status check (KAN-208, first hit on PR #3348 bumping vite 8.1.5 → 8.2.0).
+          #
+          # Exempted per-package rather than adding MPL-2.0 to allow-licenses above: a
+          # blanket entry would also permit MPL for genuine runtime dependencies, which is
+          # a different risk decision than this one.
+          allow-dependencies-licenses: >-
+            pkg:npm/protobufjs,
+            pkg:npm/lightningcss,
+            pkg:npm/lightningcss-android-arm64,
+            pkg:npm/lightningcss-darwin-arm64,
+            pkg:npm/lightningcss-darwin-x64,
+            pkg:npm/lightningcss-freebsd-x64,
+            pkg:npm/lightningcss-linux-arm-gnueabihf,
+            pkg:npm/lightningcss-linux-arm64-gnu,
+            pkg:npm/lightningcss-linux-arm64-musl,
+            pkg:npm/lightningcss-linux-x64-gnu,
+            pkg:npm/lightningcss-linux-x64-musl,
+            pkg:npm/lightningcss-win32-arm64-msvc,
+            pkg:npm/lightningcss-win32-x64-msvc


### PR DESCRIPTION
## What breaks today

`Dependency Review` — a **required status check** on `dev` and `main` — fails on **#3348** (`vite 8.1.5 → 8.2.0`) with twelve packages denied on license grounds:

`lightningcss@1.33.0` plus its eleven optional platform binaries (`-android-arm64`, `-darwin-arm64`, `-darwin-x64`, `-freebsd-x64`, `-linux-arm-gnueabihf`, `-linux-arm64-gnu`, `-linux-arm64-musl`, `-linux-x64-gnu`, `-linux-x64-musl`, `-win32-arm64-msvc`, `-win32-x64-msvc`). All declare **MPL-2.0**, absent from `allow-licenses`.

## Root cause — it is not a new dependency

`lightningcss@1.32.0` is **already on `dev`**, reaching the tree transitively via `vite` (devDependency) and `@angular/build`:

```
├─┬ @angular/build@22.1.2 → vite@7.3.6 → lightningcss@1.32.0
└─┬ vite@8.1.5           → lightningcss@1.32.0
```

`dependency-review-action` only license-checks packages whose `change_type` is `added`. The copy already in the lockfile was therefore never gated — the 1.32.0 → 1.33.0 bump re-adds it, and only then does the allow-list see it.

**So this is a recurring blocker, not a one-off:** every future `vite` / `@angular/build` bump that moves the lightningcss version fails a required check the same way.

## Why exempting is the right call

MPL-2.0 is **file-level** copyleft — obligations attach to modifications of the MPL files themselves, not to the project that links them. That is materially different from the GPL/AGPL project-level copyleft this allow-list exists to block. `lightningcss` is a Rust-compiled CSS transformer that runs **at build time**; no MPL source is redistributed in the browser bundle, and we do not modify it.

## Why per-package and not `allow-licenses: MPL-2.0`

Adding `MPL-2.0` to `allow-licenses` is a blanket policy change that would also permit MPL for genuine runtime dependencies — a different risk decision than this one, and one that should be made deliberately rather than as a side effect of unblocking a vite bump. This PR instead mirrors the `protobufjs` exemption already in the file, and adds a recorded reason for both entries (an unexplained purl in that list is indistinguishable from a policy hole).

## Verification

```
$ python3 -c "import yaml; ..."   # parses; 13 purls, comma-separated
$ npx prettier --check .github/workflows/dependency-review.yml
All matched files use Prettier code style!
```

The decisive proof is on **#3348**: once this lands on `dev`, that PR needs `@dependabot recreate` to rebase onto the new `dev`, and its `Dependency Review` must go green. I will confirm that rather than assume it.

**Not covered by this change:** the exemption is package-scoped, so a *new* MPL-2.0 dependency still fails the check. That is intended.

## Jira

[KAN-208](https://tasteslikegood.atlassian.net/browse/KAN-208) · related: KAN-90 (the protobufjs instance of this same class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp

[KAN-208]: https://tasteslikegood.atlassian.net/browse/KAN-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

