### PR TITLE
fix(publish): no 'source' link when sourceSlug is the recipe's own slug [KAN-212]

### DIFF
--- a/src/utils/public-link.spec.ts
+++ b/src/utils/public-link.spec.ts
@@ -34,6 +34,13 @@ describe('publicSlugOf', () => {
     expect(publicSlugOf({ is_public: true, slug: '' })).toBeNull();
     expect(publicSlugOf({ sourceSlug: '' })).toBeNull();
   });
+
+  // KAN-212 — see the publicLinkKind block for the full reasoning.
+  it("is null when the unpublished recipe's sourceSlug is its own slug", () => {
+    expect(
+      publicSlugOf({ is_public: false, slug: 'english-breakfast', sourceSlug: 'english-breakfast' })
+    ).toBeNull();
+  });
 });
 
 // KAN-137: the public toggle must never read OFF while an undifferentiated
@@ -68,6 +75,40 @@ describe('publicLinkKind', () => {
     expect(publicLinkKind({})).toBeNull();
     expect(publicLinkKind({ is_public: false, slug: 'draft' })).toBeNull();
     expect(publicLinkKind({ is_public: true })).toBeNull();
+  });
+
+  // KAN-212: found on live v0.4.9. When a recipe's sourceSlug IS its own slug,
+  // "the source" and "this recipe" are the same page — so unpublishing leaves
+  // the fallback pointing at the page just taken down and the link 404s. The
+  // 404 is correct; offering the link is not. There is no other recipe to
+  // degrade to, so the honest answer is no link.
+  it("is null after unpublishing when sourceSlug is the recipe's OWN slug", () => {
+    expect(
+      publicLinkKind({
+        is_public: false,
+        slug: 'english-breakfast',
+        sourceSlug: 'english-breakfast',
+      })
+    ).toBeNull();
+  });
+
+  it("is 'own' again once that same recipe is republished", () => {
+    // The other half of the cycle Adam walked live: republish → 200.
+    expect(
+      publicLinkKind({
+        is_public: true,
+        slug: 'english-breakfast',
+        sourceSlug: 'english-breakfast',
+      })
+    ).toBe('own');
+  });
+
+  it("still degrades to 'source' when the source is a DIFFERENT recipe", () => {
+    // The guard must be narrow: an unpublished copy of someone else's recipe
+    // keeps its link, which is the whole point of the sourceSlug fallback.
+    expect(
+      publicLinkKind({ is_public: false, slug: 'my-remix', sourceSlug: 'vegan-cornbread' })
+    ).toBe('source');
   });
 
   it('agrees with publicSlugOf/isPublicViewable on visibility', () => {
@@ -150,6 +191,20 @@ describe('publishToggleKind', () => {
   it('is normal for generated and saved origins', () => {
     expect(publishToggleKind({ origin: 'generated' })).toBe('normal');
     expect(publishToggleKind({ origin: 'saved', sourceSlug: 'x' })).toBe('source');
+  });
+
+  // KAN-212: 'source' greys the toggle because "its publish state belongs to
+  // the source page". When the row IS the source, that reasoning inverts — the
+  // publish state is its own, so the toggle must render normally. Adam
+  // unpublished and republished exactly this row on live and the toggle worked.
+  it("is normal when sourceSlug is the recipe's own slug", () => {
+    expect(
+      publishToggleKind({
+        is_public: false,
+        slug: 'english-breakfast',
+        sourceSlug: 'english-breakfast',
+      })
+    ).toBe('normal');
   });
 
   it('is normal for ordinary own recipes, published or not', () => {

--- a/src/utils/public-link.ts
+++ b/src/utils/public-link.ts
@@ -14,16 +14,24 @@
  * The own published slug wins when both exist. A sourceSlug target can have
  * been unpublished since saving; worst case is a 404 on a public route, not
  * a leak.
+ *
+ * Derives from publicLinkKind rather than repeating its branches: the two must
+ * never disagree (a spec case asserts it), and KAN-212 was a guard that would
+ * otherwise have had to be written twice.
  */
 export function publicSlugOf(recipe: {
   is_public?: boolean;
   slug?: string;
   sourceSlug?: string;
 }): string | null {
-  if (recipe.is_public === true && recipe.slug) {
-    return recipe.slug;
+  switch (publicLinkKind(recipe)) {
+    case 'own':
+      return recipe.slug ?? null;
+    case 'source':
+      return recipe.sourceSlug ?? null;
+    default:
+      return null;
   }
-  return recipe.sourceSlug || null;
 }
 
 export function isPublicViewable(recipe: {
@@ -45,6 +53,14 @@ export function isPublicViewable(recipe: {
  *            otherwise a publish-capable user sees "toggle off + View
  *            present" and reads it as an inconsistency.
  * null     — no public page; no link.
+ *
+ * KAN-212 — the 'source' fallback assumes the source is some OTHER recipe that
+ * is still public. When sourceSlug equals this recipe's own slug, "the source"
+ * and "this recipe" are the same page, so unpublishing left the link pointing
+ * at the page just taken down: a guaranteed 404, found on live v0.4.9. There is
+ * no other recipe to degrade to, so the honest answer is no link at all. The
+ * guard is deliberately narrow — an unpublished copy of a DIFFERENT recipe
+ * still keeps its link, which is the entire point of the fallback.
  */
 export function publicLinkKind(recipe: {
   is_public?: boolean;
@@ -54,7 +70,10 @@ export function publicLinkKind(recipe: {
   if (recipe.is_public === true && recipe.slug) {
     return 'own';
   }
-  return recipe.sourceSlug ? 'source' : null;
+  if (!recipe.sourceSlug || recipe.sourceSlug === recipe.slug) {
+    return null;
+  }
+  return 'source';
 }
 
 /**


### PR DESCRIPTION
## Summary

Found on live v0.4.9 while walking RCP-61: unpublish a recipe → the "View" link stays and **404s**; republish → 200.

`publicLinkKind`'s `'source'` fallback assumes the source is some **other** recipe that is still public:

```ts
if (recipe.is_public === true && recipe.slug) return 'own';
return recipe.sourceSlug ? 'source' : null;
```

When `sourceSlug === slug`, "the source" and "this recipe" are the same page. Unpublishing flips `is_public` false, the `'own'` branch stops matching, and control falls through to a fallback that points at the page just taken down.

The 404 itself is correct — an unpublished recipe *should* 404. The defect is the SPA continuing to offer the link. There is no other recipe to degrade to, so the honest answer is no link.

The guard is deliberately **narrow**: an unpublished copy of a *different* recipe keeps its link, which is the entire point of the fallback. A spec case pins that.

`recipe-detail.component.html`'s KAN-137 comment already stated the invariant this violated — the muted styling exists so the link "never reads as this recipe's own published page while the toggle is off."

## Two follow-on effects, both intended

- **`publishToggleKind` → `'normal'`.** `'source'` greys the toggle because "its publish state belongs to the source page"; that reasoning inverts when the row **is** the source. Its publish state is its own — and it works, which is how Adam unpublished and republished it on live.
- **`publicSlugOf` now derives from `publicLinkKind`** instead of repeating its branches. The two must never disagree (the existing `agrees with publicSlugOf/isPublicViewable` case asserts it), and duplicating this guard is exactly how `train-run.sh` ended up needing the same fix at three separate call sites (#3361 → #3365 → #3367, with three more still open as KAN-214).

## Test plan

Test-first, confirmed failing before the fix — 3 failures, one per exported function:

```
publicSlugOf       expected 'english-breakfast' to be null
publicLinkKind     expected 'source' to be null
publishToggleKind  expected 'source' to be 'normal'
```

The two regression guards added alongside (republish → `'own'`, different-source → `'source'`) passed before **and** after, which is what makes them guards.

- [x] `npx vitest run src/utils/public-link.spec.ts` — 27 passed
- [x] `npm test` — **289 passed** (was 284)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean

Not user-verified on live: the fix ships in the next release, and there is no pre-production environment to exercise it in (KAN-182 / RCP-69).

Jira: KAN-212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

