### PR TITLE
chore(release): v0.4.9 — version bump + CHANGELOG, Backend pointer f1219e8 [KAN-186]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,83 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.4.9] - 2026-08-07
+
+Backend submodule pointer: `7b6347e` → **`f1219e8`** — Backend `main`'s own tip, the
+merge commit of
+[#271](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/271).
+
+**The headline is a data-correctness fix that had never reached production.** The
+guest→login merge was carrying rows across without running the duplicate-recipe
+check, so signing in after saving as a guest silently created duplicates. The fix
+merged to Backend `dev` during Sprint 5 but sat there — `dev` is not what deploys —
+and this release is the first to actually carry it to users.
+
+### Fixed
+
+- **Guest→login merge now runs the duplicate-recipe check (INV-1) instead of
+  silently carrying rows over** — KAN-186, Backend
+  [#267](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/267) +
+  [#3344](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3344).
+  Per-row dedup on identity keys, cookbook `recipe_ids` remapped, public guest rows
+  guarded.
+- **A first-time save from a public recipe page no longer creates a duplicate
+  recipe** — KAN-198,
+  [#3358](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3358).
+  `ssrEntryGuard` invokes `handleSave` fire-and-forget, so a guard running twice for
+  one `?save=<slug>` entry started two overlapping saves; both passed the dedup check
+  while the cookbook was still empty and **both persisted**, and the straggler then
+  re-read the row the first had just written and reported "you already have this
+  recipe" after a save that had just succeeded. Repeat invocations now join the
+  in-flight save.
+
+  This was filed as KAN-156 and triaged _cosmetic, no data impact_. Writing the
+  regression test owed for it is what showed the duplicate **row**; the stray toast
+  was only its visible symptom.
+
+- **`Dependency Review` no longer blocks every `vite` upgrade** — KAN-208,
+  [#3357](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3357).
+  `lightningcss` and its eleven platform binaries declare MPL-2.0 and were never
+  license-gated, because the action only checks _added_ packages and the copy already
+  in the lockfile predated the policy. Exempted per-package, mirroring `protobufjs`.
+- **The `gcp-monitor` image can no longer be broken by an unpinned transitive
+  resolve** — KAN-207,
+  [#3356](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3356).
+
+### Changed
+
+- **Every commit pushed to an open PR is now reviewed** — KAN-183,
+  [#3334](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3334).
+  The AI review workflows excluded `synchronize`, so anything pushed after the first
+  review went unreviewed, silently, on both repos.
+- **A PR that orphans a `sprint-N` row now fails CI** — KAN-200,
+  [#3336](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3336).
+  `check_sprint_lane.sh` runs as a `pr-gate` job in `gate.needs` rather than as a
+  script someone remembers to run.
+- **Release-train driver: the checklist is now truthful** — KAN-138,
+  [#3359](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3359) +
+  [#3361](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3361).
+  It declared ten steps and only ever marked four, so six read `[ ]` forever even
+  once done. Marks are now derived from observable state, authoritative in both
+  directions. Adds RUNBOOK step 10 and a `--bump X.Y.Z` assist that writes
+  `package.json`, **both** `package-lock.json` self-references, and a CHANGELOG
+  section naming the pinned SHA — refusing outright if the pointer does not yet pin
+  Backend `main`.
+- **`ioredis` 6 is pinned to RESP2** — KAN-209,
+  [#3353](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3353).
+  Not for reply shapes (`replyMode: "legacy"` keeps those identical) but for the
+  handshake: under RESP3 ioredis authenticates via `HELLO` and injects a `default`
+  username, which Memorystore IAM auth does not use, and a rejected AUTH is not a
+  protocol-negotiation error so the automatic RESP2 fallback would not catch it.
+- Dependency upgrades — 23 bumps, including Angular 22.1.2, `vite` 8.2.0,
+  `google-auth-library` 11, `ioredis` 6, and `dd-trace` 6.8.0.
+
+### Documentation
+
+- Sprint 4 and Sprint 5 close-outs and the Sprint 5 charter (KAN-155, RCP-65).
+  Sprint 5 delivered 4 of 8 with the per-day rate falling 0.67 → 0.50, recorded as a
+  sizing verdict rather than smoothed over.
+
 ## [0.4.8] - 2026-07-31
 
 Backend submodule pointer: `0de1e2b` → **`7b6347e`** — Backend `main`'s own tip,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vegangenius-chef",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vegangenius-chef",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@angular/build": "22.1.2",
         "@angular/cli": "22.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vegangenius-chef",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "scripts": {
     "dev": "ng serve",


### PR DESCRIPTION
RUNBOOK step 5. Into `dev`, never straight to `main` — the `dev → main` PR is what ships and tags.

## What this release carries

**The headline is a data-correctness fix that had never reached production.** The guest→login merge was carrying rows over without running the duplicate-recipe check, so signing in after saving as a guest silently created duplicates. KAN-186's fix merged to Backend `dev` during Sprint 5 and stopped there — `dev` is not what deploys — so the one Sprint 5 item breaking a user has been fixed in the repo and broken for users ever since. **This release is the first to actually carry it.**

Also shipping: the KAN-198 duplicate-save race (a duplicate **row**, not the cosmetic toast it was filed as), the KAN-208 `Dependency Review` unblock, review on every pushed commit (KAN-183), the sprint-lane CI gate (KAN-200), the release-driver work (KAN-138), and 23 dependency bumps including Angular 22.1.2, `vite` 8.2.0, `google-auth-library` 11 and `ioredis` 6.

## Pointer — Backend `main`'s own SHA

`7b6347e` → **`f1219e8`**, the merge commit of Backend [#271](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/271). Pinned with `git -C Backend checkout origin/main`, **never** `git submodule update --remote` (which resolves to `dev`, because `.gitmodules` tracks it, and blocks Station 3 every time).

Promotion verified by content, not by a checklist entry:

```
$ git -C Backend merge-base --is-ancestor fd2d1c1 origin/main && echo OK
OK — the KAN-186 fix IS on Backend main
$ git -C Backend log --oneline origin/main..origin/dev
(empty — nothing landed after the promotion, so it is not stale)
```

## Gates — run, with exit codes read

```
$ ./scripts/release/train-verify.sh --for-release ; echo $?
  version          0.4.9 (CHANGELOG section: present, tag v0.4.9: not-tagged)
  submodule pointer                  f1219e81be02 (matches-backend-main)
  pointer content vs Backend main    matches-backend-main-content
  CHANGELOG names pinned SHA         present
  alembic heads                      1
  cookbook/Backend back-sync owed    0 / 0
  OK — no blocking drift.
0

$ npm run type-check   → clean
$ npm test             → 284 passed (24 files)
```

## Version bump

`package.json` **and both `package-lock.json` self-references** — written by `train-run.sh --bump 0.4.9`, this tooling's first real use. It found a bug in itself doing so (#3361): the pointer guard was reading `origin/dev`'s pointer instead of the one this tree ships, which refuses a correctly-ordered release and would have named the *old* SHA in the CHANGELOG. Fixed before this cut proceeded.

## Disclosure

The Backend pointer bump landed one PR early, in #3361, because the step-4 re-pin was still staged in my index when that commit was made — `git commit` commits the whole index, not just the last `git add`. Fully written up [on that PR](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3361#issuecomment-5224778436). Outcome is benign (`f1219e8` is exactly where the release needs the pointer, and `train-verify` confirms both SHA and content), which is why this commit is version + CHANGELOG only.

## What happens next — and what does NOT happen here

Merging **this** PR changes nothing in production. The deploy is the subsequent `dev → main` merge, which pushes tag `v0.4.9` and fires Cloud Build.

⚠️ **The freeze window opens now, not at that merge.** A `dev → main` PR merges `dev`'s *live tip*, so anything landing on `dev` between this merge and the release merge ships silently, outside this CHANGELOG, under a version that never described it.

## Jira

[KAN-186](https://tasteslikegood.atlassian.net/browse/KAN-186) ↔ RCP-61 · KAN-198 · KAN-208 · KAN-138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp

[KAN-186]: https://tasteslikegood.atlassian.net/browse/KAN-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

