### PR TITLE
docs(changelog): record #3367 in v0.4.9 and note the three unfixed read sites [KAN-211]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,15 +74,24 @@ and this release is the first to actually carry it to users.
   handshake: under RESP3 ioredis authenticates via `HELLO` and injects a `default`
   username, which Memorystore IAM auth does not use, and a rejected AUTH is not a
   protocol-negotiation error so the automatic RESP2 fallback would not catch it.
-- **Release-train driver: walk-mode step 4 reads the local gitlink; `verify_prod`
-  hardened** — KAN-211,
-  [#3365](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3365).
-  Step 4 checked the pointer via `git rev-parse origin/dev:Backend`, but a re-pin is
-  staged locally and does not reach `origin/dev` until the release PR merges — so the
-  driver could call a correctly-pinned tree wrong. It now reads `:Backend` from the
-  index, matching the same fix already made to `do_bump()` in #3361. `verify_prod`
-  switches `grep -c` → `grep -Fc` so a marker containing regex metacharacters matches
-  literally, and cleans its scratch file on an `EXIT` trap rather than only on success.
+- **Release-train driver: state checks read the local gitlink; `verify_prod` hardened**
+  — KAN-211,
+  [#3365](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3365) +
+  [#3367](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3367).
+  The driver decided the pointer via `git rev-parse origin/dev:Backend`, but a re-pin is
+  staged locally and does not reach `origin/dev` until the release PR merges — so it
+  could call a correctly-pinned tree wrong. Fixed at the walk-mode step-4 check (#3365)
+  and in `changelog_state()` (#3367), which had reported step 5 as `section-only` on a
+  CHANGELOG that named the right SHA. Both now read `:Backend` from the index, matching
+  `do_bump()` in #3361. `verify_prod` switches `grep -c` → `grep -Fc` so a marker
+  containing regex metacharacters matches literally, and cleans its scratch file on an
+  `EXIT` trap rather than only on success.
+
+  Three read sites still resolve the pointer from `origin/dev` — the `--status`
+  display, the step-1 checklist mark, and the release-PR body. They are stale in the
+  same window and are held for the next release, where the fix belongs at the single
+  point that computes it rather than a fourth patch at the call site.
+
 - Dependency upgrades — 23 bumps, including Angular 22.1.0, `vite` 8.2.0,
   `google-auth-library` 11, `ioredis` 6, and `dd-trace` 6.8.0. `@angular/build` and
   `@angular/cli` had been pinned to 22.1.2 while the rest of the family sat at 22.1.0


### PR DESCRIPTION
## Summary

Same gap as [#3366](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3366), one PR later: [#3367](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3367) merged to `dev` while [#3363](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3363) was open, so it is already in v0.4.9 (the release PR's head *is* `dev`) but had no CHANGELOG entry.

CHANGELOG-only. Two changes:

- **Folds #3365 and #3367 into one KAN-211 entry** describing the cluster rather than one call site, and names what #3367 actually fixed: `changelog_state()` reported step 5 as `section-only` on a CHANGELOG that named the correct SHA.
- **Records the three read sites that are still stale.** After #3367, `train-run.sh` still resolves the pointer from `origin/dev` in three places — the `--status` display (L216), the step-1 checklist mark (L302), and the release-PR body (L650). All are wrong in the same window. Deliberately not patched here: that would be a fourth point-fix during a release freeze, and the durable fix is at `gather()` L188, the single place that computes `$POINTER`. Held for v0.4.10 under KAN-211.

## Verification

```
train-verify.sh --for-release        exit 0
bash -n scripts/release/train-run.sh ok
submodule pointer   f1219e81be02     matches-backend-main + matches-backend-main-content
CHANGELOG names pinned SHA           present
alembic heads                        1
back-sync owed (cookbook / Backend)  0 / 0
```

Backticked version numbers in `CHANGELOG.md`: 0 — the convention settled on #3366 holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

