### PR TITLE
fix(ssr-entry): dedupe in-flight saves so a first-time save emits exactly one toast [KAN-198]

### DIFF
--- a/src/services/ssr-entry.service.test.ts
+++ b/src/services/ssr-entry.service.test.ts
@@ -233,6 +233,107 @@ describe('SsrEntryService', () => {
     expect(consoleError).toHaveBeenCalled();
   });
 
+  // ── KAN-198: the regression gate owed by KAN-156 ──────────────────────────
+  // KAN-156 ("Good news — you already have this recipe" firing right after a
+  // successful first-time save) was closed on a live walkthrough, with no test.
+  // The charter's proving gate was "a first-time save emits exactly one toast".
+  // These two assert it — the first for the ordinary path, the second for the
+  // mechanism KAN-156 actually documented.
+  describe('a first-time save emits exactly one toast (KAN-156 / KAN-198)', () => {
+    // saveRecipe here PERSISTS into savedRecipes, the way the real
+    // PersistenceService does. Without that the dedup check at the top of
+    // handleSave can never observe the row the save just wrote, and the
+    // duplicate toast this guards against becomes unreproducible.
+    const createPersistingService = (savedRecipes: unknown[]) => {
+      const saveRecipe = vi.fn().mockImplementation(async (recipe: unknown) => {
+        savedRecipes.push(recipe);
+        return true;
+      });
+      const injector = Injector.create({
+        providers: [
+          {
+            provide: AuthService,
+            useValue: {
+              ready: Promise.resolve(),
+              ensureGuestSession: vi.fn(),
+              currentUser: () => ({ isGuest: false, savedRecipes }),
+            },
+          },
+          {
+            provide: PersistenceService,
+            useValue: { saveRecipe, firstSyncSettled: Promise.resolve() },
+          },
+          { provide: ToastService, useValue: { show: toastShow } },
+        ],
+      });
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ name: 'Thai Peanut Noodles', slug: 'thai-peanut-noodles' }),
+        })
+      );
+      const service = runInInjectionContext(injector, () => new SsrEntryService());
+      return { service, saveRecipe };
+    };
+
+    it('emits exactly one toast on the ordinary single-invocation path', async () => {
+      vi.stubGlobal('crypto', { randomUUID: () => 'new-id' });
+      const { service, saveRecipe } = createPersistingService([]);
+
+      await service.handleSave('thai-peanut-noodles');
+
+      expect(saveRecipe).toHaveBeenCalledTimes(1);
+      expect(toastShow).toHaveBeenCalledTimes(1);
+      expect(toastShow.mock.calls[0][0]).toMatch(/saved to your cookbook/i);
+    });
+
+    // The KAN-156 mechanism, verbatim from the ticket: ssrEntryGuard invokes
+    // handleSave fire-and-forget and immediately returns a redirect, so when the
+    // guard runs more than once for the same ?save=<slug> entry the invocations
+    // overlap. Whichever loses the race reaches the dedup check after the winner
+    // has persisted the copy, matches on sourceSlug, and emits the bogus second
+    // toast — while ALSO having written a duplicate row.
+    it('emits exactly one toast when the guard invokes handleSave twice for one entry', async () => {
+      vi.stubGlobal('crypto', { randomUUID: () => 'new-id' });
+      const savedRecipes: unknown[] = [];
+      const { service, saveRecipe } = createPersistingService(savedRecipes);
+
+      await Promise.all([
+        service.handleSave('thai-peanut-noodles'),
+        service.handleSave('thai-peanut-noodles'),
+      ]);
+
+      // One user action → one persisted recipe → one toast.
+      expect(saveRecipe).toHaveBeenCalledTimes(1);
+      expect(savedRecipes).toHaveLength(1);
+      expect(toastShow).toHaveBeenCalledTimes(1);
+      expect(toastShow.mock.calls[0][0]).toMatch(/saved to your cookbook/i);
+      // The specific wrong toast from the bug report must never appear here.
+      expect(toastShow.mock.calls.map((c) => c[0]).join(' ')).not.toMatch(
+        /already have this recipe/i
+      );
+    });
+
+    // The dedup must be scoped to an in-flight entry, not a permanent
+    // "handled" set: a user who saves, deletes, and saves again is making a
+    // genuine second request and must not be silently ignored.
+    it('still handles a later save of the same slug once the first has settled', async () => {
+      vi.stubGlobal('crypto', { randomUUID: () => 'new-id' });
+      const savedRecipes: unknown[] = [];
+      const { service } = createPersistingService(savedRecipes);
+
+      await service.handleSave('thai-peanut-noodles');
+      expect(toastShow).toHaveBeenCalledTimes(1);
+
+      // The row is now present, so this is the legitimate "you already have it"
+      // path — a response, not silence.
+      await service.handleSave('thai-peanut-noodles');
+      expect(toastShow).toHaveBeenCalledTimes(2);
+      expect(toastShow.mock.calls[1][0]).toMatch(/already have this recipe/i);
+    });
+  });
+
   it('handleAuth waits for auth ready', async () => {
     let resolveReady!: () => void;
     const readyPromise = new Promise<void>((r) => {

--- a/src/services/ssr-entry.service.ts
+++ b/src/services/ssr-entry.service.ts
@@ -11,6 +11,19 @@ export class SsrEntryService {
   private readonly persistence = inject(PersistenceService);
   private readonly toast = inject(ToastService);
 
+  // KAN-156/KAN-198: ssrEntryGuard calls handleSave fire-and-forget and returns
+  // a redirect immediately, so a guard that runs more than once for the same
+  // ?save=<slug> entry starts overlapping saves. Without this map both pass the
+  // dedup check below while savedRecipes is still empty, and BOTH persist —
+  // whichever finishes second then re-reads the row the first just wrote and
+  // emits the bogus "you already have this recipe" toast. KAN-156 was triaged as
+  // cosmetic; the duplicate row is the part that was missed.
+  //
+  // Scoped to in-flight calls only, deliberately not a permanent handled-set: a
+  // user who saves, deletes, and saves again is making a genuine second request
+  // and must get a response rather than silence.
+  private readonly inFlightSaves = new Map<string, Promise<void>>();
+
   async handleSave(slug: string): Promise<void> {
     const normalizedSlug = slug.trim().toLowerCase();
     if (!/^[a-z0-9-]+$/.test(normalizedSlug)) {
@@ -18,6 +31,17 @@ export class SsrEntryService {
       return;
     }
 
+    const inFlight = this.inFlightSaves.get(normalizedSlug);
+    if (inFlight) return inFlight;
+
+    const save = this.runSave(normalizedSlug).finally(() => {
+      this.inFlightSaves.delete(normalizedSlug);
+    });
+    this.inFlightSaves.set(normalizedSlug, save);
+    return save;
+  }
+
+  private async runSave(normalizedSlug: string): Promise<void> {
     try {
       await this.auth.ready;
       this.auth.ensureGuestSession();


### PR DESCRIPTION
Writes the regression gate **KAN-156 was closed without** — the Sprint 4 charter's proving criterion, verbatim: *"a first-time save emits exactly one toast."* KAN-156 was verified on a live walkthrough, which confirms behaviour on the day and does nothing to stop it regressing the next time this path changes. Carried into Sprint 5 as **S3 / KAN-198 ↔ RCP-66**.

## Writing the test first found the bug still live — and mis-triaged

KAN-156 is recorded as *"Low priority — cosmetic, no data impact."* Driving `handleSave` twice for one slug fails on the **first** assertion, before any toast is examined:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ src/services/ssr-entry.service.test.ts:308
     expect(saveRecipe).toHaveBeenCalledTimes(1);
```

`saveRecipe` runs **twice** — the race persists a **duplicate recipe row**. The duplicate toast is the visible symptom of a data bug, not a cosmetic one. That matters beyond this ticket: duplicate-recipe creation is the same failure class as KAN-186 (S1, just merged), and it was sitting behind a "cosmetic" label.

## Mechanism — exactly as KAN-156 documented it

`ssrEntryGuard` calls `handleSave` fire-and-forget and returns a redirect immediately (`src/guards/ssr-entry.guard.ts:16`):

```ts
ssrEntry.handleSave(slug).catch((err) => console.error('SSR save failed:', err));
return router.createUrlTree(['/kitchen']);
```

`handleSave` had no in-flight dedup, so a guard running more than once for the same `?save=<slug>` starts overlapping saves. Both pass the `alreadySaved` check while `savedRecipes` is still empty, and both persist. Whichever settles second re-reads the row the first just wrote, matches on `sourceSlug`, and shows *"Good news — you already have this recipe"* immediately after a save that succeeded.

## Fix

An in-flight promise map keyed by normalized slug — repeat invocations **join** the first save rather than racing it.

Deliberately **not** the permanent handled-slugs set the ticket also floated: a user who saves a recipe, deletes it, and saves it again is making a genuine second request and must get a response rather than silence. The third test pins that distinction, so a future "simplification" to a permanent set fails rather than silently swallowing real saves.

## Tests — three, one per behaviour

| Test | Asserts | Before this PR |
|---|---|---|
| ordinary single-invocation path | 1 save, 1 toast, "Saved to your cookbook" | passed |
| **guard invokes `handleSave` twice** | 1 save, 1 row, 1 toast, never "already have this recipe" | **failed — 2 saves** |
| later save after the first settled | still responds, with the legitimate "already have" toast | passed |

The harness needed one change to be able to reproduce this at all: `saveRecipe` now **persists into `savedRecipes`** the way the real `PersistenceService` does. With a mock that only resolves, the dedup check can never observe the row the save just wrote and the duplicate is unreproducible — which is plausibly why no existing test caught it.

## Verification

```
npm run type-check   clean
npm test             284 passed (24 files)   # was 281
```

## Jira

[KAN-198](https://tasteslikegood.atlassian.net/browse/KAN-198) ↔ [RCP-66](https://tasteslikegood.atlassian.net/browse/RCP-66) · regression gate owed by [KAN-156](https://tasteslikegood.atlassian.net/browse/KAN-156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp

[KAN-198]: https://tasteslikegood.atlassian.net/browse/KAN-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

