### PR TITLE
docs(changelog): record #3365 in v0.4.9 and correct the Angular version [KAN-211]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,10 +85,10 @@ and this release is the first to actually carry it to users.
   literally, and cleans its scratch file on an `EXIT` trap rather than only on success.
 - Dependency upgrades — 23 bumps, including Angular 22.1.0, `vite` 8.2.0,
   `google-auth-library` 11, `ioredis` 6, and `dd-trace` 6.8.0. `@angular/build` and
-  `@angular/cli` had been pinned to `22.1.2` while the rest of the family sat at
-  `22.1.0` — a version never published for `@angular/core` — and were aligned down to
-  `22.1.0` (KAN-211); `@typescript-eslint/parser` was synced to `^8.66.0` to match the
-  plugin it is released in lockstep with.
+  `@angular/cli` had been pinned to 22.1.2 while the rest of the family sat at 22.1.0
+  — a version never published for `@angular/core` — and were aligned down to 22.1.0
+  (KAN-211); `@typescript-eslint/parser` was synced to 8.66.0 to match the plugin it
+  is released in lockstep with.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,21 @@ and this release is the first to actually carry it to users.
   handshake: under RESP3 ioredis authenticates via `HELLO` and injects a `default`
   username, which Memorystore IAM auth does not use, and a rejected AUTH is not a
   protocol-negotiation error so the automatic RESP2 fallback would not catch it.
-- Dependency upgrades — 23 bumps, including Angular 22.1.2, `vite` 8.2.0,
-  `google-auth-library` 11, `ioredis` 6, and `dd-trace` 6.8.0.
+- **Release-train driver: walk-mode step 4 reads the local gitlink; `verify_prod`
+  hardened** — KAN-211,
+  [#3365](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3365).
+  Step 4 checked the pointer via `git rev-parse origin/dev:Backend`, but a re-pin is
+  staged locally and does not reach `origin/dev` until the release PR merges — so the
+  driver could call a correctly-pinned tree wrong. It now reads `:Backend` from the
+  index, matching the same fix already made to `do_bump()` in #3361. `verify_prod`
+  switches `grep -c` → `grep -Fc` so a marker containing regex metacharacters matches
+  literally, and cleans its scratch file on an `EXIT` trap rather than only on success.
+- Dependency upgrades — 23 bumps, including Angular 22.1.0, `vite` 8.2.0,
+  `google-auth-library` 11, `ioredis` 6, and `dd-trace` 6.8.0. `@angular/build` and
+  `@angular/cli` had been pinned to `22.1.2` while the rest of the family sat at
+  `22.1.0` — a version never published for `@angular/core` — and were aligned down to
+  `22.1.0` (KAN-211); `@typescript-eslint/parser` was synced to `^8.66.0` to match the
+  plugin it is released in lockstep with.
 
 ### Documentation
 


### PR DESCRIPTION
## Summary

[#3365](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3365) merged to `dev` **after** the v0.4.9 CHANGELOG section was written, while the release PR ([#3363](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3363)) was open. Because #3363's head *is* `dev`, #3365 is already in the release — it was just going to ship with no CHANGELOG entry. That's the exact gap #3365's own body flagged and left to Adam:

> anything landing on `dev` before that PR merges ships silently in v0.4.9, outside the CHANGELOG

It landed before the cut, so this closes the gap rather than deferring it to v0.4.10.

Two edits, both to `CHANGELOG.md` only:

- **New `### Changed` entry for KAN-211 / #3365** — walk-mode step 4 now reads `:Backend` from the index instead of `origin/dev:Backend`, plus the `grep -Fc` and `EXIT`-trap hardening in `verify_prod`.
- **Corrected the dependency line.** It claimed *"Angular 22.1.2"*. That was true when written, but #3365 aligned `@angular/build` / `@angular/cli` **down** to `22.1.0` (22.1.2 is not published for `@angular/core`), so the released tree is uniformly `22.1.0`. Verified against `package.json` on `dev` — all nine `@angular/*` entries read `22.1.0`, and both `@typescript-eslint/*` read `^8.66.0`.

No code, no config, no submodule pointer.

## Verification

```
train-verify.sh --for-release        exit 0
submodule pointer   f1219e81be02     matches-backend-main + matches-backend-main-content
CHANGELOG names pinned SHA           present
alembic heads                        1
back-sync owed (cookbook / Backend)  0 / 0
```

Backend `dev→main pending 1` is the back-sync merge `a83a35f` (#272) — structurally expected after a promotion, not unshipped work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

