### PR TITLE
fix(release): --bump must read the pointer this tree ships, not origin/dev's [KAN-138]

### DIFF
--- a/scripts/release/train-run.sh
+++ b/scripts/release/train-run.sh
@@ -429,14 +429,30 @@ do_bump() {
 
   info "version   $VERSION → $to"
 
+  # Read the pointer THIS WORKING TREE will ship, not origin/dev's.
+  #
+  # gather()'s $POINTER is `git rev-parse origin/dev:Backend`, which is right
+  # for the status display but wrong here: RUNBOOK step 4 stages the re-pin
+  # locally on the release branch, and it does not reach origin/dev until this
+  # release PR merges. Comparing against origin/dev at step 5 therefore refuses
+  # a correctly-ordered release — caught on this guard's first real use, cutting
+  # v0.4.9, where step 4 had just pinned Backend main and the guard still saw
+  # dev's old pointer.
+  #
+  # The index is the right source: it holds the gitlink that will be committed.
+  local local_pointer local_short
+  local_pointer=$(git rev-parse :Backend 2>/dev/null || git rev-parse HEAD:Backend 2>/dev/null || echo "")
+  [ -n "$local_pointer" ] || die "could not read the Backend gitlink from this tree"
+  local_short=${local_pointer:0:12}
+
   # Step 5 comes AFTER step 4 for a reason: the CHANGELOG section names the
   # pinned SHA, and train-verify checks that name against the actual gitlink.
   # Scaffolding it while the pointer still pins Backend dev bakes the KAN-191
   # trap into the prose, where it reads as deliberate.
-  if [ "$POINTER" = "$BE_MAIN_FULL" ]; then
-    info "pointer   $POINTER_SHORT (Backend main) ✓"
+  if [ "$local_pointer" = "$BE_MAIN_FULL" ]; then
+    info "pointer   $local_short (Backend main) ✓"
   else
-    bad "pointer   $POINTER_SHORT does NOT pin Backend main (${BE_MAIN_FULL:0:12})"
+    bad "pointer   $local_short does NOT pin Backend main (${BE_MAIN_FULL:0:12})"
     info "RUNBOOK step 4 comes first, or this CHANGELOG will name the wrong SHA:"
     info "  git -C Backend fetch origin --prune && git -C Backend checkout origin/main && git add Backend"
     die "refusing to scaffold a CHANGELOG against a non-main pointer"
@@ -447,7 +463,7 @@ do_bump() {
     return 0
   fi
 
-  python3 - "$to" "$POINTER_SHORT" <<'PY' || die "bump failed"
+  python3 - "$to" "$local_short" <<'PY' || die "bump failed"
 import json, re, sys, datetime
 
 to, pointer = sys.argv[1], sys.argv[2]


### PR DESCRIPTION
Found on the guard's **first real use**, cutting v0.4.9. This is a follow-up to #3359.

## The bug

`do_bump` compared `gather()`'s `$POINTER` — `git rev-parse origin/dev:Backend` — against Backend `main`. That is correct for the status display and **wrong at step 5**: RUNBOOK step 4 stages the re-pin *locally on the release branch*, and it does not reach `origin/dev` until the release PR merges.

So immediately after step 4 pinned Backend `main` exactly as instructed, the guard read `dev`'s **old** pointer and refused:

```
· version   0.4.8 → 0.4.9
✗ pointer   fd2d1c1cfd58 does NOT pin Backend main (f1219e81be02)
error: refusing to scaffold a CHANGELOG against a non-main pointer
```

`fd2d1c1` is what `origin/dev` still pins. `f1219e8` is what the release branch had already staged and would ship.

## The worse half

The same stale value was passed to the CHANGELOG scaffold:

```bash
python3 - "$to" "$POINTER_SHORT"   # ← origin/dev's pointer
```

Had the comparison happened to pass, the generated section would have **named the old Backend SHA** — the exact wrong-SHA outcome this guard exists to prevent, and the KAN-191 trap wearing the guard's own uniform. A false refusal is noisy; this one would have been silent and wrong.

## Fix

Read the **index** (`git rev-parse :Backend`) — it holds the gitlink that will actually be committed — falling back to `HEAD`. `gather()`'s `$POINTER` is left alone, since the status display genuinely wants what `origin/dev` ships today.

## Verified both directions, not assumed

```
$ git rev-parse :Backend            # f1219e81be02 (step 4 staged)
$ ./scripts/release/train-run.sh --dry-run --bump 0.4.9 ; echo $?
· pointer f1219e81be02 (Backend main) ✓
0

$ git restore --staged Backend      # index falls back to HEAD's old value
$ ./scripts/release/train-run.sh --dry-run --bump 0.4.9 ; echo $?
✗ pointer fd2d1c1cfd58 does NOT pin Backend main (f1219e81be02)
2
```

Passes when the pointer is right, **still fails when it is wrong**. A guard that only ever passes is not a gate — so the negative case was re-run explicitly after the change rather than reasoned about.

## Why this took a real release to find

Every check in #3359 ran against a working tree where step 4 had *not* been performed, so `origin/dev`'s pointer and the local pointer were the same value and the bug was invisible. It only separates during an actual cut, between step 4 and step 5 — a window that exists exactly once per release.

## Jira

[KAN-138](https://tasteslikegood.atlassian.net/browse/KAN-138)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp

[KAN-138]: https://tasteslikegood.atlassian.net/browse/KAN-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

