### PR TITLE
fix(release): changelog_state() reads local gitlink, not origin/dev [KAN-211]

### DIFF
--- a/scripts/release/train-run.sh
+++ b/scripts/release/train-run.sh
@@ -245,7 +245,7 @@ STEPS=(
 # ACTUAL pointer, so the SHA in the prose and the gitlink must agree.
 # Prints one of: missing | absent | section-only | named
 #
-# Reads the gitlink from THIS WORKING TREE (index, falling back to HEAD), not
+# Prefers the gitlink from THIS WORKING TREE (index, falling back to HEAD) over
 # $POINTER from gather() (origin/dev:Backend): do_bump() scaffolds the
 # CHANGELOG naming the locally-staged pointer, which doesn't reach origin/dev
 # until the release PR merges. The same KAN-138 staleness do_bump() and the
@@ -253,7 +253,7 @@ STEPS=(
 changelog_state() {
   local local_pointer
   local_pointer=$(git rev-parse :Backend 2>/dev/null || git rev-parse HEAD:Backend 2>/dev/null || echo "$POINTER")
-  python3 - "$VERSION" "$local_pointer" <<'PY' 2>/dev/null || echo "missing"
+  python3 - "$VERSION" "${local_pointer:-none}" <<'PY' 2>/dev/null || echo "missing"
 import re, sys
 ver, pointer = sys.argv[1], sys.argv[2]
 try:

--- a/scripts/release/train-run.sh
+++ b/scripts/release/train-run.sh
@@ -244,8 +244,16 @@ STEPS=(
 # RUNBOOK step 5 requires both: train-verify checks the section against the
 # ACTUAL pointer, so the SHA in the prose and the gitlink must agree.
 # Prints one of: missing | absent | section-only | named
+#
+# Reads the gitlink from THIS WORKING TREE (index, falling back to HEAD), not
+# $POINTER from gather() (origin/dev:Backend): do_bump() scaffolds the
+# CHANGELOG naming the locally-staged pointer, which doesn't reach origin/dev
+# until the release PR merges. The same KAN-138 staleness do_bump() and the
+# step-4 check were already fixed for — see their comments.
 changelog_state() {
-  python3 - "$VERSION" "$POINTER" <<'PY' 2>/dev/null || echo "missing"
+  local local_pointer
+  local_pointer=$(git rev-parse :Backend 2>/dev/null || git rev-parse HEAD:Backend 2>/dev/null || echo "$POINTER")
+  python3 - "$VERSION" "$local_pointer" <<'PY' 2>/dev/null || echo "missing"
 import re, sys
 ver, pointer = sys.argv[1], sys.argv[2]
 try:


### PR DESCRIPTION
## Summary

Third instance of the same KAN-138 staleness pattern already fixed in `do_bump()` and the walk-mode step-4 check (#3365): `changelog_state()` compared the CHANGELOG's named SHA against the global `$POINTER` from `gather()` (`origin/dev:Backend`) instead of the working tree's gitlink.

`do_bump()` scaffolds the CHANGELOG section naming the **locally-staged** pointer (RUNBOOK step 4 pins it before step 5 writes the CHANGELOG). That local pointer doesn't reach `origin/dev` until the release PR merges. So re-running `train-run.sh` in any mode after `--bump` — which calls `changelog_state()` via `derive_steps()` on every invocation — reported step 5 as `"section-only"` instead of `"named"`: a false negative in the checklist even though the CHANGELOG is correct.

Fixed by reading `:Backend` from the index (falling back to `HEAD:Backend`) inside `changelog_state()`, same as the other two spots.

## Source

Flagged as `[CRITICAL]` by the CI review bot on #3363: https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3363#discussion_r3740117689 (thread continuation) — see the inline comment at `scripts/release/train-run.sh` line 250.

Jira: [KAN-211](https://tasteslikegood.atlassian.net/browse/KAN-211)

## Test plan

- [x] `bash -n scripts/release/train-run.sh` — syntax OK
- [x] Standalone repro of the exact `changelog_state()` python logic: same CHANGELOG body scores `"section-only"` against a stale pointer and `"named"` against the local one — confirms both the bug and the fix
- [ ] Manual: full `train-run.sh` walk mode after a real `--bump` (not simulated from this session — would touch the live release-train state)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013cQfEUfL8R99fozWrgJJo4

---
_Replied by Claude on Adam's behalf_

---
_Generated by [Claude Code](https://claude.ai/code/session_013cQfEUfL8R99fozWrgJJo4)_

[KAN-211]: https://tasteslikegood.atlassian.net/browse/KAN-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

