### PR TITLE
docs(valkey): fix ioredis option name in RESP2 pin comment [KAN-209]

### DIFF
--- a/server/valkey.ts
+++ b/server/valkey.ts
@@ -109,7 +109,7 @@ export async function createValkeyClient(): Promise<Redis | null> {
       host,
       port,
       // ioredis 6 defaults to RESP3. Reply shapes are NOT the concern — its
-      // `replyMode: "legacy"` default keeps those identical to RESP2, and the
+      // `replyMapping: "legacy"` default keeps those identical to RESP2, and the
       // only replies we consume are rate-limit-redis' EVAL array and AUTH's
       // simple string.
       //


### PR DESCRIPTION
## Summary

Comment-only fix in `server/valkey.ts`. The comment explaining the ioredis 6 RESP2 pin (KAN-209) named the reply-shape option `replyMode`, which doesn't exist. Confirmed against the installed package (`node_modules/ioredis/built/redis/RedisOptions.d.ts`) that the real option is `replyMapping` (`@default "legacy"`). No code behavior changes — the actual `resp2: true` / connection options are unaffected, this only corrects the explanatory comment.

## Source

https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3363#discussion_r... (CI review bot inline comment, `server/valkey.ts` line 113)

Jira: [KAN-209](https://tasteslikegood.atlassian.net/browse/KAN-209)

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Verified `replyMapping` (not `replyMode`) against `node_modules/ioredis/built/redis/RedisOptions.d.ts` and `.js`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013cQfEUfL8R99fozWrgJJo4

---
_Replied by Claude on Adam's behalf_

---
_Generated by [Claude Code](https://claude.ai/code/session_013cQfEUfL8R99fozWrgJJo4)_

[KAN-209]: https://tasteslikegood.atlassian.net/browse/KAN-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

